### PR TITLE
feat: refresh theme colors and button behavior

### DIFF
--- a/.changeset/theme-colors-button-enhancements.md
+++ b/.changeset/theme-colors-button-enhancements.md
@@ -1,7 +1,6 @@
 ---
-"@xaui/core": patch
-"@xaui/native": patch
-"@xaui/hybrid": patch
+'@xaui/core': patch
+'@xaui/native': patch
 ---
 
 Enhance button component with new animations, size options, and text styles. Update theme colors with improved color definitions.

--- a/.changeset/theme-colors-button-enhancements.md
+++ b/.changeset/theme-colors-button-enhancements.md
@@ -1,0 +1,7 @@
+---
+"@xaui/core": patch
+"@xaui/native": patch
+"@xaui/hybrid": patch
+---
+
+Enhance button component with new animations, size options, and text styles. Update theme colors with improved color definitions.

--- a/packages/core/src/theme/theme-colors.ts
+++ b/packages/core/src/theme/theme-colors.ts
@@ -2,6 +2,7 @@ import { colors } from '../tokens'
 
 export type ColorScheme = {
   main: string
+  accent: string
   foreground: string
   background: string
 }
@@ -20,80 +21,95 @@ export type ThemeColors = {
 
 export const themeColors: ThemeColors = {
   primary: {
-    main: colors.blue[600],
+    main: colors.purple[800],
+    accent: colors.purple[950],
     foreground: colors.white,
-    background: colors.blue[100],
+    background: colors.purple[200],
   },
   secondary: {
-    main: colors.purple[600],
+    main: colors.zinc[500],
+    accent: colors.neutral[800],
     foreground: colors.white,
-    background: colors.purple[100],
+    background: colors.purple[200],
   },
   tertiary: {
-    main: colors.orange[600],
-    foreground: colors.white,
-    background: colors.orange[100],
-  },
-  danger: {
-    main: colors.red[600],
+    main: colors.stone[500],
+    accent: colors.orange[950],
     foreground: colors.white,
     background: colors.red[100],
   },
+  danger: {
+    main: colors.red[700],
+    accent: colors.red[950],
+    foreground: colors.white,
+    background: colors.rose[200],
+  },
   warning: {
     main: colors.amber[600],
+    accent: colors.amber[900],
     foreground: colors.gray[900],
     background: colors.amber[100],
   },
   success: {
     main: colors.green[600],
+    accent: colors.green[900],
     foreground: colors.white,
     background: colors.green[100],
   },
   default: {
-    main: colors.gray[500],
-    foreground: colors.white,
-    background: colors.gray[100],
+    main: colors.white,
+    accent: colors.zinc[700],
+    foreground: colors.zinc[900],
+    background: colors.zinc[200],
   },
+
   background: colors.white,
-  foreground: colors.gray[900],
+  foreground: colors.zinc[900],
 }
 
 export const darkThemeColors: ThemeColors = {
   primary: {
-    main: colors.blue[400],
-    foreground: colors.gray[50],
-    background: colors.blue[900],
-  },
-  secondary: {
-    main: colors.purple[400],
-    foreground: colors.gray[50],
+    main: colors.purple[300],
+    accent: colors.purple[200],
+    foreground: colors.purple[950],
     background: colors.purple[900],
   },
+  secondary: {
+    main: colors.zinc[300],
+    accent: colors.purple[200],
+    foreground: colors.zinc[700],
+    background: colors.zinc[600],
+  },
   tertiary: {
-    main: colors.orange[400],
-    foreground: colors.gray[50],
-    background: colors.orange[900],
+    main: colors.red[200],
+    accent: colors.red[100],
+    foreground: colors.pink[950],
+    background: colors.stone[600],
   },
   danger: {
-    main: colors.red[400],
-    foreground: colors.gray[50],
-    background: colors.red[900],
+    main: colors.red[300],
+    accent: colors.red[300],
+    foreground: colors.rose[950],
+    background: colors.red[800],
   },
   warning: {
     main: colors.amber[400],
+    accent: colors.amber[100],
     foreground: colors.gray[50],
     background: colors.amber[900],
   },
   success: {
     main: colors.green[400],
+    accent: colors.green[200],
     foreground: colors.gray[50],
     background: colors.green[900],
   },
   default: {
-    main: colors.gray[400],
-    foreground: colors.gray[50],
-    background: colors.gray[800],
+    main: colors.zinc[900],
+    accent: colors.stone[300],
+    foreground: colors.stone[200],
+    background: colors.zinc[700],
   },
-  background: colors.gray[950],
-  foreground: colors.gray[50],
+  background: colors.zinc[900],
+  foreground: colors.stone[200],
 }

--- a/packages/hybrid/src/components/button/button.hook.ts
+++ b/packages/hybrid/src/components/button/button.hook.ts
@@ -3,17 +3,31 @@ import { useXUITheme } from '../../core'
 import type { ButtonVariant, ButtonSize, ButtonRadius } from './button.type'
 import type { ThemeColor } from '../../types'
 
-export const useButtonStyles = (
+type ButtonSizeStyles = {
+  paddingLeft: string
+  paddingRight: string
+  paddingTop: string
+  paddingBottom: string
+  minHeight: string
+  fontSize: string
+  lineHeight: string
+}
+
+export const useVariantSizesStyles = (
   themeColor: ThemeColor,
   variant: ButtonVariant,
-  size: ButtonSize,
-  radius: ButtonRadius
-) => {
+  size: ButtonSize
+): {
+  sizeStyles: ButtonSizeStyles
+  variantStyles: Record<string, string>
+  textColor: string
+  spinnerSize: number
+} => {
   const theme = useXUITheme()
   const colorScheme = theme.colors[themeColor]
 
   const sizeStyles = useMemo(() => {
-    const sizes = {
+    const sizes: Record<ButtonSize, ButtonSizeStyles> = {
       xs: {
         paddingLeft: `${theme.spacing.sm}px`,
         paddingRight: `${theme.spacing.sm}px`,
@@ -53,17 +67,6 @@ export const useButtonStyles = (
     }
     return sizes[size]
   }, [size, theme])
-
-  const radiusStyles = useMemo(() => {
-    const radii = {
-      none: theme.borderRadius.none,
-      sm: theme.borderRadius.sm,
-      md: theme.borderRadius.md,
-      lg: theme.borderRadius.lg,
-      full: theme.borderRadius.full,
-    }
-    return { borderRadius: `${radii[radius]}px` }
-  }, [radius, theme])
 
   const variantStyles = useMemo(() => {
     const styles = {
@@ -125,6 +128,39 @@ export const useButtonStyles = (
     }
     return sizes[size]
   }, [size])
+
+  return {
+    sizeStyles,
+    variantStyles,
+    textColor,
+    spinnerSize,
+  }
+}
+
+export const useButtonStyles = (
+  themeColor: ThemeColor,
+  variant: ButtonVariant,
+  size: ButtonSize,
+  radius: ButtonRadius
+) => {
+  const theme = useXUITheme()
+
+  const { sizeStyles, variantStyles, textColor, spinnerSize } = useVariantSizesStyles(
+    themeColor,
+    variant,
+    size
+  )
+
+  const radiusStyles = useMemo(() => {
+    const radii = {
+      none: theme.borderRadius.none,
+      sm: theme.borderRadius.sm,
+      md: theme.borderRadius.md,
+      lg: theme.borderRadius.lg,
+      full: theme.borderRadius.full,
+    }
+    return { borderRadius: `${radii[radius]}px` }
+  }, [radius, theme])
 
   return {
     sizeStyles,

--- a/packages/native/src/__tests__/components/button/button.hook.test.ts
+++ b/packages/native/src/__tests__/components/button/button.hook.test.ts
@@ -1,17 +1,57 @@
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useButtonStyles } from '../../../components/button/button.hook'
+import {
+  useSizesStyles,
+  useTextStyles,
+  useVariantSizesStyles,
+} from '../../../components/button/button.hook'
+import { useBorderRadiusStyles } from '../../../core/theme-hooks'
 
 vi.mock('../../../core', () => ({
   useXUITheme: () => ({
     colors: {
-      primary: { main: '#1976d2', background: '#e3f2fd', foreground: '#ffffff' },
-      secondary: { main: '#9c27b0', background: '#f3e5f5', foreground: '#ffffff' },
-      tertiary: { main: '#00796b', background: '#e0f2f1', foreground: '#ffffff' },
-      danger: { main: '#d32f2f', background: '#ffebee', foreground: '#ffffff' },
-      warning: { main: '#f57c00', background: '#fff3e0', foreground: '#ffffff' },
-      success: { main: '#388e3c', background: '#e8f5e9', foreground: '#ffffff' },
-      default: { main: '#616161', background: '#f5f5f5', foreground: '#ffffff' },
+      primary: {
+        main: '#1976d2',
+        background: '#e3f2fd',
+        foreground: '#ffffff',
+        accent: '#1976d2',
+      },
+      secondary: {
+        main: '#9c27b0',
+        background: '#f3e5f5',
+        foreground: '#ffffff',
+        accent: '#9c27b0',
+      },
+      tertiary: {
+        main: '#00796b',
+        background: '#e0f2f1',
+        foreground: '#ffffff',
+        accent: '#00796b',
+      },
+      danger: {
+        main: '#d32f2f',
+        background: '#ffebee',
+        foreground: '#ffffff',
+        accent: '#d32f2f',
+      },
+      warning: {
+        main: '#f57c00',
+        background: '#fff3e0',
+        foreground: '#ffffff',
+        accent: '#f57c00',
+      },
+      success: {
+        main: '#388e3c',
+        background: '#e8f5e9',
+        foreground: '#ffffff',
+        accent: '#388e3c',
+      },
+      default: {
+        main: '#616161',
+        background: '#f5f5f5',
+        foreground: '#ffffff',
+        accent: '#616161',
+      },
     },
     spacing: {
       xs: 4,
@@ -47,74 +87,58 @@ vi.mock('../../../core', () => ({
   }),
 }))
 
-describe('useButtonStyles', () => {
+describe('button hook styles', () => {
   it('returns correct size styles for md size', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'md', 'md')
-    )
+    const { result } = renderHook(() => useSizesStyles('md'))
 
     expect(result.current.sizeStyles.minHeight).toBe(42)
     expect(result.current.sizeStyles.fontSize).toBe(16)
   })
 
   it('returns correct size styles for lg size', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'lg', 'md')
-    )
+    const { result } = renderHook(() => useSizesStyles('lg'))
 
     expect(result.current.sizeStyles.minHeight).toBe(50)
     expect(result.current.sizeStyles.fontSize).toBe(18)
   })
 
   it('returns correct variant styles for solid variant', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'md', 'md')
-    )
+    const { result } = renderHook(() => useVariantSizesStyles('primary', 'solid'))
 
-    expect(result.current.variantStyles.backgroundColor).toBe('#1976d2')
-    expect(result.current.variantStyles.borderWidth).toBe(0)
+    expect(result.current.backgroundColor).toBe('#1976d2')
+    expect(result.current.borderWidth).toBe(0)
   })
 
   it('returns correct variant styles for outlined variant', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'outlined', 'md', 'md')
-    )
+    const { result } = renderHook(() => useVariantSizesStyles('primary', 'outlined'))
 
-    expect(result.current.variantStyles.backgroundColor).toBe('transparent')
-    expect(result.current.variantStyles.borderWidth).toBe(1)
-    if ('borderColor' in result.current.variantStyles) {
-      expect(result.current.variantStyles.borderColor).toBe('#1976d2')
+    expect(result.current.backgroundColor).toBe('transparent')
+    expect(result.current.borderWidth).toBe(1)
+    if ('borderColor' in result.current) {
+      expect(result.current.borderColor).toBe('#1976d2')
     }
   })
 
   it('returns correct text color for solid variant', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'md', 'md')
-    )
+    const { result } = renderHook(() => useTextStyles('primary', 'solid'))
 
     expect(result.current.textColor).toBe('#ffffff')
   })
 
   it('returns correct text color for outlined variant', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'outlined', 'md', 'md')
-    )
+    const { result } = renderHook(() => useTextStyles('primary', 'outlined'))
 
     expect(result.current.textColor).toBe('#1976d2')
   })
 
   it('returns correct radius styles', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'md', 'lg')
-    )
+    const { result } = renderHook(() => useBorderRadiusStyles('lg'))
 
-    expect(result.current.radiusStyles.borderRadius).toBe(12)
+    expect(result.current.borderRadius).toBe(12)
   })
 
   it('returns correct spinner size for md size', () => {
-    const { result } = renderHook(() =>
-      useButtonStyles('primary', 'solid', 'md', 'md')
-    )
+    const { result } = renderHook(() => useSizesStyles('md'))
 
     expect(result.current.spinnerSize).toBe(18)
   })

--- a/packages/native/src/__tests__/components/button/button.hook.test.tsx
+++ b/packages/native/src/__tests__/components/button/button.hook.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import {
@@ -6,6 +7,8 @@ import {
   useVariantSizesStyles,
 } from '../../../components/button/button.hook'
 import { useBorderRadiusStyles } from '../../../core/theme-hooks'
+import { XUIThemeContext } from '../../../core/theme-context'
+import { defaultTheme } from '@xaui/core/theme'
 
 vi.mock('../../../core', () => ({
   useXUITheme: () => ({
@@ -87,6 +90,7 @@ vi.mock('../../../core', () => ({
   }),
 }))
 
+
 describe('button hook styles', () => {
   it('returns correct size styles for md size', () => {
     const { result } = renderHook(() => useSizesStyles('md'))
@@ -132,7 +136,13 @@ describe('button hook styles', () => {
   })
 
   it('returns correct radius styles', () => {
-    const { result } = renderHook(() => useBorderRadiusStyles('lg'))
+    const { result } = renderHook(() => useBorderRadiusStyles('lg'), {
+      wrapper: ({ children }) => (
+        <XUIThemeContext.Provider value={defaultTheme}>
+          {children}
+        </XUIThemeContext.Provider>
+      ),
+    })
 
     expect(result.current.borderRadius).toBe(12)
   })

--- a/packages/native/src/__tests__/components/button/button.test.tsx
+++ b/packages/native/src/__tests__/components/button/button.test.tsx
@@ -31,7 +31,7 @@ describe('Button Types', () => {
       'default',
     ]
 
-    colors.forEach((color) => {
+    colors.forEach(color => {
       const props: ButtonProps = {
         children: 'Test',
         themeColor: color,
@@ -50,7 +50,7 @@ describe('Button Types', () => {
       'faded',
     ]
 
-    variants.forEach((variant) => {
+    variants.forEach(variant => {
       const props: ButtonProps = {
         children: 'Test',
         variant,
@@ -62,7 +62,7 @@ describe('Button Types', () => {
   it('accepts all sizes', () => {
     const sizes: Array<ButtonProps['size']> = ['xs', 'sm', 'md', 'lg']
 
-    sizes.forEach((size) => {
+    sizes.forEach(size => {
       const props: ButtonProps = {
         children: 'Test',
         size,
@@ -74,7 +74,7 @@ describe('Button Types', () => {
   it('accepts all radius options', () => {
     const radii: Array<ButtonProps['radius']> = ['none', 'sm', 'md', 'lg', 'full']
 
-    radii.forEach((radius) => {
+    radii.forEach(radius => {
       const props: ButtonProps = {
         children: 'Test',
         radius,
@@ -86,7 +86,7 @@ describe('Button Types', () => {
   it('accepts spinner placement options', () => {
     const placements: Array<ButtonProps['spinnerPlacement']> = ['start', 'end']
 
-    placements.forEach((placement) => {
+    placements.forEach(placement => {
       const props: ButtonProps = {
         children: 'Test',
         spinnerPlacement: placement,

--- a/packages/native/src/components/button/button.animation.ts
+++ b/packages/native/src/components/button/button.animation.ts
@@ -1,0 +1,39 @@
+import { Animated } from 'react-native'
+
+export const runPressInAnimation = (
+  animatedScale: Animated.Value,
+  animatedOpacity: Animated.Value
+) => {
+  Animated.parallel([
+    Animated.spring(animatedScale, {
+      toValue: 0.965,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 0,
+    }),
+    Animated.timing(animatedOpacity, {
+      toValue: 0.9,
+      duration: 100,
+      useNativeDriver: true,
+    }),
+  ]).start()
+}
+
+export const runPressOutAnimation = (
+  animatedScale: Animated.Value,
+  animatedOpacity: Animated.Value
+) => {
+  Animated.parallel([
+    Animated.spring(animatedScale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 0,
+    }),
+    Animated.timing(animatedOpacity, {
+      toValue: 1,
+      duration: 100,
+      useNativeDriver: true,
+    }),
+  ]).start()
+}

--- a/packages/native/src/components/button/button.hook.ts
+++ b/packages/native/src/components/button/button.hook.ts
@@ -1,23 +1,42 @@
 import { useMemo } from 'react'
 import { useXUITheme } from '../../core'
-import type { ButtonVariant, ButtonSize, ButtonRadius } from './button.type'
-import type { ThemeColor } from '../../types'
+import type { ButtonVariant } from './button.type'
+import type { Size, ThemeColor } from '../../types'
 import { getSafeThemeColor } from '@xaui/core'
 
-export const useButtonStyles = (
-  themeColor: ThemeColor,
-  variant: ButtonVariant,
-  size: ButtonSize,
-  radius: ButtonRadius
-) => {
+type ButtonSizeStyles = {
+  paddingHorizontal: number
+  paddingVertical: number
+  minHeight: number
+  fontSize: number
+}
+
+export const useTextStyles = (themeColor: ThemeColor, variant: ButtonVariant) => {
   const theme = useXUITheme()
 
-  //access themeColor safely returns default color if themeColor is not found
   const safeThemeColor = getSafeThemeColor(themeColor)
   const colorScheme = theme.colors[safeThemeColor]
 
+  const textColor = useMemo(() => {
+    if (variant === 'solid' || variant === 'elevated') {
+      return colorScheme.foreground
+    }
+    return colorScheme.accent
+  }, [variant, colorScheme])
+
+  return {
+    textColor,
+  }
+}
+
+export function useSizesStyles(size: Size): {
+  sizeStyles: ButtonSizeStyles
+  spinnerSize: number
+} {
+  const theme = useXUITheme()
+
   const sizeStyles = useMemo(() => {
-    const sizes = {
+    const sizes: Record<Size, ButtonSizeStyles> = {
       xs: {
         paddingHorizontal: theme.spacing.sm,
         paddingVertical: theme.spacing.xs,
@@ -46,16 +65,23 @@ export const useButtonStyles = (
     return sizes[size]
   }, [size, theme])
 
-  const radiusStyles = useMemo(() => {
-    const radii = {
-      none: theme.borderRadius.none,
-      sm: theme.borderRadius.sm,
-      md: theme.borderRadius.md,
-      lg: theme.borderRadius.lg,
-      full: theme.borderRadius.full,
+  const spinnerSize = useMemo(() => {
+    const sizes = {
+      xs: 14,
+      sm: 16,
+      md: 18,
+      lg: 20,
     }
-    return { borderRadius: radii[radius] }
-  }, [radius, theme])
+    return sizes[size] as number
+  }, [size])
+
+  return { sizeStyles, spinnerSize }
+}
+
+export function useVariantSizesStyles(themeColor: ThemeColor, variant: ButtonVariant) {
+  const theme = useXUITheme()
+  const safeThemeColor = getSafeThemeColor(themeColor)
+  const colorScheme = theme.colors[safeThemeColor]
 
   const variantStyles = useMemo(() => {
     const styles = {
@@ -90,28 +116,5 @@ export const useButtonStyles = (
     return styles[variant]
   }, [variant, colorScheme, theme])
 
-  const textColor = useMemo(() => {
-    if (variant === 'solid' || variant === 'elevated') {
-      return colorScheme.foreground
-    }
-    return colorScheme.main
-  }, [variant, colorScheme])
-
-  const spinnerSize = useMemo(() => {
-    const sizes = {
-      xs: 14,
-      sm: 16,
-      md: 18,
-      lg: 20,
-    }
-    return sizes[size]
-  }, [size])
-
-  return {
-    sizeStyles,
-    radiusStyles,
-    variantStyles,
-    textColor,
-    spinnerSize,
-  }
+  return variantStyles
 }

--- a/packages/native/src/components/button/button.tsx
+++ b/packages/native/src/components/button/button.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import { Pressable, Text, View, Animated } from 'react-native'
 import { ActivityIndicator } from '../indicator'
 import { styles } from './button.style'
-import { useButtonStyles } from './button.hook'
+import { useSizesStyles, useTextStyles, useVariantSizesStyles } from './button.hook'
 import type { ButtonProps } from './button.type'
+import { useBorderRadiusStyles } from '../../core/theme-hooks'
+import { runPressInAnimation, runPressOutAnimation } from './button.animation'
 
 export const Button: React.FC<ButtonProps> = ({
   children,
@@ -27,24 +29,14 @@ export const Button: React.FC<ButtonProps> = ({
   const animatedScale = React.useRef(new Animated.Value(1)).current
   const animatedOpacity = React.useRef(new Animated.Value(1)).current
 
-  const { sizeStyles, radiusStyles, variantStyles, textColor, spinnerSize } =
-    useButtonStyles(themeColor, variant, size, radius)
+  const { sizeStyles, spinnerSize } = useSizesStyles(size)
+  const radiusStyles = useBorderRadiusStyles(radius)
+  const variantStyles = useVariantSizesStyles(themeColor, variant)
+  const { textColor } = useTextStyles(themeColor, variant)
 
   const handlePressIn = (event: Parameters<NonNullable<ButtonProps['onPressIn']>>[0]) => {
     if (!isDisabled && !isLoading) {
-      Animated.parallel([
-        Animated.spring(animatedScale, {
-          toValue: 0.98,
-          useNativeDriver: true,
-          speed: 50,
-          bounciness: 0,
-        }),
-        Animated.timing(animatedOpacity, {
-          toValue: 0.9,
-          duration: 100,
-          useNativeDriver: true,
-        }),
-      ]).start()
+      runPressInAnimation(animatedScale, animatedOpacity)
     }
     onPressIn?.(event)
   }
@@ -53,19 +45,7 @@ export const Button: React.FC<ButtonProps> = ({
     event: Parameters<NonNullable<ButtonProps['onPressOut']>>[0]
   ) => {
     if (!isDisabled && !isLoading) {
-      Animated.parallel([
-        Animated.spring(animatedScale, {
-          toValue: 1,
-          useNativeDriver: true,
-          speed: 50,
-          bounciness: 0,
-        }),
-        Animated.timing(animatedOpacity, {
-          toValue: 1,
-          duration: 100,
-          useNativeDriver: true,
-        }),
-      ]).start()
+      runPressOutAnimation(animatedScale, animatedOpacity)
     }
     onPressOut?.(event)
   }
@@ -104,7 +84,7 @@ export const Button: React.FC<ButtonProps> = ({
           ]}
         >
           <View style={styles.contentContainer}>
-            {startContent && !isLoading && (
+            {startContent && !isLoading && spinnerPlacement !== 'start' && (
               <View style={styles.startContent}>{startContent}</View>
             )}
 
@@ -127,7 +107,7 @@ export const Button: React.FC<ButtonProps> = ({
               <View style={styles.spinner}>{spinner}</View>
             )}
 
-            {endContent && !isLoading && (
+            {endContent && !isLoading && spinnerPlacement !== 'end' && (
               <View style={styles.endContent}>{endContent}</View>
             )}
           </View>

--- a/packages/native/src/components/button/button.type.ts
+++ b/packages/native/src/components/button/button.type.ts
@@ -1,9 +1,8 @@
 import { ReactNode } from 'react'
 import type { TextStyle, ViewStyle, GestureResponderEvent } from 'react-native'
-import type { ThemeColor } from '../../types'
+import type { Size, ThemeColor } from '../../types'
 
 export type ButtonVariant = 'solid' | 'outlined' | 'flat' | 'light' | 'elevated' | 'faded'
-export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
 export type ButtonRadius = 'none' | 'sm' | 'md' | 'lg' | 'full'
 export type SpinnerPlacement = 'start' | 'end'
 
@@ -26,7 +25,7 @@ export type ButtonProps = {
    * The size of the button.
    * @default 'md'
    */
-  size?: ButtonSize
+  size?: Size
   /**
    * The border radius of the button.
    * @default 'md'

--- a/packages/native/src/components/button/index.ts
+++ b/packages/native/src/components/button/index.ts
@@ -2,7 +2,6 @@ export { Button } from './button'
 export type {
   ButtonProps,
   ButtonVariant,
-  ButtonSize,
   ButtonRadius,
   SpinnerPlacement,
 } from './button.type'

--- a/packages/native/src/core/theme-hooks.ts
+++ b/packages/native/src/core/theme-hooks.ts
@@ -1,6 +1,7 @@
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { useColorScheme } from 'react-native'
 import { XUIThemeContext } from './theme-context'
+import { Radius } from '../types'
 import { XUITheme } from '@xaui/core/theme'
 
 type ColorMode = 'light' | 'dark'
@@ -24,4 +25,20 @@ export function useXUIColors(): XUITheme['colors'] {
   const theme = useXUITheme()
 
   return theme.colors
+}
+
+export function useBorderRadiusStyles(radius: Radius): { borderRadius: number } {
+  const theme = useXUITheme()
+  const borderRadius = useMemo(() => {
+    const radiusMap = {
+      none: theme.borderRadius.none,
+      sm: theme.borderRadius.sm,
+      md: theme.borderRadius.md,
+      lg: theme.borderRadius.lg,
+      full: theme.borderRadius.full,
+    }
+    return { borderRadius: radiusMap[radius] }
+  }, [radius, theme])
+
+  return borderRadius
 }

--- a/packages/native/src/types/index.ts
+++ b/packages/native/src/types/index.ts
@@ -1,1 +1,27 @@
-export * from './theme'
+export type ThemeColor =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'danger'
+  | 'warning'
+  | 'success'
+  | 'default'
+
+export type Size = 'xs' | 'sm' | 'md' | 'lg'
+
+export type Radius = 'none' | 'sm' | 'md' | 'lg' | 'full'
+
+export type SizeValues = {
+  xs: number
+  sm: number
+  md: number
+  lg: number
+}
+
+export type RadiusValues = {
+  none: number
+  sm: number
+  md: number
+  lg: number
+  full: number
+}


### PR DESCRIPTION
###   Summary

  - Add accent color tokens and refresh light/dark theme palettes
  - Refactor button hooks to split size/variant/text logic and reuse border-radius helper
  - Add native press animations and adjust start/end content when spinner is shown
  - Align native size/radius types in shared types