### PR TITLE
feat: add switch component package

### DIFF
--- a/.changeset/tricky-turkeys-post.md
+++ b/.changeset/tricky-turkeys-post.md
@@ -1,0 +1,5 @@
+---
+"@xaui/switches": patch
+---
+
+feat: add switch component package

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,168 @@
+# AGENT.md
+
+This file provides guidance to Agent when working with code in this repository.
+
+## Project Overview
+
+XAUI is a modern React Native UI library inspired by Flutter, built as a Turborepo monorepo. The library focuses on Flutter-like APIs, smooth animations using React Native Reanimated, and a complete design system with a Tailwind-inspired color palette.
+
+## Monorepo Architecture
+
+This is a **Turborepo monorepo** using **pnpm workspaces**:
+
+- `apps/*` - Application packages (e.g., documentation site built with Next.js)
+- `packages/*` - Shared packages (e.g., UI component library, design tokens, utilities)
+
+All workspace packages are managed through the root `package.json` and built/tested via Turborepo's task orchestration.
+
+## Development Commands
+
+**Package Manager**: This project uses `pnpm` (version 10.28.0+). Always use `pnpm` instead of npm or yarn.
+
+**Common commands** (run from repository root):
+
+```bash
+pnpm dev              # Start development servers for all apps
+pnpm build            # Build all packages and apps
+pnpm test             # Run tests across all workspaces
+pnpm lint             # Lint all workspaces
+pnpm format           # Format code with Prettier
+```
+
+**Workspace-specific commands**:
+
+```bash
+pnpm --filter <workspace-name> <command>   # Run command in specific workspace
+pnpm --filter @xaui/core dev                # Example: dev mode for core package
+pnpm --filter docs test                    # Example: test docs app
+```
+
+## Release Process
+
+This project uses **Changesets** for versioning and publishing:
+
+```bash
+pnpm changeset              # Create a new changeset
+pnpm version-packages       # Update versions based on changesets
+pnpm release                # Build and publish packages to npm
+```
+
+The release process builds only scoped `@xaui/*` packages before publishing.
+
+## Code Style
+
+**Prettier** is configured with these key settings:
+
+- No semicolons
+- Single quotes
+- 90 character line width
+- 2 space indentation
+- ES5 trailing commas
+
+Run `pnpm format` to auto-format code.
+
+## Technology Stack
+
+- **TypeScript**: Fully typed codebase
+- **React Native**: Mobile UI framework
+- **React Native Reanimated**: Native animations
+- **Next.js**: Documentation site
+- **Vitest**: Testing framework
+- **Turborepo**: Build system and task runner
+- **Changesets**: Version management and publishing
+- **tsup**: Package bundler for library packages
+
+## Architecture Guidelines
+
+**Flutter-inspired API**: Components should follow Flutter's compositional patterns with props like `padding`, `margin`, `borderRadius`, etc., rather than traditional React Native style objects where appropriate.
+
+**Design System**: The library includes a comprehensive color system inspired by Tailwind (20+ colors with 11 shades each). Use these design tokens consistently across components.
+
+**Animation-first**: Leverage React Native Reanimated for all animations to ensure native performance.
+
+## Requirements
+
+- Node.js >= 20
+- pnpm 10.28.0+
+
+## Workspace Structure
+
+**Current workspaces:**
+
+- `@xaui/colors` - Tailwind-inspired color palette package with 20+ colors × 11 shades
+- `demo` - Expo React Native demo application
+- `docs` - Next.js documentation site
+
+**Package configurations:**
+
+- Library packages (`@xaui/*`) use **tsup** for building with dual CJS/ESM output
+- All packages have individual test configurations with Vitest
+- Apps without tests should use `passWithNoTests: true` in vitest.config.ts to prevent CI failures
+
+## Testing
+
+**Run tests:**
+
+```bash
+pnpm test                          # Run all tests in monorepo
+pnpm --filter @xaui/colors test    # Run tests for specific package
+pnpm --filter @xaui/colors test:ui # Run tests with Vitest UI
+pnpm --filter @xaui/colors test:coverage # Run tests with coverage
+```
+
+**Test configuration:**
+
+- Vitest is installed at root level and inherited by workspaces
+- Packages with tests use standard Vitest config (e.g., `packages/colors/vitest.config.ts`)
+- Apps without tests must include `passWithNoTests: true` to avoid CI failures (e.g., `apps/docs/vitest.config.ts`)
+
+**Important:** Turborepo runs `test` tasks with `dependsOn: ["build"]`, so builds happen automatically before tests run.
+
+## CI/CD
+
+The project uses GitHub Actions with the following workflow:
+
+1. **CI Pipeline** (on push/PR to main/dev):
+   - Lint → Type check → Test → Build
+   - Node.js 22 with pnpm 10
+
+2. **Publish Pipeline** (on push to main):
+   - Uses Changesets action to create release PRs or publish to npm
+   - Only builds `@xaui/*` scoped packages before publishing
+
+## Pull Request Guidelines
+
+- Use `pnpm changeset` to create a new changeset
+- Before generate changeset message, run `pnpm changeset version` to update versions based on changesets
+- For pull request add What, Why, How with details for better review
+
+## Code Best Practices
+
+- Dont add any console.log or console.error
+- Dont add any debugger statements
+- Dont add any comments that are not needed
+- Avoid deep code nesting like if (condition) { if (condition) { if (condition) { } } } or for (let i = 0; i < 10; i++) { if (condition) { if (condition) { if (condition) { } } } }
+- Use early returns to avoid deep code nesting
+- Use early returns to avoid deep code nesting
+- Avoid any type as much as possible
+
+## Package Dependencies
+
+- Use pnpm for package management
+- Use workspace: \* for dependencies
+- Dont use react-native-reanimated, use built-in Reanimated from react-native
+
+## Commit Message Guidelines
+
+- generate a commit message with commitizen specification
+- dont add co authored with claude in commit message
+
+## Pull Request Guidelines
+
+- Use `pnpm changeset` to create a new changeset
+- Before generate changeset message, run `pnpm changeset version` to update versions based on changesets
+- For pull request add What, Why, How with details for better review
+- Use gh to create the pull request
+- We are in alpha mode so keep all change to patch
+- if multiple package updated apply changesets for each
+- verify last commit on branch for pull request global implementation description

--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ export default function App() {
 #### Progress Indicators
 - 🔄 [**CircularActivityIndicator**](./packages/components/progress) - Animated activity indicators with 3 variants (spinner, ticks, bullets)
 
+#### Form Controls
+- ☑️ [**Checkbox**](./packages/components/checkboxes) - Customizable checkbox component with filled and light variants
+- 🔘 [**Switch**](./packages/components/switches) - Toggle switch component with inside and overlap variants
+
 ### Coming Soon
 
-- ☐ **Checkbox** - Customizable checkbox component
 - ☐ **Radio** - Radio button component
-- ☐ **Switch** - Toggle switch component
 - ☐ **Input** - Text input with validation
 - ☐ **Card** - Container component with variants
 - ☐ **Modal** - Dialog and modal system

--- a/apps/demo/app/(tabs)/explore.tsx
+++ b/apps/demo/app/(tabs)/explore.tsx
@@ -1,51 +1,12 @@
 import { View, Text, StyleSheet, ScrollView } from 'react-native'
 import { useState } from 'react'
-import { CircularActivityIndicator } from '@xaui/progress'
 import { colors } from '@xaui/colors'
-import { Button, IconButton } from '@xaui/buttons'
-import { Checkbox } from '@xaui/checkboxes'
-import Svg, { Path } from 'react-native-svg'
-
-const HeartIcon = ({ width = 24, height = 24, color = '#000' }) => (
-  <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
-      stroke={color}
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </Svg>
-)
-
-const SearchIcon = ({ width = 24, height = 24, color = '#000' }) => (
-  <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM21 21l-4.35-4.35"
-      stroke={color}
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </Svg>
-)
-
-const PlusIcon = ({ width = 24, height = 24, color = '#000' }) => (
-  <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M12 5v14M5 12h14"
-      stroke={color}
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </Svg>
-)
+import { Switch } from '@xaui/switches'
 
 export default function ExploreScreen() {
-  const [checkboxStates, setCheckboxStates] = useState({
-    filledPrimary: false,
-    lightPrimary: false,
+  const [switchStates, setSwitchStates] = useState({
+    insideVariant: false,
+    overlapVariant: false,
     primary: true,
     secondary: false,
     success: false,
@@ -54,353 +15,243 @@ export default function ExploreScreen() {
     small: false,
     medium: true,
     large: false,
-    checked: true,
-    unchecked: false,
+    selected: true,
+    unselected: false,
     alignRight: false,
     alignLeft: false,
-    justifyLeft: false,
+    justifyLeft: true,
     justifyRight: false,
   })
 
-  const handleCheckboxChange = (key: string) => (value: boolean) => {
-    setCheckboxStates(prev => ({ ...prev, [key]: value }))
+  const handleSwitchChange = (key: string) => (value: boolean) => {
+    setSwitchStates(prev => ({ ...prev, [key]: value }))
   }
 
   return (
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Button Components</Text>
+      <Text style={styles.title}>Switch Components</Text>
 
       <View style={styles.section}>
         <Text style={styles.label}>Variants</Text>
-        <Button themeColor="primary" variant="solid" onPress={() => {}}>
-          Solid
-        </Button>
-        <Button themeColor="primary" variant="outlined" onPress={() => {}}>
-          Outlined
-        </Button>
-        <Button themeColor="primary" variant="flat" onPress={() => {}}>
-          Flat
-        </Button>
-        <Button themeColor="primary" variant="light" onPress={() => {}}>
-          Light
-        </Button>
-        <Button themeColor="primary" variant="elevated" onPress={() => {}}>
-          Elevated
-        </Button>
-        <Button themeColor="primary" variant="faded" onPress={() => {}}>
-          Faded
-        </Button>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Colors</Text>
-        <Button themeColor="primary" onPress={() => {}}>
-          Primary
-        </Button>
-        <Button themeColor="secondary" onPress={() => {}}>
-          Secondary
-        </Button>
-        <Button themeColor="success" onPress={() => {}}>
-          Success
-        </Button>
-        <Button themeColor="warning" onPress={() => {}}>
-          Warning
-        </Button>
-        <Button themeColor="danger" onPress={() => {}}>
-          Danger
-        </Button>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Sizes</Text>
-        <Button themeColor="primary" size="xs" onPress={() => {}}>
-          Extra Small
-        </Button>
-        <Button themeColor="primary" size="sm" onPress={() => {}}>
-          Small
-        </Button>
-        <Button themeColor="primary" size="md" onPress={() => {}}>
-          Medium
-        </Button>
-        <Button themeColor="primary" size="lg" onPress={() => {}}>
-          Large
-        </Button>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Loading States</Text>
-        <Button
+        <Switch
+          size="sm"
+          variant="inside"
+          label="Inside Switch"
           themeColor="primary"
-          isLoading
-          spinnerType="ticks"
-          spinnerPlacement="start"
-          onPress={() => {}}
-        >
-          Loading Start
-        </Button>
-        <Button themeColor="primary" isLoading spinnerPlacement="end" onPress={() => {}}>
-          Loading End
-        </Button>
-        <Button
-          themeColor="secondary"
-          variant="outlined"
-          radius="full"
-          isLoading
-          spinnerType="bullets"
-          onPress={() => {}}
-        >
-          Dots Spinner
-        </Button>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>States</Text>
-        <Button themeColor="primary" isDisabled onPress={() => {}}>
-          Disabled
-        </Button>
-        <Button themeColor="primary" fullWidth onPress={() => {}}>
-          Full Width
-        </Button>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Ripple Effect</Text>
-        <Button themeColor="primary" variant="solid" enableRipple onPress={() => {}}>
-          Solid with Ripple
-        </Button>
-        <Button themeColor="secondary" variant="outlined" enableRipple onPress={() => {}}>
-          Outlined with Ripple
-        </Button>
-        <Button themeColor="success" variant="flat" enableRipple onPress={() => {}}>
-          Flat with Ripple
-        </Button>
-      </View>
-
-      <Text style={[styles.title, { marginTop: 32 }]}>Icon Buttons</Text>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Icon Button Variants</Text>
-        <View style={styles.iconRow}>
-          <IconButton
-            icon={<HeartIcon color={colors.red[500]} />}
-            themeColor="danger"
-            variant="light"
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<SearchIcon color={colors.blue[500]} />}
-            themeColor="primary"
-            variant="light"
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<PlusIcon color={colors.green[500]} />}
-            themeColor="success"
-            variant="light"
-            onPress={() => {}}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Icon Button Sizes</Text>
-        <View style={styles.iconRow}>
-          <IconButton
-            icon={<HeartIcon />}
-            themeColor="danger"
-            variant="solid"
-            size="xs"
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<HeartIcon />}
-            themeColor="danger"
-            variant="solid"
-            size="sm"
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<HeartIcon />}
-            themeColor="danger"
-            variant="solid"
-            size="md"
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<HeartIcon />}
-            themeColor="danger"
-            variant="solid"
-            size="lg"
-            onPress={() => {}}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Icon Button with Ripple</Text>
-        <View style={styles.iconRow}>
-          <IconButton
-            icon={<HeartIcon />}
-            themeColor="danger"
-            variant="solid"
-            radius="full"
-            enableRipple
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<SearchIcon />}
-            themeColor="primary"
-            variant="outlined"
-            radius="full"
-            enableRipple
-            onPress={() => {}}
-          />
-          <IconButton
-            icon={<PlusIcon />}
-            themeColor="success"
-            variant="flat"
-            radius="full"
-            enableRipple
-            onPress={() => {}}
-          />
-        </View>
-      </View>
-
-      <Text style={[styles.title, { marginTop: 32 }]}>Progress Indicators</Text>
-      <View style={styles.section}>
-        <CircularActivityIndicator variant="spinner" themeColor="primary" />
-        <CircularActivityIndicator variant="ticks" themeColor="secondary" />
-        <CircularActivityIndicator variant="bullets" themeColor="tertiary" />
-      </View>
-
-      <Text style={[styles.title, { marginTop: 32 }]}>Checkbox Components</Text>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Variants</Text>
-        <Checkbox
-          variant="filled"
-          label="Filled Checkbox"
-          themeColor="primary"
-          isChecked={checkboxStates.filledPrimary}
-          onValueChange={handleCheckboxChange('filledPrimary')}
+          isSelected={switchStates.insideVariant}
+          onValueChange={handleSwitchChange('insideVariant')}
         />
-        <Checkbox
-          variant="light"
-          label="Light Checkbox"
+        <Switch
+          variant="overlap"
+          size="sm"
+          label="Overlap Switch"
           themeColor="primary"
-          isChecked={checkboxStates.lightPrimary}
-          onValueChange={handleCheckboxChange('lightPrimary')}
+          isSelected={switchStates.overlapVariant}
+          onValueChange={handleSwitchChange('overlapVariant')}
         />
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.label}>Colors</Text>
-        <Checkbox
+        <Text style={styles.label}>Colors - Inside Variant</Text>
+        <Switch
+          variant="inside"
           label="Primary"
           themeColor="primary"
-          isChecked={checkboxStates.primary}
-          onValueChange={handleCheckboxChange('primary')}
+          isSelected={switchStates.primary}
+          onValueChange={handleSwitchChange('primary')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Secondary"
           themeColor="secondary"
-          isChecked={checkboxStates.secondary}
-          onValueChange={handleCheckboxChange('secondary')}
+          isSelected={switchStates.secondary}
+          onValueChange={handleSwitchChange('secondary')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Success"
           themeColor="success"
-          isChecked={checkboxStates.success}
-          onValueChange={handleCheckboxChange('success')}
+          isSelected={switchStates.success}
+          onValueChange={handleSwitchChange('success')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Warning"
           themeColor="warning"
-          isChecked={checkboxStates.warning}
-          onValueChange={handleCheckboxChange('warning')}
+          isSelected={switchStates.warning}
+          onValueChange={handleSwitchChange('warning')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Danger"
           themeColor="danger"
-          isChecked={checkboxStates.danger}
-          onValueChange={handleCheckboxChange('danger')}
+          isSelected={switchStates.danger}
+          onValueChange={handleSwitchChange('danger')}
         />
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.label}>Sizes</Text>
-        <Checkbox
+        <Text style={styles.label}>Sizes - Inside Variant</Text>
+        <Switch
+          variant="inside"
           label="Small"
           themeColor="primary"
           size="sm"
-          isChecked={checkboxStates.small}
-          onValueChange={handleCheckboxChange('small')}
+          isSelected={switchStates.small}
+          onValueChange={handleSwitchChange('small')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Medium"
           themeColor="primary"
           size="md"
-          isChecked={checkboxStates.medium}
-          onValueChange={handleCheckboxChange('medium')}
+          isSelected={switchStates.medium}
+          onValueChange={handleSwitchChange('medium')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Large"
           themeColor="primary"
           size="lg"
-          isChecked={checkboxStates.large}
-          onValueChange={handleCheckboxChange('large')}
+          isSelected={switchStates.large}
+          onValueChange={handleSwitchChange('large')}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Sizes - Overlap Variant</Text>
+        <Switch
+          variant="overlap"
+          label="Small"
+          themeColor="primary"
+          size="sm"
+          isSelected={switchStates.small}
+          onValueChange={handleSwitchChange('small')}
+        />
+        <Switch
+          variant="overlap"
+          label="Medium"
+          themeColor="primary"
+          size="md"
+          isSelected={switchStates.medium}
+          onValueChange={handleSwitchChange('medium')}
+        />
+        <Switch
+          variant="overlap"
+          label="Large"
+          themeColor="primary"
+          size="lg"
+          isSelected={switchStates.large}
+          onValueChange={handleSwitchChange('large')}
         />
       </View>
 
       <View style={styles.section}>
         <Text style={styles.label}>States</Text>
-        <Checkbox
-          label="Checked"
+        <Switch
+          variant="inside"
+          label="Selected"
           themeColor="primary"
-          isChecked={checkboxStates.checked}
-          onValueChange={handleCheckboxChange('checked')}
+          isSelected={switchStates.selected}
+          onValueChange={handleSwitchChange('selected')}
         />
-        <Checkbox
-          label="Unchecked"
+        <Switch
+          variant="inside"
+          label="Unselected"
           themeColor="primary"
-          isChecked={checkboxStates.unchecked}
-          onValueChange={handleCheckboxChange('unchecked')}
+          isSelected={switchStates.unselected}
+          onValueChange={handleSwitchChange('unselected')}
         />
-        <Checkbox label="Disabled" themeColor="primary" isDisabled isChecked={false} />
-        <Checkbox label="Disabled & Checked" themeColor="primary" isDisabled isChecked />
+        <Switch
+          variant="inside"
+          label="Disabled"
+          themeColor="primary"
+          isDisabled
+          isSelected={false}
+        />
+        <Switch
+          variant="inside"
+          label="Disabled & Selected"
+          themeColor="primary"
+          isDisabled
+          isSelected
+        />
       </View>
 
       <View style={styles.section}>
         <Text style={styles.label}>Label Alignment</Text>
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Label on Right (default)"
           labelAlignment="right"
           themeColor="primary"
-          isChecked={checkboxStates.alignRight}
-          onValueChange={handleCheckboxChange('alignRight')}
+          isSelected={switchStates.alignRight}
+          onValueChange={handleSwitchChange('alignRight')}
         />
-        <Checkbox
+        <Switch
+          variant="inside"
           label="Label on Left"
           labelAlignment="left"
           themeColor="primary"
-          isChecked={checkboxStates.alignLeft}
-          onValueChange={handleCheckboxChange('alignLeft')}
+          isSelected={switchStates.alignLeft}
+          onValueChange={handleSwitchChange('alignLeft')}
         />
-        <Checkbox
-          label="Settings"
+        <Switch
+          variant="inside"
+          label="Enable notifications"
           labelAlignment="justify-left"
           fullWidth
           themeColor="primary"
-          isChecked={checkboxStates.justifyLeft}
-          onValueChange={handleCheckboxChange('justifyLeft')}
+          isSelected={switchStates.justifyLeft}
+          onValueChange={handleSwitchChange('justifyLeft')}
         />
-        <Checkbox
-          label="Notifications"
+        <Switch
+          variant="inside"
+          label="Dark mode"
           labelAlignment="justify-right"
           fullWidth
           themeColor="primary"
-          isChecked={checkboxStates.justifyRight}
-          onValueChange={handleCheckboxChange('justifyRight')}
+          isSelected={switchStates.justifyRight}
+          onValueChange={handleSwitchChange('justifyRight')}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Overlap Variant Colors</Text>
+        <Switch
+          variant="overlap"
+          label="Primary"
+          themeColor="primary"
+          isSelected={switchStates.primary}
+          onValueChange={handleSwitchChange('primary')}
+        />
+        <Switch
+          variant="overlap"
+          label="Secondary"
+          themeColor="secondary"
+          isSelected={switchStates.secondary}
+          onValueChange={handleSwitchChange('secondary')}
+        />
+        <Switch
+          variant="overlap"
+          label="Success"
+          themeColor="success"
+          isSelected={switchStates.success}
+          onValueChange={handleSwitchChange('success')}
+        />
+        <Switch
+          variant="overlap"
+          label="Warning"
+          themeColor="warning"
+          isSelected={switchStates.warning}
+          onValueChange={handleSwitchChange('warning')}
+        />
+        <Switch
+          variant="overlap"
+          label="Danger"
+          themeColor="danger"
+          isSelected={switchStates.danger}
+          onValueChange={handleSwitchChange('danger')}
         />
       </View>
     </ScrollView>
@@ -432,15 +283,6 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: colors.white,
-  },
-  note: {
-    fontSize: 12,
-    color: colors.slate[400],
-  },
-  iconRow: {
-    flexDirection: 'row',
-    gap: 12,
-    alignItems: 'center',
+    color: colors.gray[900],
   },
 })

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -41,7 +41,8 @@
     "@xaui/colors": "workspace:*",
     "@xaui/progress": "workspace:*",
     "@xaui/buttons": "workspace:*",
-    "@xaui/checkboxes": "workspace:*"
+    "@xaui/checkboxes": "workspace:*",
+    "@xaui/switches": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/packages/components/switches/README.md
+++ b/packages/components/switches/README.md
@@ -1,0 +1,423 @@
+# @xaui/switches
+
+Switch components for XAUI - A modern React Native UI library with Flutter-inspired API.
+
+## Installation
+
+```bash
+pnpm add @xaui/switches @xaui/core
+```
+
+## Components
+
+- **Switch** - Versatile switch/toggle component with inside and overlap variants, smooth animations, and flexible label alignment
+
+## Switch
+
+A comprehensive switch component with support for two distinct variants, multiple sizes, and smooth animations using React Native's built-in Animated API.
+
+### Basic Usage
+
+```tsx
+import { Switch } from '@xaui/switches'
+
+function App() {
+  const [enabled, setEnabled] = React.useState(false)
+
+  return (
+    <Switch
+      label="Enable notifications"
+      isSelected={enabled}
+      onValueChange={setEnabled}
+    />
+  )
+}
+```
+
+### Variants
+
+The Switch component supports 2 different variants:
+
+```tsx
+<Switch variant="inside" label="Inside Switch" />
+<Switch variant="overlap" label="Overlap Switch" />
+```
+
+- **inside** (default) - Traditional switch where the thumb moves inside the track with padding
+- **overlap** - Modern iOS-style where the thumb overlaps the track with shadow effects and uses background color palette when selected
+
+### Theme Colors
+
+```tsx
+<Switch themeColor="primary" label="Primary" />
+<Switch themeColor="secondary" label="Secondary" />
+<Switch themeColor="tertiary" label="Tertiary" />
+<Switch themeColor="success" label="Success" />
+<Switch themeColor="warning" label="Warning" />
+<Switch themeColor="danger" label="Danger" />
+<Switch themeColor="default" label="Default" />
+```
+
+### Sizes
+
+```tsx
+<Switch size="sm" label="Small" />
+<Switch size="md" label="Medium" />
+<Switch size="lg" label="Large" />
+```
+
+### Border Radius
+
+```tsx
+<Switch radius="none" label="No Radius" />
+<Switch radius="sm" label="Small Radius" />
+<Switch radius="md" label="Medium Radius" />
+<Switch radius="lg" label="Large Radius" />
+<Switch radius="full" label="Full Radius" />
+```
+
+### Label Alignment
+
+Control the position and layout of the label relative to the switch:
+
+```tsx
+// Label on the right (default)
+<Switch label="Label on right" labelAlignment="right" />
+
+// Label on the left
+<Switch label="Label on left" labelAlignment="left" />
+
+// Label on left, justified (switch and label pushed to edges)
+<Switch label="Justified left" labelAlignment="justify-left" fullWidth />
+
+// Label on right, justified (switch and label pushed to edges)
+<Switch label="Justified right" labelAlignment="justify-right" fullWidth />
+```
+
+- **right** (default) - Label appears to the right of switch
+- **left** - Label appears to the left of switch
+- **justify-left** - Label on left, switch and label justified to container edges
+- **justify-right** - Label on right, switch and label justified to container edges
+
+### Full Width
+
+Make the switch container take full available width (useful with justify alignments):
+
+```tsx
+<Switch
+  label="Enable dark mode"
+  labelAlignment="justify-right"
+  fullWidth
+  isSelected={enabled}
+  onValueChange={setEnabled}
+/>
+```
+
+### States
+
+```tsx
+// Selected
+const [selected, setSelected] = React.useState(true)
+<Switch label="Selected" isSelected={selected} onValueChange={setSelected} />
+
+// Unselected
+const [unselected, setUnselected] = React.useState(false)
+<Switch label="Unselected" isSelected={unselected} onValueChange={setUnselected} />
+
+// Disabled
+<Switch label="Disabled" isDisabled />
+
+// Disabled & Selected
+<Switch label="Disabled & Selected" isDisabled isSelected />
+```
+
+### Custom Styling
+
+```tsx
+<Switch
+  themeColor="primary"
+  label="Custom Styled Switch"
+  labelStyle={{ fontWeight: 'bold', fontSize: 18 }}
+  style={{ marginTop: 20 }}
+  isSelected={enabled}
+  onValueChange={setEnabled}
+/>
+```
+
+### Switch Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | - | Switch label text |
+| `labelAlignment` | `'left' \| 'right' \| 'justify-left' \| 'justify-right'` | `'right'` | Label position and alignment |
+| `themeColor` | `'primary' \| 'secondary' \| 'tertiary' \| 'danger' \| 'warning' \| 'success' \| 'default'` | `'primary'` | Theme color |
+| `variant` | `'inside' \| 'overlap'` | `'inside'` | Switch variant |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Switch size |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'full'` | `'full'` | Border radius |
+| `fullWidth` | `boolean` | `false` | Make container full width |
+| `isSelected` | `boolean` | `false` | Selected state |
+| `isDisabled` | `boolean` | `false` | Disabled state |
+| `labelStyle` | `TextStyle` | - | Custom label text style |
+| `style` | `ViewStyle` | - | Custom container style |
+| `onValueChange` | `(isSelected: boolean) => void` | - | Value change handler |
+
+---
+
+## Advanced Examples
+
+### Settings Screen
+
+```tsx
+function SettingsScreen() {
+  const [settings, setSettings] = React.useState({
+    notifications: true,
+    darkMode: false,
+    autoUpdate: true,
+  })
+
+  return (
+    <View style={{ gap: 12, padding: 20 }}>
+      <Switch
+        variant="inside"
+        label="Enable notifications"
+        labelAlignment="justify-left"
+        fullWidth
+        isSelected={settings.notifications}
+        onValueChange={(value) =>
+          setSettings({ ...settings, notifications: value })
+        }
+      />
+      <Switch
+        variant="inside"
+        label="Dark mode"
+        labelAlignment="justify-left"
+        fullWidth
+        isSelected={settings.darkMode}
+        onValueChange={(value) =>
+          setSettings({ ...settings, darkMode: value })
+        }
+      />
+      <Switch
+        variant="inside"
+        label="Auto update"
+        labelAlignment="justify-left"
+        fullWidth
+        isSelected={settings.autoUpdate}
+        onValueChange={(value) =>
+          setSettings({ ...settings, autoUpdate: value })
+        }
+      />
+    </View>
+  )
+}
+```
+
+### Form Integration
+
+```tsx
+function PreferencesForm() {
+  const [preferences, setPreferences] = React.useState({
+    newsletter: false,
+    marketing: false,
+    analytics: true,
+  })
+
+  const handleSubmit = () => {
+    console.log('Preferences:', preferences)
+  }
+
+  return (
+    <View style={{ gap: 16 }}>
+      <Switch
+        themeColor="primary"
+        variant="overlap"
+        label="Subscribe to newsletter"
+        isSelected={preferences.newsletter}
+        onValueChange={(value) =>
+          setPreferences({ ...preferences, newsletter: value })
+        }
+      />
+
+      <Switch
+        themeColor="secondary"
+        variant="overlap"
+        label="Receive marketing emails"
+        isSelected={preferences.marketing}
+        onValueChange={(value) =>
+          setPreferences({ ...preferences, marketing: value })
+        }
+      />
+
+      <Switch
+        themeColor="default"
+        variant="overlap"
+        label="Allow analytics tracking"
+        isSelected={preferences.analytics}
+        onValueChange={(value) =>
+          setPreferences({ ...preferences, analytics: value })
+        }
+      />
+
+      <Button themeColor="primary" onPress={handleSubmit}>
+        Save Preferences
+      </Button>
+    </View>
+  )
+}
+```
+
+### Different Variants Comparison
+
+```tsx
+<View style={{ gap: 16 }}>
+  <Text style={{ fontWeight: 'bold' }}>Inside Variant</Text>
+  <Switch variant="inside" themeColor="primary" label="Inside Primary" isSelected />
+  <Switch variant="inside" themeColor="success" label="Inside Success" isSelected />
+
+  <Text style={{ fontWeight: 'bold', marginTop: 20 }}>Overlap Variant</Text>
+  <Switch variant="overlap" themeColor="primary" label="Overlap Primary" isSelected />
+  <Switch variant="overlap" themeColor="success" label="Overlap Success" isSelected />
+</View>
+```
+
+### Label Alignment Examples
+
+```tsx
+<View style={{ gap: 16, padding: 20 }}>
+  <Switch
+    label="Default (right aligned)"
+    labelAlignment="right"
+    isSelected={enabled1}
+    onValueChange={setEnabled1}
+  />
+
+  <Switch
+    label="Left aligned"
+    labelAlignment="left"
+    isSelected={enabled2}
+    onValueChange={setEnabled2}
+  />
+
+  <Switch
+    label="Dark mode"
+    labelAlignment="justify-left"
+    fullWidth
+    isSelected={enabled3}
+    onValueChange={setEnabled3}
+  />
+
+  <Switch
+    label="Notifications"
+    labelAlignment="justify-right"
+    fullWidth
+    isSelected={enabled4}
+    onValueChange={setEnabled4}
+  />
+</View>
+```
+
+### Size Comparison
+
+```tsx
+<View style={{ gap: 16 }}>
+  <Switch size="sm" label="Small switch" isSelected />
+  <Switch size="md" label="Medium switch" isSelected />
+  <Switch size="lg" label="Large switch" isSelected />
+</View>
+```
+
+## Animations
+
+The Switch component features smooth animations using React Native's built-in Animated API:
+
+- **Thumb sliding** - Spring animation for smooth thumb movement across the track
+- **Press animation** - Spring animation on press for tactile feedback (thumb and track scale)
+- **Color transition** - Smooth color transitions for track background
+- **Shadow effects** - Overlap variant includes elevation shadow for depth
+
+All animations use `useNativeDriver: true` for optimal native performance.
+
+## Variant Details
+
+### Inside Variant
+- Thumb moves inside the track with padding
+- Track changes color when selected (uses `main` color from theme)
+- Thumb remains white
+- More compact appearance
+
+### Overlap Variant
+- Thumb is larger than track and overlaps it
+- Track uses `background` color from theme palette when selected (lighter shade)
+- Thumb uses `main` color from theme when selected
+- Shadow effects for visual depth
+- Modern iOS-style appearance
+
+## Theme Integration
+
+Switch integrates seamlessly with the XAUI theme system via `@xaui/core`:
+
+```tsx
+import { XUIProvider } from '@xaui/core'
+import { Switch } from '@xaui/switches'
+
+function App() {
+  const [enabled, setEnabled] = React.useState(false)
+
+  return (
+    <XUIProvider>
+      <Switch
+        themeColor="primary"
+        label="Themed Switch"
+        isSelected={enabled}
+        onValueChange={setEnabled}
+      />
+    </XUIProvider>
+  )
+}
+```
+
+## Accessibility
+
+The component supports standard React Native accessibility props:
+
+```tsx
+<Switch
+  label="Enable notifications"
+  isSelected={enabled}
+  onValueChange={setEnabled}
+  accessibilityLabel="Enable notifications"
+  accessibilityHint="Double tap to toggle notifications"
+  accessibilityRole="switch"
+/>
+```
+
+## TypeScript Support
+
+Full TypeScript support with comprehensive type definitions:
+
+```tsx
+import type { SwitchProps, SwitchEvents } from '@xaui/switches'
+```
+
+## Testing
+
+```bash
+# Run tests
+pnpm test
+
+# Run tests with UI
+pnpm test:ui
+
+# Run tests with coverage
+pnpm test:coverage
+```
+
+## License
+
+MIT
+
+## Related Packages
+
+- [@xaui/core](../core) - Core theme system and provider
+- [@xaui/colors](../colors) - Color palette system
+- [@xaui/checkboxes](../checkboxes) - Checkbox components

--- a/packages/components/switches/eslint.config.js
+++ b/packages/components/switches/eslint.config.js
@@ -1,0 +1,3 @@
+import baseConfig from '../../../eslint.config.base.js'
+
+export default [...baseConfig]

--- a/packages/components/switches/package.json
+++ b/packages/components/switches/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@xaui/switches",
+  "version": "0.1.0",
+  "description": "Switch components for XAUI - A modern React Native UI library with Flutter-inspired API",
+  "keywords": [
+    "react-native",
+    "ui",
+    "components",
+    "switch",
+    "toggle",
+    "flutter",
+    "design-system",
+    "typescript",
+    "xaui",
+    "animation"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rygrams/xaui.git",
+    "directory": "packages/components/switches"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --external react --external react-native",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --external react --external react-native --watch",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "lint": "eslint src/",
+    "type-check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-native": ">=0.70.0"
+  },
+  "dependencies": {
+    "@xaui/colors": "workspace:*",
+    "@xaui/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@testing-library/react-native": "^13.3.3",
+    "@types/react": "^19.1.0",
+    "@types/react-native": "^0.73.0",
+    "react": "19.1.0",
+    "react-native": "^0.81.5",
+    "react-test-renderer": "19.1.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/components/switches/src/__tests__/__mocks__/react-native.ts
+++ b/packages/components/switches/src/__tests__/__mocks__/react-native.ts
@@ -1,0 +1,33 @@
+import { vi } from 'vitest'
+
+export const StyleSheet = {
+  create: <T>(styles: T): T => styles,
+}
+
+export const View = 'View'
+export const Text = 'Text'
+export const Pressable = 'Pressable'
+
+export const useColorScheme = vi.fn(() => 'light')
+
+export const Platform = {
+  OS: 'ios',
+  select: <T>(obj: Record<string, T>): T | undefined => obj.ios || obj.default,
+}
+
+export const Animated = {
+  View: 'Animated.View',
+  Value: class AnimatedValue {
+    constructor(public value: number) {}
+  },
+  timing: vi.fn(() => ({
+    start: vi.fn(),
+  })),
+  spring: vi.fn(() => ({
+    start: vi.fn(),
+  })),
+  parallel: vi.fn(() => ({
+    start: vi.fn(),
+  })),
+  createAnimatedComponent: (component: unknown) => component,
+}

--- a/packages/components/switches/src/__tests__/switch.test.tsx
+++ b/packages/components/switches/src/__tests__/switch.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import type { SwitchProps } from '../switch-types'
+
+describe('Switch Types', () => {
+  it('exports SwitchProps type', () => {
+    const props: SwitchProps = {
+      label: 'Test Switch',
+      labelAlignment: 'right',
+      themeColor: 'primary',
+      variant: 'inside',
+      size: 'md',
+      radius: 'full',
+      fullWidth: false,
+      isSelected: false,
+      isDisabled: false,
+    }
+
+    expect(props).toBeDefined()
+    expect(props.label).toBe('Test Switch')
+    expect(props.themeColor).toBe('primary')
+    expect(props.variant).toBe('inside')
+  })
+
+  it('accepts all theme colors', () => {
+    const colors: Array<SwitchProps['themeColor']> = [
+      'primary',
+      'secondary',
+      'tertiary',
+      'danger',
+      'warning',
+      'success',
+      'default',
+    ]
+
+    colors.forEach((color) => {
+      const props: SwitchProps = {
+        themeColor: color,
+      }
+      expect(props.themeColor).toBe(color)
+    })
+  })
+
+  it('accepts all variants', () => {
+    const variants: Array<SwitchProps['variant']> = ['inside', 'overlap']
+
+    variants.forEach((variant) => {
+      const props: SwitchProps = {
+        variant,
+      }
+      expect(props.variant).toBe(variant)
+    })
+  })
+
+  it('accepts all sizes', () => {
+    const sizes: Array<SwitchProps['size']> = ['sm', 'md', 'lg']
+
+    sizes.forEach((size) => {
+      const props: SwitchProps = {
+        size,
+      }
+      expect(props.size).toBe(size)
+    })
+  })
+
+  it('accepts all radius options', () => {
+    const radii: Array<SwitchProps['radius']> = ['none', 'sm', 'md', 'lg', 'full']
+
+    radii.forEach((radius) => {
+      const props: SwitchProps = {
+        radius,
+      }
+      expect(props.radius).toBe(radius)
+    })
+  })
+
+  it('accepts all label alignment options', () => {
+    const alignments: Array<SwitchProps['labelAlignment']> = [
+      'left',
+      'right',
+      'justify-left',
+      'justify-right',
+    ]
+
+    alignments.forEach((alignment) => {
+      const props: SwitchProps = {
+        labelAlignment: alignment,
+      }
+      expect(props.labelAlignment).toBe(alignment)
+    })
+  })
+
+  it('accepts boolean props', () => {
+    const props: SwitchProps = {
+      fullWidth: true,
+      isSelected: true,
+      isDisabled: true,
+    }
+
+    expect(props.fullWidth).toBe(true)
+    expect(props.isSelected).toBe(true)
+    expect(props.isDisabled).toBe(true)
+  })
+
+  it('accepts optional label', () => {
+    const propsWithLabel: SwitchProps = {
+      label: 'Enable notifications',
+    }
+
+    const propsWithoutLabel: SwitchProps = {}
+
+    expect(propsWithLabel.label).toBe('Enable notifications')
+    expect(propsWithoutLabel.label).toBeUndefined()
+  })
+
+  it('accepts onValueChange handler', () => {
+    const handler = (isSelected: boolean) => {
+      expect(typeof isSelected).toBe('boolean')
+    }
+
+    const props: SwitchProps = {
+      onValueChange: handler,
+    }
+
+    expect(props.onValueChange).toBeDefined()
+    props.onValueChange?.(true)
+  })
+
+  it('accepts custom styles', () => {
+    const props: SwitchProps = {
+      style: {
+        marginTop: 10,
+        marginBottom: 20,
+      },
+      labelStyle: {
+        fontWeight: 'bold',
+        fontSize: 16,
+      },
+    }
+
+    expect(props.style).toBeDefined()
+    expect(props.labelStyle).toBeDefined()
+    expect(props.style?.marginTop).toBe(10)
+    expect(props.labelStyle?.fontWeight).toBe('bold')
+  })
+
+  it('has correct default values', () => {
+    const props: SwitchProps = {}
+
+    expect(props.labelAlignment).toBeUndefined()
+    expect(props.themeColor).toBeUndefined()
+    expect(props.variant).toBeUndefined()
+    expect(props.size).toBeUndefined()
+    expect(props.radius).toBeUndefined()
+    expect(props.fullWidth).toBeUndefined()
+    expect(props.isSelected).toBeUndefined()
+    expect(props.isDisabled).toBeUndefined()
+  })
+
+  it('allows combining multiple props', () => {
+    const props: SwitchProps = {
+      label: 'Enable dark mode',
+      labelAlignment: 'left',
+      themeColor: 'primary',
+      variant: 'overlap',
+      size: 'lg',
+      radius: 'full',
+      fullWidth: true,
+      isSelected: true,
+      isDisabled: false,
+      onValueChange: (_selected) => {},
+      style: { padding: 10 },
+      labelStyle: { color: '#000' },
+    }
+
+    expect(props.label).toBe('Enable dark mode')
+    expect(props.labelAlignment).toBe('left')
+    expect(props.themeColor).toBe('primary')
+    expect(props.variant).toBe('overlap')
+    expect(props.size).toBe('lg')
+    expect(props.radius).toBe('full')
+    expect(props.fullWidth).toBe(true)
+    expect(props.isSelected).toBe(true)
+    expect(props.isDisabled).toBe(false)
+  })
+
+  it('uses isSelected instead of isChecked', () => {
+    const propsSelected: SwitchProps = {
+      isSelected: true,
+    }
+
+    const propsUnselected: SwitchProps = {
+      isSelected: false,
+    }
+
+    expect(propsSelected.isSelected).toBe(true)
+    expect(propsUnselected.isSelected).toBe(false)
+  })
+
+  it('variant inside is the default', () => {
+    const props: SwitchProps = {
+      variant: 'inside',
+    }
+
+    expect(props.variant).toBe('inside')
+  })
+
+  it('variant overlap is supported', () => {
+    const props: SwitchProps = {
+      variant: 'overlap',
+    }
+
+    expect(props.variant).toBe('overlap')
+  })
+
+  it('onValueChange receives boolean for isSelected state', () => {
+    let receivedValue: boolean | undefined
+
+    const handler = (isSelected: boolean) => {
+      receivedValue = isSelected
+    }
+
+    const props: SwitchProps = {
+      onValueChange: handler,
+    }
+
+    props.onValueChange?.(true)
+    expect(receivedValue).toBe(true)
+
+    props.onValueChange?.(false)
+    expect(receivedValue).toBe(false)
+  })
+})

--- a/packages/components/switches/src/index.ts
+++ b/packages/components/switches/src/index.ts
@@ -1,0 +1,2 @@
+export { Switch } from './switch'
+export type { SwitchProps, SwitchEvents } from './switch-types'

--- a/packages/components/switches/src/switch-types.ts
+++ b/packages/components/switches/src/switch-types.ts
@@ -1,0 +1,26 @@
+import type { TextStyle, ViewStyle } from 'react-native'
+
+export type SwitchProps = {
+  label?: string
+  labelAlignment?: 'left' | 'right' | 'justify-left' | 'justify-right'
+  themeColor?:
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'danger'
+    | 'warning'
+    | 'success'
+    | 'default'
+  variant?: 'inside' | 'overlap'
+  size?: 'sm' | 'md' | 'lg'
+  radius?: 'none' | 'sm' | 'md' | 'lg' | 'full'
+  fullWidth?: boolean
+  isSelected?: boolean
+  isDisabled?: boolean
+  labelStyle?: TextStyle
+  style?: ViewStyle
+} & SwitchEvents
+
+export type SwitchEvents = {
+  onValueChange?: (isSelected: boolean) => void
+}

--- a/packages/components/switches/src/switch.tsx
+++ b/packages/components/switches/src/switch.tsx
@@ -1,0 +1,285 @@
+import React, { useMemo, useEffect, useRef } from 'react'
+import { Pressable, Text, View, StyleSheet, Animated } from 'react-native'
+import { useXUITheme } from '@xaui/core'
+import { colors } from '@xaui/colors'
+import type { SwitchProps } from './switch-types'
+
+export const Switch: React.FC<SwitchProps> = ({
+  label,
+  labelAlignment = 'right',
+  themeColor = 'primary',
+  variant = 'inside',
+  size = 'md',
+  radius = 'full',
+  fullWidth = false,
+  isSelected = false,
+  isDisabled = false,
+  labelStyle,
+  style,
+  onValueChange,
+}) => {
+  const theme = useXUITheme()
+  const scale = useRef(new Animated.Value(1)).current
+  const thumbPosition = useRef(new Animated.Value(isSelected ? 1 : 0)).current
+  const thumbScale = useRef(new Animated.Value(1)).current
+
+  const colorScheme = theme.colors[themeColor]
+
+  const sizeStyles = useMemo(() => {
+    if (variant === 'overlap') {
+      const sizes = {
+        sm: {
+          trackWidth: 40,
+          trackHeight: 16,
+          thumbSize: 22,
+          fontSize: theme.fontSizes.sm,
+          padding: 0,
+        },
+        md: {
+          trackWidth: 48,
+          trackHeight: 18,
+          thumbSize: 26,
+          fontSize: theme.fontSizes.md,
+          padding: 0,
+        },
+        lg: {
+          trackWidth: 56,
+          trackHeight: 20,
+          thumbSize: 30,
+          fontSize: theme.fontSizes.lg,
+          padding: 0,
+        },
+      }
+      return sizes[size]
+    }
+
+    const sizes = {
+      sm: {
+        trackWidth: 40,
+        trackHeight: 24,
+        thumbSize: 18,
+        fontSize: theme.fontSizes.sm,
+        padding: 3,
+      },
+      md: {
+        trackWidth: 48,
+        trackHeight: 28,
+        thumbSize: 22,
+        fontSize: theme.fontSizes.md,
+        padding: 3,
+      },
+      lg: {
+        trackWidth: 56,
+        trackHeight: 32,
+        thumbSize: 26,
+        fontSize: theme.fontSizes.lg,
+        padding: 3,
+      },
+    }
+    return sizes[size]
+  }, [size, theme, variant])
+
+  const radiusStyles = useMemo(() => {
+    const radii = {
+      none: theme.borderRadius.none,
+      sm: theme.borderRadius.sm,
+      md: theme.borderRadius.md,
+      lg: theme.borderRadius.lg,
+      full: theme.borderRadius.full,
+    }
+    return { borderRadius: radii[radius] }
+  }, [radius, theme])
+
+  const thumbRadius = useMemo(() => {
+    const radiusLookup = {
+      none: theme.borderRadius.none,
+      sm: theme.borderRadius.sm,
+      md: theme.borderRadius.md,
+      lg: theme.borderRadius.lg,
+      full: theme.borderRadius.full,
+    }
+    return radiusLookup[radius]
+  }, [radius, theme])
+
+  const trackStyles = useMemo(() => {
+    const baseTrackColor = isSelected
+      ? variant === 'overlap'
+        ? colorScheme.background
+        : colorScheme.main
+      : colors.gray[300]
+
+    return {
+      width: sizeStyles.trackWidth,
+      height: sizeStyles.trackHeight,
+      backgroundColor: baseTrackColor,
+      ...radiusStyles,
+      paddingHorizontal: sizeStyles.padding,
+    }
+  }, [sizeStyles, radiusStyles, isSelected, colorScheme])
+
+  const thumbStyles = useMemo(() => {
+    const maxTranslateX =
+      variant === 'overlap'
+        ? sizeStyles.trackWidth - sizeStyles.thumbSize
+        : sizeStyles.trackWidth - sizeStyles.thumbSize - sizeStyles.padding * 2
+
+    const translateX = thumbPosition.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, maxTranslateX],
+    })
+
+    return {
+      width: sizeStyles.thumbSize,
+      height: sizeStyles.thumbSize,
+      borderRadius: thumbRadius,
+      backgroundColor:
+        variant === 'overlap' && isSelected ? colorScheme.main : colors.white,
+      transform: [{ translateX }, { scale: thumbScale }],
+      ...(variant === 'overlap' && {
+        shadowColor: '#000',
+        shadowOffset: {
+          width: 0,
+          height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+        elevation: 5,
+      }),
+    }
+  }, [
+    sizeStyles,
+    thumbPosition,
+    thumbScale,
+    thumbRadius,
+    variant,
+    isSelected,
+    colorScheme,
+  ])
+
+  const containerStyles = useMemo(() => {
+    const isJustified =
+      labelAlignment === 'justify-left' || labelAlignment === 'justify-right'
+
+    return {
+      flexDirection:
+        labelAlignment === 'left' || labelAlignment === 'justify-left'
+          ? ('row-reverse' as const)
+          : ('row' as const),
+      justifyContent: isJustified ? ('space-between' as const) : ('flex-start' as const),
+      width: fullWidth ? ('100%' as const) : undefined,
+    }
+  }, [labelAlignment, fullWidth])
+
+  useEffect(() => {
+    Animated.spring(thumbPosition, {
+      toValue: isSelected ? 1 : 0,
+      useNativeDriver: true,
+      damping: 15,
+      stiffness: 150,
+    }).start()
+  }, [isSelected, thumbPosition])
+
+  const handlePress = () => {
+    if (isDisabled) return
+    onValueChange?.(!isSelected)
+  }
+
+  const handlePressIn = () => {
+    if (isDisabled) return
+
+    Animated.parallel([
+      Animated.spring(scale, {
+        toValue: 0.95,
+        useNativeDriver: true,
+      }),
+      Animated.spring(thumbScale, {
+        toValue: variant === 'overlap' ? 1.1 : 1.2,
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }
+
+  const handlePressOut = () => {
+    if (isDisabled) return
+
+    Animated.parallel([
+      Animated.spring(scale, {
+        toValue: 1,
+        useNativeDriver: true,
+      }),
+      Animated.spring(thumbScale, {
+        toValue: 1,
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      disabled={isDisabled}
+      style={[styles.container, containerStyles, isDisabled && styles.disabled, style]}
+    >
+      <Animated.View
+        style={[
+          styles.track,
+          trackStyles,
+          {
+            transform: [{ scale }],
+          },
+        ]}
+      >
+        <View style={styles.thumbContainer}>
+          <Animated.View style={[styles.thumb, thumbStyles]} />
+        </View>
+      </Animated.View>
+
+      {label && (
+        <Text
+          style={[
+            styles.label,
+            { fontSize: sizeStyles.fontSize },
+            isDisabled && styles.disabledText,
+            labelStyle,
+          ]}
+        >
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  track: {
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  thumbContainer: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumb: {
+    position: 'absolute',
+    left: 0,
+  },
+  label: {
+    fontWeight: '400',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  disabledText: {
+    opacity: 0.7,
+  },
+})

--- a/packages/components/switches/tsconfig.json
+++ b/packages/components/switches/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-native"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/components/switches/vitest.config.ts
+++ b/packages/components/switches/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'react-native': path.resolve(__dirname, 'src/__tests__/__mocks__/react-native.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,ts,tsx}'],
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@xaui/progress':
         specifier: workspace:*
         version: link:../../packages/components/progress
+      '@xaui/switches':
+        specifier: workspace:*
+        version: link:../../packages/components/switches
       expo:
         specifier: ~54.0.31
         version: 54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -307,6 +310,40 @@ importers:
       react-native-svg:
         specifier: ^15.8.0
         version: 15.15.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/components/switches:
+    dependencies:
+      '@xaui/colors':
+        specifier: workspace:*
+        version: link:../../core/colors
+      '@xaui/core':
+        specifier: workspace:*
+        version: link:../../core/core
+    devDependencies:
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.17
+      '@types/react-native':
+        specifier: ^0.73.0
+        version: 0.73.0(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-native:
+        specifier: ^0.81.5
+        version: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+      react-test-renderer:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## What
- add `@xaui/switches` package with Switch component, docs, and tests
- update demo explore screen to showcase switch variants, sizes, and states
- add changeset and update workspace deps/lockfile and README component list

## Why
- introduce a first-class switch/toggle control and make it discoverable in the demo

## How
- implement animated Switch with inside/overlap variants and label alignment
- wire demo state and variants using the new package
- document the component and add a patch changeset for publishing
