### PR TITLE
feat: add select component package

### DIFF
--- a/.changeset/bright-bugs-smile.md
+++ b/.changeset/bright-bugs-smile.md
@@ -1,0 +1,5 @@
+---
+'@xaui/select': patch
+---
+
+feat: add select component package

--- a/.changeset/empty-panthers-smash.md
+++ b/.changeset/empty-panthers-smash.md
@@ -1,0 +1,5 @@
+---
+'@xaui/colors': patch
+---
+
+docs: update colors documentation

--- a/AGENT.md
+++ b/AGENT.md
@@ -166,3 +166,4 @@ The project uses GitHub Actions with the following workflow:
 - We are in alpha mode so keep all change to patch
 - if multiple package updated apply changesets for each
 - verify last commit on branch for pull request global implementation description
+- Add test for each component you code or update

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,11 +130,20 @@ The project uses GitHub Actions with the following workflow:
    - Uses Changesets action to create release PRs or publish to npm
    - Only builds `@xaui/*` scoped packages before publishing
 
+## Commit Message Guidelines
+
+- generate a commit message with commitizen specification
+- dont add co authored with claude in commit message
+
 ## Pull Request Guidelines
 
 - Use `pnpm changeset` to create a new changeset
 - Before generate changeset message, run `pnpm changeset version` to update versions based on changesets
 - For pull request add What, Why, How with details for better review
+- Use gh to create the pull request
+- We are in alpha mode so keep all change to patch
+- if multiple package updated apply changesets for each
+- verify last commit on branch for pull request global implementation description
 
 ## Code Best Practices
 
@@ -151,3 +160,4 @@ The project uses GitHub Actions with the following workflow:
 - Use pnpm for package management
 - Use workspace: \* for dependencies
 - Dont use react-native-reanimated, use built-in Reanimated from react-native
+- Add test for each component you code or update

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ export default function App() {
 #### Form Controls
 - ☑️ [**Checkbox**](./packages/components/checkboxes) - Customizable checkbox component with filled and light variants
 - 🔘 [**Switch**](./packages/components/switches) - Toggle switch component with inside and overlap variants
+- 🧭 [**Select**](./packages/components/select) - Select component with single/multiple selection and variants
 
 ### Coming Soon
 

--- a/apps/demo/app/(tabs)/explore.tsx
+++ b/apps/demo/app/(tabs)/explore.tsx
@@ -6,15 +6,17 @@ import { Select, SelectItem } from '@xaui/select'
 export default function ExploreScreen() {
   const [singleSelectKeys, setSingleSelectKeys] = useState(['fr'])
   const [multiSelectKeys, setMultiSelectKeys] = useState(['design', 'mobile'])
-  const [variantFlatKeys, setVariantFlatKeys] = useState(['option1'])
   const [variantOutlinedKeys, setVariantOutlinedKeys] = useState(['option2'])
+  const [variantFlatKeys, setVariantFlatKeys] = useState(['option1'])
+  const [variantLightKeys, setVariantLightKeys] = useState(['option3'])
   const [variantFadedKeys, setVariantFadedKeys] = useState(['option1'])
-  const [variantUnderlinedKeys, setVariantUnderlinedKeys] = useState(['option3'])
-  const [colorPrimaryKeys, setColorPrimaryKeys] = useState(['item1'])
-  const [colorSecondaryKeys, setColorSecondaryKeys] = useState(['item2'])
-  const [colorSuccessKeys, setColorSuccessKeys] = useState(['item1'])
-  const [colorWarningKeys, setColorWarningKeys] = useState(['item3'])
-  const [colorDangerKeys, setColorDangerKeys] = useState(['item2'])
+  const [variantUnderlinedKeys, setVariantUnderlinedKeys] = useState(['option2'])
+  const [colorDefaultKeys, setColorDefaultKeys] = useState(['item1'])
+  const [colorPrimaryKeys, setColorPrimaryKeys] = useState(['item2'])
+  const [colorSecondaryKeys, setColorSecondaryKeys] = useState(['item1'])
+  const [colorSuccessKeys, setColorSuccessKeys] = useState(['item3'])
+  const [colorWarningKeys, setColorWarningKeys] = useState(['item2'])
+  const [colorDangerKeys, setColorDangerKeys] = useState(['item1'])
   const [sizeSmallKeys, setSizeSmallKeys] = useState(['small1'])
   const [sizeMediumKeys, setSizeMediumKeys] = useState(['medium2'])
   const [sizeLargeKeys, setSizeLargeKeys] = useState(['large1'])
@@ -74,6 +76,20 @@ export default function ExploreScreen() {
       <View style={styles.section}>
         <Text style={styles.label}>Variants</Text>
         <Select
+          label="Outlined Variant"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={variantOutlinedKeys}
+          onSelectionChange={setVariantOutlinedKeys}
+          variant="outlined"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="option1" title="Option 1" />
+          <SelectItem key="option2" title="Option 2" />
+          <SelectItem key="option3" title="Option 3" />
+        </Select>
+        <Select
           label="Flat Variant"
           placeholder="Select option"
           selectionMode="single"
@@ -88,12 +104,12 @@ export default function ExploreScreen() {
           <SelectItem key="option3" title="Option 3" />
         </Select>
         <Select
-          label="Outlined Variant"
+          label="Light Variant"
           placeholder="Select option"
           selectionMode="single"
-          selectedKeys={variantOutlinedKeys}
-          onSelectionChange={setVariantOutlinedKeys}
-          variant="outlined"
+          selectedKeys={variantLightKeys}
+          onSelectionChange={setVariantLightKeys}
+          variant="light"
           size="md"
           radius="md"
         >
@@ -134,12 +150,27 @@ export default function ExploreScreen() {
       <View style={styles.section}>
         <Text style={styles.label}>Colors</Text>
         <Select
+          label="Default (Gray)"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorDefaultKeys}
+          onSelectionChange={setColorDefaultKeys}
+          variant="outlined"
+          themeColor="default"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
+        <Select
           label="Primary"
           placeholder="Select option"
           selectionMode="single"
           selectedKeys={colorPrimaryKeys}
           onSelectionChange={setColorPrimaryKeys}
-          variant="faded"
+          variant="outlined"
           themeColor="primary"
           size="md"
           radius="md"
@@ -154,7 +185,7 @@ export default function ExploreScreen() {
           selectionMode="single"
           selectedKeys={colorSecondaryKeys}
           onSelectionChange={setColorSecondaryKeys}
-          variant="faded"
+          variant="outlined"
           themeColor="secondary"
           size="md"
           radius="md"
@@ -169,7 +200,7 @@ export default function ExploreScreen() {
           selectionMode="single"
           selectedKeys={colorSuccessKeys}
           onSelectionChange={setColorSuccessKeys}
-          variant="faded"
+          variant="outlined"
           themeColor="success"
           size="md"
           radius="md"
@@ -184,7 +215,7 @@ export default function ExploreScreen() {
           selectionMode="single"
           selectedKeys={colorWarningKeys}
           onSelectionChange={setColorWarningKeys}
-          variant="faded"
+          variant="outlined"
           themeColor="warning"
           size="md"
           radius="md"
@@ -199,7 +230,7 @@ export default function ExploreScreen() {
           selectionMode="single"
           selectedKeys={colorDangerKeys}
           onSelectionChange={setColorDangerKeys}
-          variant="faded"
+          variant="outlined"
           themeColor="danger"
           size="md"
           radius="md"

--- a/apps/demo/app/(tabs)/explore.tsx
+++ b/apps/demo/app/(tabs)/explore.tsx
@@ -1,258 +1,405 @@
 import { View, Text, StyleSheet, ScrollView } from 'react-native'
 import { useState } from 'react'
 import { colors } from '@xaui/colors'
-import { Switch } from '@xaui/switches'
+import { Select, SelectItem } from '@xaui/select'
 
 export default function ExploreScreen() {
-  const [switchStates, setSwitchStates] = useState({
-    insideVariant: false,
-    overlapVariant: false,
-    primary: true,
-    secondary: false,
-    success: false,
-    warning: false,
-    danger: false,
-    small: false,
-    medium: true,
-    large: false,
-    selected: true,
-    unselected: false,
-    alignRight: false,
-    alignLeft: false,
-    justifyLeft: true,
-    justifyRight: false,
-  })
-
-  const handleSwitchChange = (key: string) => (value: boolean) => {
-    setSwitchStates(prev => ({ ...prev, [key]: value }))
-  }
+  const [singleSelectKeys, setSingleSelectKeys] = useState(['fr'])
+  const [multiSelectKeys, setMultiSelectKeys] = useState(['design', 'mobile'])
+  const [variantFlatKeys, setVariantFlatKeys] = useState(['option1'])
+  const [variantOutlinedKeys, setVariantOutlinedKeys] = useState(['option2'])
+  const [variantFadedKeys, setVariantFadedKeys] = useState(['option1'])
+  const [variantUnderlinedKeys, setVariantUnderlinedKeys] = useState(['option3'])
+  const [colorPrimaryKeys, setColorPrimaryKeys] = useState(['item1'])
+  const [colorSecondaryKeys, setColorSecondaryKeys] = useState(['item2'])
+  const [colorSuccessKeys, setColorSuccessKeys] = useState(['item1'])
+  const [colorWarningKeys, setColorWarningKeys] = useState(['item3'])
+  const [colorDangerKeys, setColorDangerKeys] = useState(['item2'])
+  const [sizeSmallKeys, setSizeSmallKeys] = useState(['small1'])
+  const [sizeMediumKeys, setSizeMediumKeys] = useState(['medium2'])
+  const [sizeLargeKeys, setSizeLargeKeys] = useState(['large1'])
+  const [radiusNoneKeys, setRadiusNoneKeys] = useState(['r1'])
+  const [radiusSmKeys, setRadiusSmKeys] = useState(['r2'])
+  const [radiusMdKeys, setRadiusMdKeys] = useState(['r1'])
+  const [radiusLgKeys, setRadiusLgKeys] = useState(['r3'])
+  const [radiusFullKeys, setRadiusFullKeys] = useState(['r2'])
+  const [labelOutsideKeys, setLabelOutsideKeys] = useState(['lo1'])
+  const [labelInsideKeys, setLabelInsideKeys] = useState(['li2'])
+  const [labelOutsideLeftKeys, setLabelOutsideLeftKeys] = useState(['lol1'])
 
   return (
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Switch Components</Text>
+      <Text style={styles.title}>Select Components</Text>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Single Select</Text>
+        <Select
+          label="Country"
+          placeholder="Pick a country"
+          selectionMode="single"
+          selectedKeys={singleSelectKeys}
+          onSelectionChange={setSingleSelectKeys}
+          hint="Choose your primary location"
+          variant="outlined"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="fr" title="France" description="Paris" />
+          <SelectItem key="es" title="Spain" description="Madrid" />
+          <SelectItem key="jp" title="Japan" description="Tokyo" />
+          <SelectItem key="us" title="United States" description="Washington, D.C." />
+        </Select>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Multiple Select</Text>
+        <Select
+          label="Interests"
+          placeholder="Pick interests"
+          selectionMode="multiple"
+          selectedKeys={multiSelectKeys}
+          onSelectionChange={setMultiSelectKeys}
+          hint="Select multiple options"
+          variant="faded"
+          size="md"
+          radius="lg"
+        >
+          <SelectItem key="design" title="Design" />
+          <SelectItem key="mobile" title="Mobile" />
+          <SelectItem key="web" title="Web" />
+          <SelectItem key="ai" title="AI" />
+        </Select>
+      </View>
 
       <View style={styles.section}>
         <Text style={styles.label}>Variants</Text>
-        <Switch
-          size="sm"
-          variant="inside"
-          label="Inside Switch"
-          themeColor="primary"
-          isSelected={switchStates.insideVariant}
-          onValueChange={handleSwitchChange('insideVariant')}
-        />
-        <Switch
-          variant="overlap"
-          size="sm"
-          label="Overlap Switch"
-          themeColor="primary"
-          isSelected={switchStates.overlapVariant}
-          onValueChange={handleSwitchChange('overlapVariant')}
-        />
+        <Select
+          label="Flat Variant"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={variantFlatKeys}
+          onSelectionChange={setVariantFlatKeys}
+          variant="flat"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="option1" title="Option 1" />
+          <SelectItem key="option2" title="Option 2" />
+          <SelectItem key="option3" title="Option 3" />
+        </Select>
+        <Select
+          label="Outlined Variant"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={variantOutlinedKeys}
+          onSelectionChange={setVariantOutlinedKeys}
+          variant="outlined"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="option1" title="Option 1" />
+          <SelectItem key="option2" title="Option 2" />
+          <SelectItem key="option3" title="Option 3" />
+        </Select>
+        <Select
+          label="Faded Variant"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={variantFadedKeys}
+          onSelectionChange={setVariantFadedKeys}
+          variant="faded"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="option1" title="Option 1" />
+          <SelectItem key="option2" title="Option 2" />
+          <SelectItem key="option3" title="Option 3" />
+        </Select>
+        <Select
+          label="Underlined Variant"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={variantUnderlinedKeys}
+          onSelectionChange={setVariantUnderlinedKeys}
+          variant="underlined"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="option1" title="Option 1" />
+          <SelectItem key="option2" title="Option 2" />
+          <SelectItem key="option3" title="Option 3" />
+        </Select>
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.label}>Colors - Inside Variant</Text>
-        <Switch
-          variant="inside"
+        <Text style={styles.label}>Colors</Text>
+        <Select
           label="Primary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorPrimaryKeys}
+          onSelectionChange={setColorPrimaryKeys}
+          variant="faded"
           themeColor="primary"
-          isSelected={switchStates.primary}
-          onValueChange={handleSwitchChange('primary')}
-        />
-        <Switch
-          variant="inside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
+        <Select
           label="Secondary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorSecondaryKeys}
+          onSelectionChange={setColorSecondaryKeys}
+          variant="faded"
           themeColor="secondary"
-          isSelected={switchStates.secondary}
-          onValueChange={handleSwitchChange('secondary')}
-        />
-        <Switch
-          variant="inside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
+        <Select
           label="Success"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorSuccessKeys}
+          onSelectionChange={setColorSuccessKeys}
+          variant="faded"
           themeColor="success"
-          isSelected={switchStates.success}
-          onValueChange={handleSwitchChange('success')}
-        />
-        <Switch
-          variant="inside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
+        <Select
           label="Warning"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorWarningKeys}
+          onSelectionChange={setColorWarningKeys}
+          variant="faded"
           themeColor="warning"
-          isSelected={switchStates.warning}
-          onValueChange={handleSwitchChange('warning')}
-        />
-        <Switch
-          variant="inside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
+        <Select
           label="Danger"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={colorDangerKeys}
+          onSelectionChange={setColorDangerKeys}
+          variant="faded"
           themeColor="danger"
-          isSelected={switchStates.danger}
-          onValueChange={handleSwitchChange('danger')}
-        />
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="item1" title="Item 1" />
+          <SelectItem key="item2" title="Item 2" />
+          <SelectItem key="item3" title="Item 3" />
+        </Select>
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.label}>Sizes - Inside Variant</Text>
-        <Switch
-          variant="inside"
+        <Text style={styles.label}>Sizes</Text>
+        <Select
           label="Small"
-          themeColor="primary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={sizeSmallKeys}
+          onSelectionChange={setSizeSmallKeys}
+          variant="outlined"
           size="sm"
-          isSelected={switchStates.small}
-          onValueChange={handleSwitchChange('small')}
-        />
-        <Switch
-          variant="inside"
+          radius="md"
+        >
+          <SelectItem key="small1" title="Small Option 1" />
+          <SelectItem key="small2" title="Small Option 2" />
+        </Select>
+        <Select
           label="Medium"
-          themeColor="primary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={sizeMediumKeys}
+          onSelectionChange={setSizeMediumKeys}
+          variant="outlined"
           size="md"
-          isSelected={switchStates.medium}
-          onValueChange={handleSwitchChange('medium')}
-        />
-        <Switch
-          variant="inside"
+          radius="md"
+        >
+          <SelectItem key="medium1" title="Medium Option 1" />
+          <SelectItem key="medium2" title="Medium Option 2" />
+        </Select>
+        <Select
           label="Large"
-          themeColor="primary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={sizeLargeKeys}
+          onSelectionChange={setSizeLargeKeys}
+          variant="outlined"
           size="lg"
-          isSelected={switchStates.large}
-          onValueChange={handleSwitchChange('large')}
-        />
+          radius="md"
+        >
+          <SelectItem key="large1" title="Large Option 1" />
+          <SelectItem key="large2" title="Large Option 2" />
+        </Select>
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.label}>Sizes - Overlap Variant</Text>
-        <Switch
-          variant="overlap"
-          label="Small"
-          themeColor="primary"
-          size="sm"
-          isSelected={switchStates.small}
-          onValueChange={handleSwitchChange('small')}
-        />
-        <Switch
-          variant="overlap"
-          label="Medium"
-          themeColor="primary"
+        <Text style={styles.label}>Radius</Text>
+        <Select
+          label="None"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={radiusNoneKeys}
+          onSelectionChange={setRadiusNoneKeys}
+          variant="outlined"
           size="md"
-          isSelected={switchStates.medium}
-          onValueChange={handleSwitchChange('medium')}
-        />
-        <Switch
-          variant="overlap"
+          radius="none"
+        >
+          <SelectItem key="r1" title="Radius None" />
+          <SelectItem key="r2" title="Option 2" />
+        </Select>
+        <Select
+          label="Small"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={radiusSmKeys}
+          onSelectionChange={setRadiusSmKeys}
+          variant="outlined"
+          size="md"
+          radius="sm"
+        >
+          <SelectItem key="r1" title="Radius Small" />
+          <SelectItem key="r2" title="Option 2" />
+        </Select>
+        <Select
+          label="Medium"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={radiusMdKeys}
+          onSelectionChange={setRadiusMdKeys}
+          variant="outlined"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="r1" title="Radius Medium" />
+          <SelectItem key="r2" title="Option 2" />
+        </Select>
+        <Select
           label="Large"
-          themeColor="primary"
-          size="lg"
-          isSelected={switchStates.large}
-          onValueChange={handleSwitchChange('large')}
-        />
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={radiusLgKeys}
+          onSelectionChange={setRadiusLgKeys}
+          variant="outlined"
+          size="md"
+          radius="lg"
+        >
+          <SelectItem key="r1" title="Radius Large" />
+          <SelectItem key="r2" title="Option 2" />
+          <SelectItem key="r3" title="Option 3" />
+        </Select>
+        <Select
+          label="Full"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={radiusFullKeys}
+          onSelectionChange={setRadiusFullKeys}
+          variant="outlined"
+          size="md"
+          radius="full"
+        >
+          <SelectItem key="r1" title="Radius Full" />
+          <SelectItem key="r2" title="Option 2" />
+        </Select>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Label Placements</Text>
+        <Select
+          label="Outside Label"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={labelOutsideKeys}
+          onSelectionChange={setLabelOutsideKeys}
+          variant="outlined"
+          labelPlacement="outside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="lo1" title="Option 1" />
+          <SelectItem key="lo2" title="Option 2" />
+        </Select>
+        <Select
+          label="Inside Label"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={labelInsideKeys}
+          onSelectionChange={setLabelInsideKeys}
+          variant="outlined"
+          labelPlacement="inside"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="li1" title="Option 1" />
+          <SelectItem key="li2" title="Option 2" />
+        </Select>
+        <Select
+          label="Outside Left"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={labelOutsideLeftKeys}
+          onSelectionChange={setLabelOutsideLeftKeys}
+          variant="outlined"
+          labelPlacement="outside-left"
+          size="md"
+          radius="md"
+        >
+          <SelectItem key="lol1" title="Option 1" />
+          <SelectItem key="lol2" title="Option 2" />
+        </Select>
       </View>
 
       <View style={styles.section}>
         <Text style={styles.label}>States</Text>
-        <Switch
-          variant="inside"
-          label="Selected"
-          themeColor="primary"
-          isSelected={switchStates.selected}
-          onValueChange={handleSwitchChange('selected')}
-        />
-        <Switch
-          variant="inside"
-          label="Unselected"
-          themeColor="primary"
-          isSelected={switchStates.unselected}
-          onValueChange={handleSwitchChange('unselected')}
-        />
-        <Switch
-          variant="inside"
+        <Select
           label="Disabled"
-          themeColor="primary"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={[]}
+          onSelectionChange={() => {}}
+          variant="outlined"
+          size="md"
+          radius="md"
           isDisabled
-          isSelected={false}
-        />
-        <Switch
-          variant="inside"
-          label="Disabled & Selected"
-          themeColor="primary"
-          isDisabled
-          isSelected
-        />
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Label Alignment</Text>
-        <Switch
-          variant="inside"
-          label="Label on Right (default)"
-          labelAlignment="right"
-          themeColor="primary"
-          isSelected={switchStates.alignRight}
-          onValueChange={handleSwitchChange('alignRight')}
-        />
-        <Switch
-          variant="inside"
-          label="Label on Left"
-          labelAlignment="left"
-          themeColor="primary"
-          isSelected={switchStates.alignLeft}
-          onValueChange={handleSwitchChange('alignLeft')}
-        />
-        <Switch
-          variant="inside"
-          label="Enable notifications"
-          labelAlignment="justify-left"
-          fullWidth
-          themeColor="primary"
-          isSelected={switchStates.justifyLeft}
-          onValueChange={handleSwitchChange('justifyLeft')}
-        />
-        <Switch
-          variant="inside"
-          label="Dark mode"
-          labelAlignment="justify-right"
-          fullWidth
-          themeColor="primary"
-          isSelected={switchStates.justifyRight}
-          onValueChange={handleSwitchChange('justifyRight')}
-        />
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.label}>Overlap Variant Colors</Text>
-        <Switch
-          variant="overlap"
-          label="Primary"
-          themeColor="primary"
-          isSelected={switchStates.primary}
-          onValueChange={handleSwitchChange('primary')}
-        />
-        <Switch
-          variant="overlap"
-          label="Secondary"
-          themeColor="secondary"
-          isSelected={switchStates.secondary}
-          onValueChange={handleSwitchChange('secondary')}
-        />
-        <Switch
-          variant="overlap"
-          label="Success"
-          themeColor="success"
-          isSelected={switchStates.success}
-          onValueChange={handleSwitchChange('success')}
-        />
-        <Switch
-          variant="overlap"
-          label="Warning"
-          themeColor="warning"
-          isSelected={switchStates.warning}
-          onValueChange={handleSwitchChange('warning')}
-        />
-        <Switch
-          variant="overlap"
-          label="Danger"
-          themeColor="danger"
-          isSelected={switchStates.danger}
-          onValueChange={handleSwitchChange('danger')}
-        />
+        >
+          <SelectItem key="d1" title="Option 1" />
+          <SelectItem key="d2" title="Option 2" />
+        </Select>
+        <Select
+          label="Invalid"
+          placeholder="Select option"
+          selectionMode="single"
+          selectedKeys={[]}
+          onSelectionChange={() => {}}
+          variant="outlined"
+          size="md"
+          radius="md"
+          isInvalid
+          errorMessage="This field is required"
+        >
+          <SelectItem key="i1" title="Option 1" />
+          <SelectItem key="i2" title="Option 2" />
+        </Select>
       </View>
     </ScrollView>
   )

--- a/apps/demo/app/(tabs)/explore.tsx
+++ b/apps/demo/app/(tabs)/explore.tsx
@@ -82,6 +82,7 @@ export default function ExploreScreen() {
           selectedKeys={variantOutlinedKeys}
           onSelectionChange={setVariantOutlinedKeys}
           variant="outlined"
+          themeColor="primary"
           size="md"
           radius="md"
         >

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -42,7 +42,8 @@
     "@xaui/progress": "workspace:*",
     "@xaui/buttons": "workspace:*",
     "@xaui/checkboxes": "workspace:*",
-    "@xaui/switches": "workspace:*"
+    "@xaui/switches": "workspace:*",
+    "@xaui/select": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -23,3 +23,48 @@ import { Select, SelectItem } from '@xaui/select'
   <SelectItem key="es" title="Spain" />
 </Select>
 ```
+
+## Props
+
+### Select
+
+- `selectionMode`: `single | multiple`
+- `selectedKeys`: `string[]`
+- `disabledKeys`: `string[]`
+- `defaultSelectedKeys`: `string[]`
+- `variant`: `flat | outlined | faded | underlined | light`
+- `themeColor`: `primary | secondary | tertiary | danger | warning | success | default`
+- `size`: `sm | md | lg`
+- `radius`: `none | sm | md | lg | full`
+- `placeholder`: `string`
+- `labelPlacement`: `inside | outside | outside-left | outside-top`
+- `label`: `ReactNode`
+- `hint`: `ReactNode`
+- `errorMessage`: `ReactNode`
+- `startContent`: `ReactNode`
+- `endContent`: `ReactNode`
+- `selectorIcon`: `ReactNode`
+- `maxListboxHeight`: `number`
+- `fullWidth`: `boolean`
+- `isOpened`: `boolean`
+- `isDisabled`: `boolean`
+- `isInvalid`: `boolean`
+
+### Events
+
+- `onClose`: `() => void`
+- `onOpenChange`: `(isOpen: boolean) => void`
+- `onSelectionChange`: `(keys: string[]) => void`
+- `onClear`: `() => void`
+
+### SelectItem
+
+- `title`: `ReactNode`
+- `description`: `ReactNode`
+- `startContent`: `ReactNode`
+- `endContent`: `ReactNode`
+- `selectedIcon`: `ReactNode`
+- `isDisabled`: `boolean`
+- `isSelected`: `boolean`
+- `isReadOnly`: `boolean`
+- `onSelected`: `() => void`

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -1,0 +1,25 @@
+# @xaui/select
+
+Select components for XAUI.
+
+## Installation
+
+```bash
+pnpm add @xaui/select
+```
+
+## Usage
+
+```tsx
+import { Select, SelectItem } from '@xaui/select'
+
+<Select
+  label="Country"
+  placeholder="Choose a country"
+  selectionMode="single"
+  defaultSelectedKeys={['fr']}
+>
+  <SelectItem key="fr" title="France" />
+  <SelectItem key="es" title="Spain" />
+</Select>
+```

--- a/packages/components/select/eslint.config.js
+++ b/packages/components/select/eslint.config.js
@@ -1,0 +1,3 @@
+import baseConfig from '../../../eslint.config.base.js'
+
+export default [...baseConfig]

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@xaui/select",
+  "version": "0.1.0",
+  "description": "Select components for XAUI - A modern React Native UI library with Flutter-inspired API",
+  "keywords": [
+    "react-native",
+    "ui",
+    "components",
+    "select",
+    "flutter",
+    "design-system",
+    "typescript",
+    "xaui",
+    "reanimated",
+    "animation"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rygrams/xaui.git",
+    "directory": "packages/select"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --external react --external react-native",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --external react --external react-native --watch",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "lint": "eslint src/",
+    "type-check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-native": ">=0.70.0",
+    "react-native-svg": ">=13.0.0"
+  },
+  "dependencies": {
+    "@xaui/colors": "workspace:*",
+    "@xaui/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@testing-library/react-native": "^13.3.3",
+    "@types/react": "^19.1.0",
+    "@types/react-native": "^0.73.0",
+    "react": "19.1.0",
+    "react-native": "^0.81.5",
+    "react-native-svg": "^15.8.0",
+    "react-test-renderer": "19.1.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/components/select/src/__tests__/__mocks__/react-native.ts
+++ b/packages/components/select/src/__tests__/__mocks__/react-native.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest'
+
+export const StyleSheet = {
+  create: <T,>(styles: T): T => styles,
+}
+
+export const View = 'View'
+export const Text = 'Text'
+export const TouchableOpacity = 'TouchableOpacity'
+export const Pressable = 'Pressable'
+export const ScrollView = 'ScrollView'
+export const Modal = 'Modal'
+
+export const useColorScheme = vi.fn(() => 'light')
+
+export const Platform = {
+  OS: 'ios',
+  select: <T,>(obj: Record<string, T>): T | undefined => obj.ios || obj.default,
+}

--- a/packages/components/select/src/__tests__/select.test.tsx
+++ b/packages/components/select/src/__tests__/select.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import type { SelectItemProps, SelectProps } from '../select-types'
+
+describe('Select Types', () => {
+  it('accepts Select props', () => {
+    const props: SelectProps = {
+      children: 'Test',
+      selectionMode: 'multiple',
+      selectedKeys: ['a'],
+      disabledKeys: ['b'],
+      defaultSelectedKeys: ['c'],
+      variant: 'outlined',
+      themeColor: 'primary',
+      size: 'sm',
+      radius: 'lg',
+      placeholder: 'Pick',
+      labelPlacement: 'inside',
+      label: 'Label',
+      hint: 'Hint',
+      errorMessage: 'Error',
+      startContent: 'Start',
+      endContent: 'End',
+      selectorIcon: 'Icon',
+      maxListboxHeight: 240,
+      fullWidth: false,
+      isOpened: false,
+      isDisabled: false,
+      isInvalid: false,
+      onClose: () => {},
+      onOpenChange: () => {},
+      onSelectionChange: () => {},
+      onClear: () => {},
+    }
+
+    expect(props.children).toBe('Test')
+    expect(props.selectionMode).toBe('multiple')
+    expect(props.variant).toBe('outlined')
+  })
+
+  it('accepts all variants', () => {
+    const variants: Array<SelectProps['variant']> = [
+      'flat',
+      'outlined',
+      'faded',
+      'underlined',
+      'light',
+    ]
+
+    variants.forEach((variant) => {
+      const props: SelectProps = {
+        children: 'Test',
+        variant,
+      }
+
+      expect(props.variant).toBe(variant)
+    })
+  })
+})
+
+describe('SelectItem Types', () => {
+  it('accepts SelectItem props', () => {
+    const props: SelectItemProps = {
+      title: 'Item',
+      description: 'Description',
+      startContent: 'Start',
+      endContent: 'End',
+      selectedIcon: 'Selected',
+      isDisabled: false,
+      isSelected: true,
+      isReadOnly: false,
+      onSelected: () => {},
+    }
+
+    expect(props.title).toBe('Item')
+    expect(props.isSelected).toBe(true)
+  })
+})

--- a/packages/components/select/src/checkmark-icon.tsx
+++ b/packages/components/select/src/checkmark-icon.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import Svg, { Polyline } from 'react-native-svg'
+
+type CheckmarkIconProps = {
+  color: string
+  size: number
+}
+
+export function CheckmarkIcon({ color, size }: CheckmarkIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 17 18" fill="none">
+      <Polyline
+        points="1 9 7 14 15 4"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}

--- a/packages/components/select/src/chevron-down-icon.tsx
+++ b/packages/components/select/src/chevron-down-icon.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Svg, { Path } from 'react-native-svg'
+
+type ChevronDownIconProps = {
+  color: string
+  size: number
+  isOpen?: boolean
+}
+
+export function ChevronDownIcon({ color, size, isOpen = false }: ChevronDownIconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      style={isOpen ? { transform: [{ rotate: '180deg' }] } : undefined}
+    >
+      <Path
+        d="M6 9L12 15L18 9"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}

--- a/packages/components/select/src/chevron-down-icon.tsx
+++ b/packages/components/select/src/chevron-down-icon.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
+import { Animated } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 
 type ChevronDownIconProps = {
@@ -8,21 +9,32 @@ type ChevronDownIconProps = {
 }
 
 export function ChevronDownIcon({ color, size, isOpen = false }: ChevronDownIconProps) {
+  const rotation = useRef(new Animated.Value(isOpen ? 1 : 0)).current
+
+  useEffect(() => {
+    Animated.timing(rotation, {
+      toValue: isOpen ? 1 : 0,
+      duration: 180,
+      useNativeDriver: true,
+    }).start()
+  }, [isOpen, rotation])
+
+  const rotate = rotation.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '180deg'],
+  })
+
   return (
-    <Svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      style={isOpen ? { transform: [{ rotate: '180deg' }] } : undefined}
-    >
-      <Path
-        d="M6 9L12 15L18 9"
-        stroke={color}
-        strokeWidth={2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </Svg>
+    <Animated.View style={{ transform: [{ rotate }] }}>
+      <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+        <Path
+          d="M6 9L12 15L18 9"
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </Svg>
+    </Animated.View>
   )
 }

--- a/packages/components/select/src/index.ts
+++ b/packages/components/select/src/index.ts
@@ -1,0 +1,3 @@
+export { Select } from './select'
+export { SelectItem } from './select-item'
+export type { SelectProps, SelectItemProps } from './select-types'

--- a/packages/components/select/src/select-context.ts
+++ b/packages/components/select/src/select-context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react'
+import type { SelectSize, SelectThemeColor } from './select-types'
+
+export type SelectContextValue = {
+  size: SelectSize
+  themeColor: SelectThemeColor
+  isDisabled: boolean
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null)

--- a/packages/components/select/src/select-item.tsx
+++ b/packages/components/select/src/select-item.tsx
@@ -17,6 +17,8 @@ export const SelectItem: React.FC<SelectItemProps> = ({
   isDisabled = false,
   isSelected = false,
   isReadOnly = false,
+  mainStyle,
+  textStyle,
   onSelected,
 }) => {
   const theme = useXUITheme()
@@ -61,12 +63,15 @@ export const SelectItem: React.FC<SelectItemProps> = ({
   }, [isSelected, colorScheme])
 
   const textColor = useMemo(() => {
-    if (isSelected) {
-      return colorScheme.main
-    }
-
     return theme.colors.foreground
-  }, [isSelected, colorScheme, theme])
+  }, [theme])
+
+  const checkmarkColor = useMemo(() => {
+    if (themeColor === 'default') {
+      return theme.colors.primary.main
+    }
+    return colorScheme.main
+  }, [themeColor, colorScheme, theme])
 
   const handlePress = () => {
     if (isItemDisabled || isReadOnly) {
@@ -88,11 +93,12 @@ export const SelectItem: React.FC<SelectItemProps> = ({
           backgroundColor,
         },
         isItemDisabled && styles.disabled,
+        mainStyle,
       ]}
     >
       {startContent}
       <View style={styles.content}>
-        <Text style={[styles.title, { fontSize: sizeStyles.titleSize, color: textColor }]}>
+        <Text style={[styles.title, { fontSize: sizeStyles.titleSize, color: textColor }, textStyle]}>
           {title}
         </Text>
         {description && (
@@ -106,7 +112,7 @@ export const SelectItem: React.FC<SelectItemProps> = ({
           </Text>
         )}
       </View>
-      {isSelected && (selectedIcon || <CheckmarkIcon color={colorScheme.main} size={16} />)}
+      {isSelected && (selectedIcon || <CheckmarkIcon color={checkmarkColor} size={16} />)}
       {endContent}
     </Pressable>
   )

--- a/packages/components/select/src/select-item.tsx
+++ b/packages/components/select/src/select-item.tsx
@@ -1,0 +1,134 @@
+import React, { useContext, useMemo } from 'react'
+import { Pressable, Text, View, StyleSheet } from 'react-native'
+import { useXUITheme } from '@xaui/core'
+import { colors } from '@xaui/colors'
+import { SelectContext } from './select-context'
+import type { SelectItemProps } from './select-types'
+import { CheckmarkIcon } from './checkmark-icon'
+
+const defaultSize = 'md' as const
+
+export const SelectItem: React.FC<SelectItemProps> = ({
+  title,
+  description,
+  startContent,
+  endContent,
+  selectedIcon,
+  isDisabled = false,
+  isSelected = false,
+  isReadOnly = false,
+  onSelected,
+}) => {
+  const theme = useXUITheme()
+  const context = useContext(SelectContext)
+  const size = context?.size ?? defaultSize
+  const themeColor = context?.themeColor ?? 'default'
+  const isItemDisabled = context?.isDisabled ? true : isDisabled
+
+  const colorScheme = theme.colors[themeColor]
+
+  const sizeStyles = useMemo(() => {
+    const sizes = {
+      sm: {
+        paddingVertical: theme.spacing.sm,
+        paddingHorizontal: theme.spacing.md,
+        titleSize: theme.fontSizes.sm,
+        descriptionSize: theme.fontSizes.xs,
+      },
+      md: {
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.md,
+        titleSize: theme.fontSizes.md,
+        descriptionSize: theme.fontSizes.sm,
+      },
+      lg: {
+        paddingVertical: theme.spacing.lg,
+        paddingHorizontal: theme.spacing.lg,
+        titleSize: theme.fontSizes.lg,
+        descriptionSize: theme.fontSizes.md,
+      },
+    }
+
+    return sizes[size]
+  }, [size, theme])
+
+  const backgroundColor = useMemo(() => {
+    if (isSelected) {
+      return colorScheme.background
+    }
+
+    return colors.transparent
+  }, [isSelected, colorScheme])
+
+  const textColor = useMemo(() => {
+    if (isSelected) {
+      return colorScheme.main
+    }
+
+    return theme.colors.foreground
+  }, [isSelected, colorScheme, theme])
+
+  const handlePress = () => {
+    if (isItemDisabled || isReadOnly) {
+      return
+    }
+
+    onSelected?.()
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      disabled={isItemDisabled}
+      style={[
+        styles.item,
+        {
+          paddingVertical: sizeStyles.paddingVertical,
+          paddingHorizontal: sizeStyles.paddingHorizontal,
+          backgroundColor,
+        },
+        isItemDisabled && styles.disabled,
+      ]}
+    >
+      {startContent}
+      <View style={styles.content}>
+        <Text style={[styles.title, { fontSize: sizeStyles.titleSize, color: textColor }]}>
+          {title}
+        </Text>
+        {description && (
+          <Text
+            style={[
+              styles.description,
+              { fontSize: sizeStyles.descriptionSize, color: theme.colors.foreground },
+            ]}
+          >
+            {description}
+          </Text>
+        )}
+      </View>
+      {isSelected && (selectedIcon || <CheckmarkIcon color={colorScheme.main} size={16} />)}
+      {endContent}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  content: {
+    flex: 1,
+    gap: 2,
+  },
+  title: {
+    fontWeight: '500',
+  },
+  description: {
+    opacity: 0.7,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+})

--- a/packages/components/select/src/select-types.ts
+++ b/packages/components/select/src/select-types.ts
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react'
+
+export type SelectThemeColor =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'danger'
+  | 'warning'
+  | 'success'
+  | 'default'
+
+export type SelectVariant = 'flat' | 'outlined' | 'faded' | 'underlined' | 'light'
+
+export type SelectSize = 'sm' | 'md' | 'lg'
+
+export type SelectRadius = 'none' | 'sm' | 'md' | 'lg' | 'full'
+
+export type SelectLabelPlacement = 'inside' | 'outside' | 'outside-left' | 'outside-top'
+
+export type SelectSelectionMode = 'single' | 'multiple'
+
+export type SelectProps = {
+  children: ReactNode
+  selectionMode?: SelectSelectionMode
+  selectedKeys?: string[]
+  disabledKeys?: string[]
+  defaultSelectedKeys?: string[]
+  variant?: SelectVariant
+  themeColor?: SelectThemeColor
+  size?: SelectSize
+  radius?: SelectRadius
+  placeholder?: string
+  labelPlacement?: SelectLabelPlacement
+  label?: ReactNode
+  hint?: ReactNode
+  errorMessage?: ReactNode
+  startContent?: ReactNode
+  endContent?: ReactNode
+  selectorIcon?: ReactNode
+  maxListboxHeight?: number
+  fullWidth?: boolean
+  isOpened?: boolean
+  isDisabled?: boolean
+  isInvalid?: boolean
+} & SelectEvents
+
+export type SelectEvents = {
+  onClose?: () => void
+  onOpenChange?: (isOpen: boolean) => void
+  onSelectionChange?: (keys: string[]) => void
+  onClear?: () => void
+}
+
+export type SelectItemProps = {
+  title: ReactNode
+  description?: ReactNode
+  startContent?: ReactNode
+  endContent?: ReactNode
+  selectedIcon?: ReactNode
+  isDisabled?: boolean
+  isSelected?: boolean
+  isReadOnly?: boolean
+  onSelected?: () => void
+}

--- a/packages/components/select/src/select-types.ts
+++ b/packages/components/select/src/select-types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import type { ViewStyle, TextStyle } from 'react-native'
 
 export type SelectThemeColor =
   | 'primary'
@@ -9,7 +10,7 @@ export type SelectThemeColor =
   | 'success'
   | 'default'
 
-export type SelectVariant = 'flat' | 'outlined' | 'faded' | 'underlined' | 'light'
+export type SelectVariant = 'outlined' | 'flat' | 'light' | 'faded' | 'underlined'
 
 export type SelectSize = 'sm' | 'md' | 'lg'
 
@@ -42,6 +43,8 @@ export type SelectProps = {
   isOpened?: boolean
   isDisabled?: boolean
   isInvalid?: boolean
+  mainStyle?: ViewStyle
+  textStyle?: TextStyle
 } & SelectEvents
 
 export type SelectEvents = {
@@ -60,5 +63,7 @@ export type SelectItemProps = {
   isDisabled?: boolean
   isSelected?: boolean
   isReadOnly?: boolean
+  mainStyle?: ViewStyle
+  textStyle?: TextStyle
   onSelected?: () => void
 }

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -1,0 +1,481 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  StyleSheet,
+  type LayoutChangeEvent,
+} from 'react-native'
+import { useXUITheme } from '@xaui/core'
+import { colors } from '@xaui/colors'
+import { SelectContext } from './select-context'
+import type { SelectItemProps, SelectProps } from './select-types'
+import { ChevronDownIcon } from './chevron-down-icon'
+
+const defaultPlaceholder = 'Select an option'
+
+type ItemData = {
+  key: string
+  element: React.ReactElement<SelectItemProps>
+  titleText: string
+}
+
+export const Select: React.FC<SelectProps> = ({
+  children,
+  selectionMode = 'single',
+  selectedKeys,
+  disabledKeys,
+  defaultSelectedKeys,
+  variant = 'flat',
+  themeColor = 'default',
+  size = 'md',
+  radius = 'md',
+  placeholder = defaultPlaceholder,
+  labelPlacement = 'outside',
+  label,
+  hint,
+  errorMessage,
+  startContent,
+  endContent,
+  selectorIcon,
+  maxListboxHeight = 280,
+  fullWidth = true,
+  isOpened,
+  isDisabled = false,
+  isInvalid = false,
+  onClose,
+  onOpenChange,
+  onSelectionChange,
+  onClear,
+}) => {
+  const theme = useXUITheme()
+  const [internalSelectedKeys, setInternalSelectedKeys] = useState(
+    defaultSelectedKeys ?? [],
+  )
+  const [internalOpen, setInternalOpen] = useState(false)
+  const [triggerWidth, setTriggerWidth] = useState<number | null>(null)
+
+  const isControlledSelection = selectedKeys !== undefined
+  const currentSelectedKeys = isControlledSelection
+    ? selectedKeys ?? []
+    : internalSelectedKeys
+
+  const isOpen = isOpened ?? internalOpen
+
+  const disabledKeySet = useMemo(() => {
+    return new Set(disabledKeys ?? [])
+  }, [disabledKeys])
+
+  const items = useMemo(() => {
+    const elements = React.Children.toArray(children).filter(Boolean)
+    return elements
+      .map((child, index) => {
+        if (!React.isValidElement<SelectItemProps>(child)) {
+          return null
+        }
+
+        const keyFromElement = typeof child.key === 'string' ? child.key : undefined
+        const keyFromTitle =
+          typeof child.props.title === 'string' ? child.props.title : undefined
+        const key = keyFromElement ?? keyFromTitle ?? String(index)
+        const titleText =
+          typeof child.props.title === 'string'
+            ? child.props.title
+            : typeof child.props.title === 'number'
+              ? String(child.props.title)
+              : key
+
+        return {
+          key,
+          element: child,
+          titleText,
+        }
+      })
+      .filter((item): item is ItemData => item !== null)
+  }, [children])
+
+  const selectedLabels = useMemo(() => {
+    const labelMap = new Map(items.map((item) => [item.key, item.titleText]))
+    return currentSelectedKeys
+      .map((key) => labelMap.get(key))
+      .filter((value): value is string => Boolean(value))
+  }, [currentSelectedKeys, items])
+
+  const displayValue = selectedLabels.length ? selectedLabels.join(', ') : placeholder
+
+  const shouldShowPlaceholder = selectedLabels.length === 0
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen && isDisabled) {
+        return
+      }
+
+      if (isOpened === undefined) {
+        setInternalOpen(nextOpen)
+      }
+
+      onOpenChange?.(nextOpen)
+
+      if (!nextOpen) {
+        onClose?.()
+      }
+    },
+    [isDisabled, isOpened, onOpenChange, onClose],
+  )
+
+  const updateSelection = useCallback(
+    (nextKeys: string[]) => {
+      if (!isControlledSelection) {
+        setInternalSelectedKeys(nextKeys)
+      }
+
+      onSelectionChange?.(nextKeys)
+
+      if (nextKeys.length === 0) {
+        onClear?.()
+      }
+    },
+    [isControlledSelection, onSelectionChange, onClear],
+  )
+
+  const handleItemSelection = useCallback(
+    (key: string) => {
+      if (isDisabled) {
+        return
+      }
+
+      const isAlreadySelected = currentSelectedKeys.includes(key)
+
+      if (selectionMode === 'multiple') {
+        const nextKeys = isAlreadySelected
+          ? currentSelectedKeys.filter((existingKey) => existingKey !== key)
+          : [...currentSelectedKeys, key]
+
+        updateSelection(nextKeys)
+        return
+      }
+
+      if (!isAlreadySelected) {
+        updateSelection([key])
+      }
+
+      setOpen(false)
+    },
+    [
+      currentSelectedKeys,
+      isDisabled,
+      selectionMode,
+      setOpen,
+      updateSelection,
+    ],
+  )
+
+  const handleClear = () => {
+    if (isDisabled || currentSelectedKeys.length === 0) {
+      return
+    }
+
+    updateSelection([])
+  }
+
+  const handleTriggerLayout = (event: LayoutChangeEvent) => {
+    setTriggerWidth(event.nativeEvent.layout.width)
+  }
+
+  const handleOverlayPress = () => {
+    setOpen(false)
+  }
+
+  const sizeStyles = useMemo(() => {
+    const sizes = {
+      sm: {
+        minHeight: 36,
+        paddingHorizontal: theme.spacing.md,
+        paddingVertical: theme.spacing.sm,
+        fontSize: theme.fontSizes.sm,
+        labelSize: theme.fontSizes.xs,
+      },
+      md: {
+        minHeight: 40,
+        paddingHorizontal: theme.spacing.md,
+        paddingVertical: theme.spacing.sm,
+        fontSize: theme.fontSizes.md,
+        labelSize: theme.fontSizes.sm,
+      },
+      lg: {
+        minHeight: 48,
+        paddingHorizontal: theme.spacing.lg,
+        paddingVertical: theme.spacing.md,
+        fontSize: theme.fontSizes.lg,
+        labelSize: theme.fontSizes.md,
+      },
+    }
+
+    return sizes[size]
+  }, [size, theme])
+
+  const radiusStyles = useMemo(() => {
+    const radii = {
+      none: theme.borderRadius.none,
+      sm: theme.borderRadius.sm,
+      md: theme.borderRadius.md,
+      lg: theme.borderRadius.lg,
+      full: theme.borderRadius.full,
+    }
+    return { borderRadius: radii[radius] }
+  }, [radius, theme])
+
+  const colorScheme = theme.colors[themeColor]
+
+  const variantStyles = useMemo(() => {
+    if (variant === 'outlined') {
+      return {
+        backgroundColor: colors.transparent,
+        borderWidth: theme.borderWidth.sm,
+        borderColor: isInvalid ? theme.colors.danger.main : colorScheme.main,
+      }
+    }
+
+    if (variant === 'faded') {
+      return {
+        backgroundColor: colorScheme.background,
+        borderWidth: theme.borderWidth.sm,
+        borderColor: isInvalid ? theme.colors.danger.main : colorScheme.main,
+      }
+    }
+
+    if (variant === 'underlined') {
+      return {
+        backgroundColor: colors.transparent,
+        borderBottomWidth: theme.borderWidth.sm,
+        borderColor: isInvalid ? theme.colors.danger.main : colorScheme.main,
+      }
+    }
+
+    if (variant === 'light') {
+      return {
+        backgroundColor: colors.transparent,
+        borderWidth: 0,
+      }
+    }
+
+    return {
+      backgroundColor: colorScheme.background,
+      borderWidth: 0,
+    }
+  }, [variant, theme, colorScheme, isInvalid])
+
+  const labelStyle = useMemo(() => {
+    const baseColor = isInvalid ? theme.colors.danger.main : theme.colors.foreground
+    return {
+      fontSize: sizeStyles.labelSize,
+      color: baseColor,
+    }
+  }, [isInvalid, sizeStyles.labelSize, theme])
+
+  const valueColor = useMemo(() => {
+    if (isInvalid) {
+      return theme.colors.danger.main
+    }
+
+    if (shouldShowPlaceholder) {
+      return colors.gray[500]
+    }
+
+    return theme.colors.foreground
+  }, [isInvalid, shouldShowPlaceholder, theme])
+
+  const renderLabel = label ? <Text style={[styles.label, labelStyle]}>{label}</Text> : null
+
+  const renderSelectorIcon = selectorIcon ?? (
+    <ChevronDownIcon color={colors.gray[700]} size={16} isOpen={isOpen} />
+  )
+
+  const shouldShowHelper = Boolean(hint || errorMessage)
+  const helperContent = isInvalid && errorMessage ? errorMessage : hint
+
+  const listboxWidth = fullWidth ? triggerWidth ?? '100%' : 280
+
+  const listItems = items.map((item) => {
+    const itemProps = item.element.props
+    const itemDisabled = isDisabled || itemProps.isDisabled || disabledKeySet.has(item.key)
+    const itemSelected = itemProps.isSelected ?? currentSelectedKeys.includes(item.key)
+
+    const handleItemSelected = () => {
+      if (itemDisabled || itemProps.isReadOnly) {
+        return
+      }
+
+      handleItemSelection(item.key)
+      itemProps.onSelected?.()
+    }
+
+    return React.cloneElement(item.element, {
+      key: item.key,
+      isDisabled: itemDisabled,
+      isSelected: itemSelected,
+      onSelected: handleItemSelected,
+    })
+  })
+
+  const isLabelInside = labelPlacement === 'inside'
+  const isLabelOutsideLeft = labelPlacement === 'outside-left'
+  const isLabelOutside = labelPlacement === 'outside' || labelPlacement === 'outside-top'
+
+  const triggerContent = (
+    <Pressable
+      onPress={() => setOpen(!isOpen)}
+      disabled={isDisabled}
+      onLayout={handleTriggerLayout}
+      style={[
+        styles.trigger,
+        radiusStyles,
+        variantStyles,
+        {
+          minHeight: sizeStyles.minHeight,
+          paddingHorizontal: sizeStyles.paddingHorizontal,
+          paddingVertical: sizeStyles.paddingVertical,
+        },
+        isDisabled && styles.disabled,
+      ]}
+    >
+      <View style={[styles.triggerContent, isLabelInside && styles.triggerContentColumn]}>
+        {startContent}
+        <View style={styles.valueWrapper}>
+          {isLabelInside && renderLabel}
+          <Text style={[styles.valueText, { fontSize: sizeStyles.fontSize, color: valueColor }]}>
+            {displayValue}
+          </Text>
+        </View>
+        {endContent}
+      </View>
+      <View style={styles.endSlot}>
+        {onClear && currentSelectedKeys.length > 0 && (
+          <Pressable onPress={handleClear} style={styles.clearButton}>
+            <Text style={styles.clearText}>x</Text>
+          </Pressable>
+        )}
+        {renderSelectorIcon}
+      </View>
+    </Pressable>
+  )
+
+  const labelBlock = isLabelOutside || isLabelInside ? renderLabel : null
+
+  return (
+    <View style={[styles.container, fullWidth ? styles.fullWidth : styles.minWidth]}>
+      {isLabelOutside && labelBlock}
+      {isLabelOutsideLeft ? (
+        <View style={styles.outsideLeftRow}>
+          {renderLabel}
+          {triggerContent}
+        </View>
+      ) : (
+        triggerContent
+      )}
+      {shouldShowHelper && helperContent && (
+        <Text
+          style={[
+            styles.helperText,
+            { color: isInvalid ? theme.colors.danger.main : colors.gray[600] },
+          ]}
+        >
+          {helperContent}
+        </Text>
+      )}
+
+      <Modal visible={isOpen} transparent animationType="fade" onRequestClose={handleOverlayPress}>
+        <Pressable style={styles.overlay} onPress={handleOverlayPress}>
+          <Pressable
+            style={[
+              styles.listbox,
+              radiusStyles,
+              { width: listboxWidth, maxHeight: maxListboxHeight },
+            ]}
+            onPress={(event) => event.stopPropagation()}
+          >
+            <SelectContext.Provider value={{ size, themeColor, isDisabled }}>
+              <ScrollView>{listItems}</ScrollView>
+            </SelectContext.Provider>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 6,
+  },
+  fullWidth: {
+    width: '100%',
+  },
+  minWidth: {
+    minWidth: 200,
+  },
+  label: {
+    fontWeight: '500',
+  },
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  triggerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: 8,
+  },
+  triggerContentColumn: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  valueWrapper: {
+    flex: 1,
+    gap: 2,
+  },
+  valueText: {
+    flexShrink: 1,
+  },
+  endSlot: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  clearButton: {
+    paddingHorizontal: 4,
+    paddingVertical: 2,
+  },
+  clearText: {
+    fontSize: 12,
+    color: colors.gray[700],
+  },
+  helperText: {
+    fontSize: 12,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  listbox: {
+    backgroundColor: colors.white,
+    overflow: 'hidden',
+  },
+  outsideLeftRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+})

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import {
   Animated,
@@ -57,7 +58,7 @@ export const Select: React.FC<SelectProps> = ({
   const theme = useXUITheme()
   const triggerRef = useRef<View>(null)
   const [internalSelectedKeys, setInternalSelectedKeys] = useState(
-    defaultSelectedKeys ?? [],
+    defaultSelectedKeys ?? []
   )
   const [internalOpen, setInternalOpen] = useState(false)
   const [triggerWidth, setTriggerWidth] = useState<number | null>(null)
@@ -72,7 +73,7 @@ export const Select: React.FC<SelectProps> = ({
 
   const isControlledSelection = selectedKeys !== undefined
   const currentSelectedKeys = isControlledSelection
-    ? selectedKeys ?? []
+    ? (selectedKeys ?? [])
     : internalSelectedKeys
 
   const isOpen = isOpened ?? internalOpen
@@ -110,9 +111,9 @@ export const Select: React.FC<SelectProps> = ({
   }, [children])
 
   const selectedLabels = useMemo(() => {
-    const labelMap = new Map(items.map((item) => [item.key, item.titleText]))
+    const labelMap = new Map(items.map(item => [item.key, item.titleText]))
     return currentSelectedKeys
-      .map((key) => labelMap.get(key))
+      .map(key => labelMap.get(key))
       .filter((value): value is string => Boolean(value))
   }, [currentSelectedKeys, items])
 
@@ -136,7 +137,7 @@ export const Select: React.FC<SelectProps> = ({
         onClose?.()
       }
     },
-    [isDisabled, isOpened, onOpenChange, onClose],
+    [isDisabled, isOpened, onOpenChange, onClose]
   )
 
   const updateSelection = useCallback(
@@ -151,7 +152,7 @@ export const Select: React.FC<SelectProps> = ({
         onClear?.()
       }
     },
-    [isControlledSelection, onSelectionChange, onClear],
+    [isControlledSelection, onSelectionChange, onClear]
   )
 
   const handleItemSelection = useCallback(
@@ -164,7 +165,7 @@ export const Select: React.FC<SelectProps> = ({
 
       if (selectionMode === 'multiple') {
         const nextKeys = isAlreadySelected
-          ? currentSelectedKeys.filter((existingKey) => existingKey !== key)
+          ? currentSelectedKeys.filter(existingKey => existingKey !== key)
           : [...currentSelectedKeys, key]
 
         updateSelection(nextKeys)
@@ -177,13 +178,7 @@ export const Select: React.FC<SelectProps> = ({
 
       setOpen(false)
     },
-    [
-      currentSelectedKeys,
-      isDisabled,
-      selectionMode,
-      setOpen,
-      updateSelection,
-    ],
+    [currentSelectedKeys, isDisabled, selectionMode, setOpen, updateSelection]
   )
 
   const handleClear = () => {
@@ -290,12 +285,19 @@ export const Select: React.FC<SelectProps> = ({
   }, [variant, theme, colorScheme, isInvalid, themeColor])
 
   const labelStyle = useMemo(() => {
-    const baseColor = isInvalid ? theme.colors.danger.main : theme.colors.foreground
+    let baseColor = theme.colors.foreground
+
+    if (isInvalid) {
+      baseColor = theme.colors.danger.main
+    } else if (themeColor !== 'default') {
+      baseColor = colorScheme.main
+    }
+
     return {
       fontSize: sizeStyles.labelSize,
       color: baseColor,
     }
-  }, [isInvalid, sizeStyles.labelSize, theme])
+  }, [isInvalid, sizeStyles.labelSize, theme, themeColor, colorScheme])
 
   const valueColor = useMemo(() => {
     if (isInvalid) {
@@ -309,7 +311,9 @@ export const Select: React.FC<SelectProps> = ({
     return theme.colors.foreground
   }, [isInvalid, shouldShowPlaceholder, theme])
 
-  const renderLabel = label ? <Text style={[styles.label, labelStyle]}>{label}</Text> : null
+  const renderLabel = label ? (
+    <Text style={[styles.label, labelStyle]}>{label}</Text>
+  ) : null
 
   const renderSelectorIcon = selectorIcon ?? (
     <ChevronDownIcon color={colors.gray[700]} size={16} isOpen={isOpen} />
@@ -318,9 +322,7 @@ export const Select: React.FC<SelectProps> = ({
   const shouldShowHelper = Boolean(hint || errorMessage)
   const helperContent = isInvalid && errorMessage ? errorMessage : hint
 
-  const listboxWidth = fullWidth
-    ? triggerWidth ?? triggerPosition?.width ?? 200
-    : 280
+  const listboxWidth = fullWidth ? (triggerWidth ?? triggerPosition?.width ?? 200) : 280
 
   useEffect(() => {
     if (!isOpen) {
@@ -364,15 +366,16 @@ export const Select: React.FC<SelectProps> = ({
     const left = Math.max(12, Math.min(centeredLeft, screenWidth - listWidth - 12))
     const top = Math.min(
       triggerPosition.y + triggerPosition.height + 8,
-      screenHeight - maxListboxHeight - 12,
+      screenHeight - maxListboxHeight - 12
     )
 
     return { top, left }
   }, [triggerPosition, listboxWidth, screenWidth, screenHeight, maxListboxHeight])
 
-  const listItems = items.map((item) => {
+  const listItems = items.map(item => {
     const itemProps = item.element.props
-    const itemDisabled = isDisabled || itemProps.isDisabled || disabledKeySet.has(item.key)
+    const itemDisabled =
+      isDisabled || itemProps.isDisabled || disabledKeySet.has(item.key)
     const itemSelected = itemProps.isSelected ?? currentSelectedKeys.includes(item.key)
 
     const handleItemSelected = () => {
@@ -408,32 +411,41 @@ export const Select: React.FC<SelectProps> = ({
           variantStyles,
           {
             minHeight: sizeStyles.minHeight,
-            paddingHorizontal: sizeStyles.paddingHorizontal,
+            paddingHorizontal:
+              variant === 'underlined' ? 2 : sizeStyles.paddingHorizontal,
             paddingVertical: sizeStyles.paddingVertical,
           },
           isDisabled && styles.disabled,
           mainStyle,
         ]}
       >
-      <View style={[styles.triggerContent, isLabelInside && styles.triggerContentColumn]}>
-        {startContent}
-        <View style={styles.valueWrapper}>
-          {isLabelInside && renderLabel}
-          <Text style={[styles.valueText, { fontSize: sizeStyles.fontSize, color: valueColor }, textStyle]}>
-            {displayValue}
-          </Text>
+        <View
+          style={[styles.triggerContent, isLabelInside && styles.triggerContentColumn]}
+        >
+          {startContent}
+          <View style={styles.valueWrapper}>
+            {isLabelInside && renderLabel}
+            <Text
+              style={[
+                styles.valueText,
+                { fontSize: sizeStyles.fontSize, color: valueColor },
+                textStyle,
+              ]}
+            >
+              {displayValue}
+            </Text>
+          </View>
+          {endContent}
         </View>
-        {endContent}
-      </View>
-      <View style={styles.endSlot}>
-        {onClear && currentSelectedKeys.length > 0 && (
-          <Pressable onPress={handleClear} style={styles.clearButton}>
-            <Text style={styles.clearText}>x</Text>
-          </Pressable>
-        )}
-        {renderSelectorIcon}
-      </View>
-    </Pressable>
+        <View style={styles.endSlot}>
+          {onClear && currentSelectedKeys.length > 0 && (
+            <Pressable onPress={handleClear} style={styles.clearButton}>
+              <Text style={styles.clearText}>x</Text>
+            </Pressable>
+          )}
+          {renderSelectorIcon}
+        </View>
+      </Pressable>
     </View>
   )
 
@@ -461,7 +473,12 @@ export const Select: React.FC<SelectProps> = ({
         </Text>
       )}
 
-      <Modal visible={isOpen} transparent animationType="fade" onRequestClose={handleOverlayPress}>
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={handleOverlayPress}
+      >
         <Pressable style={styles.overlay} onPress={handleOverlayPress}>
           <Animated.View
             style={[
@@ -478,7 +495,7 @@ export const Select: React.FC<SelectProps> = ({
               },
             ]}
           >
-            <Pressable onPress={(event) => event.stopPropagation()} style={{ flex: 1 }}>
+            <Pressable onPress={event => event.stopPropagation()} style={{ flex: 1 }}>
               <SelectContext.Provider value={{ size, themeColor, isDisabled }}>
                 <ScrollView>{listItems}</ScrollView>
               </SelectContext.Provider>

--- a/packages/components/select/tsconfig.json
+++ b/packages/components/select/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-native"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/components/select/vitest.config.ts
+++ b/packages/components/select/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // eslint-disable-next-line no-undef
+      'react-native': path.resolve(__dirname, 'src/__tests__/__mocks__/react-native.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,ts,tsx}'],
+    passWithNoTests: true,
+  },
+})

--- a/packages/core/colors/README.md
+++ b/packages/core/colors/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive color palette for XAUI, a React Native component library strongly inspired by Flutter. This package provides a Tailwind CSS-inspired color system with 20+ color families, 11 shades each (50-950), utility functions, and full TypeScript support.
 
+Designed to work seamlessly with XAUI components and theme tokens.
+
 ## Installation
 
 ```bash

--- a/packages/core/core/src/theme-colors.ts
+++ b/packages/core/core/src/theme-colors.ts
@@ -50,8 +50,8 @@ export const themeColors: ThemeColors = {
     background: colors.green[100],
   },
   default: {
-    main: colors.white,
-    foreground: colors.gray[900],
+    main: colors.gray[500],
+    foreground: colors.white,
     background: colors.gray[100],
   },
   background: colors.white,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@xaui/progress':
         specifier: workspace:*
         version: link:../../packages/components/progress
+      '@xaui/select':
+        specifier: workspace:*
+        version: link:../../packages/components/select
       '@xaui/switches':
         specifier: workspace:*
         version: link:../../packages/components/switches
@@ -310,6 +313,43 @@ importers:
       react-native-svg:
         specifier: ^15.8.0
         version: 15.15.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/components/select:
+    dependencies:
+      '@xaui/colors':
+        specifier: workspace:*
+        version: link:../../core/colors
+      '@xaui/core':
+        specifier: workspace:*
+        version: link:../../core/core
+    devDependencies:
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.17
+      '@types/react-native':
+        specifier: ^0.73.0
+        version: 0.73.0(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-native:
+        specifier: ^0.81.5
+        version: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+      react-native-svg:
+        specifier: ^15.8.0
+        version: 15.15.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-test-renderer:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## What
- add new @xaui/select package with Select and SelectItem components
- add demo usages and variants in explore screen
- improve select interactions (label theme color, chevron rotation, modal positioning)

## Why
- provide a selectable input component consistent with XAUI design system
- offer demo coverage for variants, sizes, and colors

## How
- implement select logic and styling with theme tokens
- add listbox positioning + open animation and icon rotation
- wire demo usage for select variants