### PR TITLE
docs: Update package names in documentation to singular form

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # demo
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @xaui/button@0.1.4
+  - @xaui/checkbox@0.1.4
+  - @xaui/switch@0.1.4
+
 ## 1.0.5
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "demo",
   "main": "expo-router/entry",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "scripts": {
     "dev": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -40,9 +40,9 @@
     "@xaui/core": "workspace:*",
     "@xaui/colors": "workspace:*",
     "@xaui/progress": "workspace:*",
-    "@xaui/buttons": "workspace:*",
-    "@xaui/checkboxes": "workspace:*",
-    "@xaui/switches": "workspace:*",
+    "@xaui/button": "workspace:*",
+    "@xaui/checkbox": "workspace:*",
+    "@xaui/switch": "workspace:*",
     "@xaui/select": "workspace:*"
   },
   "devDependencies": {

--- a/packages/components/buttons/CHANGELOG.md
+++ b/packages/components/buttons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xaui/buttons
 
+## 0.1.4
+
+### Patch Changes
+
+- Update README documentation to use @xaui/button instead of @xaui/buttons
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/components/buttons/README.md
+++ b/packages/components/buttons/README.md
@@ -1,11 +1,11 @@
-# @xaui/buttons
+# @xaui/button
 
 Button components for XAUI - A modern React Native UI library with Flutter-inspired API.
 
 ## Installation
 
 ```bash
-pnpm add @xaui/buttons @xaui/core @xaui/progress
+pnpm add @xaui/button @xaui/core @xaui/progress
 ```
 
 ## Components
@@ -20,7 +20,7 @@ A comprehensive button component with support for multiple variants, sizes, load
 ### Basic Usage
 
 ```tsx
-import { Button } from '@xaui/buttons'
+import { Button } from '@xaui/button'
 
 function App() {
   return (
@@ -191,7 +191,7 @@ A specialized button component designed for icon-only actions. Default variant i
 ### Basic Usage
 
 ```tsx
-import { IconButton } from '@xaui/buttons'
+import { IconButton } from '@xaui/button'
 import { HeartIcon } from 'your-icon-library'
 
 function App() {
@@ -378,7 +378,7 @@ Both Button and IconButton integrate seamlessly with the XAUI theme system via `
 
 ```tsx
 import { XUIProvider } from '@xaui/core'
-import { Button } from '@xaui/buttons'
+import { Button } from '@xaui/button'
 
 function App() {
   return (
@@ -417,7 +417,7 @@ Both components support standard React Native accessibility props:
 Full TypeScript support with comprehensive type definitions:
 
 ```tsx
-import type { ButtonProps, IconButtonProps } from '@xaui/buttons'
+import type { ButtonProps, IconButtonProps } from '@xaui/button'
 ```
 
 ## Testing

--- a/packages/components/buttons/package.json
+++ b/packages/components/buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xaui/button",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Button components for XAUI - A modern React Native UI library with Flutter-inspired API",
   "keywords": [
     "react-native",

--- a/packages/components/checkboxes/CHANGELOG.md
+++ b/packages/components/checkboxes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xaui/checkboxes
 
+## 0.1.4
+
+### Patch Changes
+
+- Update README documentation to use @xaui/checkbox instead of @xaui/checkboxes
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -1,11 +1,11 @@
-# @xaui/checkboxes
+# @xaui/checkbox
 
 Checkbox components for XAUI - A modern React Native UI library with Flutter-inspired API.
 
 ## Installation
 
 ```bash
-pnpm add @xaui/checkboxes @xaui/core
+pnpm add @xaui/checkbox @xaui/core
 ```
 
 ## Components
@@ -19,7 +19,7 @@ A comprehensive checkbox component with support for multiple variants, sizes, an
 ### Basic Usage
 
 ```tsx
-import { Checkbox } from '@xaui/checkboxes'
+import { Checkbox } from '@xaui/checkbox'
 
 function App() {
   const [checked, setChecked] = React.useState(false)
@@ -324,7 +324,7 @@ Checkbox integrates seamlessly with the XAUI theme system via `@xaui/core`:
 
 ```tsx
 import { XUIProvider } from '@xaui/core'
-import { Checkbox } from '@xaui/checkboxes'
+import { Checkbox } from '@xaui/checkbox'
 
 function App() {
   const [checked, setChecked] = React.useState(false)
@@ -362,7 +362,7 @@ The component supports standard React Native accessibility props:
 Full TypeScript support with comprehensive type definitions:
 
 ```tsx
-import type { CheckboxProps, CheckboxEvents } from '@xaui/checkboxes'
+import type { CheckboxProps, CheckboxEvents } from '@xaui/checkbox'
 ```
 
 ## Testing

--- a/packages/components/checkboxes/package.json
+++ b/packages/components/checkboxes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xaui/checkbox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Checkbox components for XAUI - A modern React Native UI library with Flutter-inspired API",
   "keywords": [
     "react-native",

--- a/packages/components/switches/CHANGELOG.md
+++ b/packages/components/switches/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xaui/switches
 
+## 0.1.4
+
+### Patch Changes
+
+- Update README documentation to use @xaui/switch instead of @xaui/switches
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/components/switches/README.md
+++ b/packages/components/switches/README.md
@@ -1,11 +1,11 @@
-# @xaui/switches
+# @xaui/switch
 
 Switch components for XAUI - A modern React Native UI library with Flutter-inspired API.
 
 ## Installation
 
 ```bash
-pnpm add @xaui/switches @xaui/core
+pnpm add @xaui/switch @xaui/core
 ```
 
 ## Components
@@ -19,7 +19,7 @@ A comprehensive switch component with support for two distinct variants, multipl
 ### Basic Usage
 
 ```tsx
-import { Switch } from '@xaui/switches'
+import { Switch } from '@xaui/switch'
 
 function App() {
   const [enabled, setEnabled] = React.useState(false)
@@ -358,7 +358,7 @@ Switch integrates seamlessly with the XAUI theme system via `@xaui/core`:
 
 ```tsx
 import { XUIProvider } from '@xaui/core'
-import { Switch } from '@xaui/switches'
+import { Switch } from '@xaui/switch'
 
 function App() {
   const [enabled, setEnabled] = React.useState(false)
@@ -396,7 +396,7 @@ The component supports standard React Native accessibility props:
 Full TypeScript support with comprehensive type definitions:
 
 ```tsx
-import type { SwitchProps, SwitchEvents } from '@xaui/switches'
+import type { SwitchProps, SwitchEvents } from '@xaui/switch'
 ```
 
 ## Testing
@@ -420,4 +420,4 @@ MIT
 
 - [@xaui/core](../core) - Core theme system and provider
 - [@xaui/colors](../colors) - Color palette system
-- [@xaui/checkboxes](../checkboxes) - Checkbox components
+- [@xaui/checkbox](../checkboxes) - Checkbox components

--- a/packages/components/switches/package.json
+++ b/packages/components/switches/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xaui/switch",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Switch components for XAUI - A modern React Native UI library with Flutter-inspired API",
   "keywords": [
     "react-native",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,10 +74,10 @@ importers:
       '@react-navigation/native':
         specifier: ^7.1.8
         version: 7.1.26(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      '@xaui/buttons':
+      '@xaui/button':
         specifier: workspace:*
         version: link:../../packages/components/buttons
-      '@xaui/checkboxes':
+      '@xaui/checkbox':
         specifier: workspace:*
         version: link:../../packages/components/checkboxes
       '@xaui/colors':
@@ -92,7 +92,7 @@ importers:
       '@xaui/select':
         specifier: workspace:*
         version: link:../../packages/components/select
-      '@xaui/switches':
+      '@xaui/switch':
         specifier: workspace:*
         version: link:../../packages/components/switches
       expo:
@@ -9449,9 +9449,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.5.0
@@ -9466,8 +9466,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -9493,7 +9493,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9504,18 +9504,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9528,7 +9528,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9539,7 +9539,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What

This PR updates all documentation to use the new singular package names:

- `@xaui/buttons` → `@xaui/button`
- `@xaui/checkboxes` → `@xaui/checkbox`
- `@xaui/switches` → `@xaui/switch`

Files updated:
- README.md for each component package with all import examples
- demo/package.json dependencies section
- Package versions bumped from 0.1.3 to 0.1.4
- CHANGELOG entries generated

## Why

Following the package rename in PR #17, the documentation still referenced the old plural package names. This updates all documentation to reflect the current singular naming convention, ensuring users see consistent package names throughout the documentation.

## How

1. Updated all README.md files to use singular package names in:
   - Installation instructions
   - Import statements in code examples
   - TypeScript type imports
   - Related packages sections
2. Updated demo app package.json to use singular package names
3. Created changesets for each package (@xaui/button, @xaui/checkbox, @xaui/switch)
4. Applied changesets with `pnpm changeset version`, which:
   - Updated package versions from 0.1.3 to 0.1.4 (patch release)
   - Generated CHANGELOG entries for each package
   - Updated demo app version to 1.0.6

## Checklist

- [x] Updated all README.md files with singular package names
- [x] Updated demo/package.json dependencies
- [x] Created changesets for all affected packages
- [x] Applied changesets with `pnpm changeset version`
- [x] All packages follow alpha versioning (patch releases)