### PR TITLE
feat(native): add date/time, OTP, and number input components

### DIFF
--- a/.changeset/input-improvements.md
+++ b/.changeset/input-improvements.md
@@ -1,0 +1,14 @@
+---
+'@xaui/native': patch
+'demo': patch
+---
+
+Improve TextInput component with focus wrapper, animations, and better styling
+
+- Add clickable wrapper to focus input when clicking anywhere in the field
+- Add smooth border color animation on focus (200ms transition)
+- Borders are always visible - only color animates between unfocused and focused states
+- Fix border bottom color for underlined variant using borderBottomColor
+- Increase inside label font size for better readability (sm: 12, md: 13, lg: 15)
+- Add padding bottom (2px) to inside labels for better spacing
+- Reduce border color opacity from 0.2 to 0.1 for subtler appearance

--- a/.changeset/input-improvements.md
+++ b/.changeset/input-improvements.md
@@ -1,6 +1,5 @@
 ---
 '@xaui/native': patch
-'demo': patch
 ---
 
 Improve TextInput component with focus wrapper, animations, and better styling

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -39,10 +39,8 @@ export default function RootLayout() {
             options={{ title: 'DatePicker Examples' }}
           />
           <Stack.Screen name="fab" options={{ title: 'FAB Examples' }} />
-          <Stack.Screen
-            name="indicator"
-            options={{ title: 'Indicator Examples' }}
-          />
+          <Stack.Screen name="indicator" options={{ title: 'Indicator Examples' }} />
+          <Stack.Screen name="input" options={{ title: 'Input Examples' }} />
           <Stack.Screen name="menus" options={{ title: 'Menu Examples' }} />
           <Stack.Screen name="progress" options={{ title: 'Progress Examples' }} />
           <Stack.Screen

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -41,6 +41,18 @@ export default function RootLayout() {
           <Stack.Screen name="fab" options={{ title: 'FAB Examples' }} />
           <Stack.Screen name="indicator" options={{ title: 'Indicator Examples' }} />
           <Stack.Screen name="input" options={{ title: 'Input Examples' }} />
+          <Stack.Screen
+            name="date-input"
+            options={{ title: 'Date/Time Input Examples' }}
+          />
+          <Stack.Screen
+            name="otp-input"
+            options={{ title: 'OTP Input Examples' }}
+          />
+          <Stack.Screen
+            name="number-input"
+            options={{ title: 'Number Input Examples' }}
+          />
           <Stack.Screen name="menus" options={{ title: 'Menu Examples' }} />
           <Stack.Screen name="progress" options={{ title: 'Progress Examples' }} />
           <Stack.Screen

--- a/apps/demo/app/date-input.tsx
+++ b/apps/demo/app/date-input.tsx
@@ -1,0 +1,226 @@
+import { useXUIColors, useXUITheme } from '@xaui/native/core'
+import { StyleSheet, View, ScrollView, Text } from 'react-native'
+import { useState } from 'react'
+import { DateInput, TimeInput, DateTimeInput } from '@xaui/native/input'
+
+export default function DateInputScreen() {
+  const colors = useXUIColors()
+  const theme = useXUITheme()
+
+  const [dashDate, setDashDate] = useState('')
+  const [slashDate, setSlashDate] = useState('')
+  const [dotDate, setDotDate] = useState('')
+  const [ymdDate, setYmdDate] = useState('')
+  const [dmyDate, setDmyDate] = useState('')
+  const [mdyDate, setMdyDate] = useState('')
+  const [frDate, setFrDate] = useState('')
+  const [jaDate, setJaDate] = useState('')
+  const [time24, setTime24] = useState('')
+  const [time12, setTime12] = useState('')
+  const [timeSeconds, setTimeSeconds] = useState('')
+  const [dateTime, setDateTime] = useState('')
+  const [validDate, setValidDate] = useState('')
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { gap: theme.spacing.lg }]}
+    >
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Separators
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <DateInput
+            label="Dash separator (-)"
+            separator="-"
+            value={dashDate}
+            onValueChange={setDashDate}
+            variant="bordered"
+            themeColor="primary"
+          />
+          <DateInput
+            label="Slash separator (/)"
+            separator="/"
+            value={slashDate}
+            onValueChange={setSlashDate}
+            variant="bordered"
+            themeColor="secondary"
+          />
+          <DateInput
+            label="Dot separator (.)"
+            separator="."
+            value={dotDate}
+            onValueChange={setDotDate}
+            variant="bordered"
+            themeColor="tertiary"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Date Orders
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <DateInput
+            label="YMD (Year-Month-Day)"
+            dateOrder="YMD"
+            separator="-"
+            value={ymdDate}
+            onValueChange={setYmdDate}
+            variant="bordered"
+            themeColor="primary"
+          />
+          <DateInput
+            label="DMY (Day-Month-Year)"
+            dateOrder="DMY"
+            separator="/"
+            value={dmyDate}
+            onValueChange={setDmyDate}
+            variant="bordered"
+            themeColor="secondary"
+          />
+          <DateInput
+            label="MDY (Month-Day-Year)"
+            dateOrder="MDY"
+            separator="/"
+            value={mdyDate}
+            onValueChange={setMdyDate}
+            variant="bordered"
+            themeColor="success"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Locale Auto-Detection
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <DateInput
+            label="French (fr)"
+            locale="fr"
+            separator="/"
+            value={frDate}
+            onValueChange={setFrDate}
+            description="Auto-detects DMY order"
+            variant="bordered"
+            themeColor="primary"
+          />
+          <DateInput
+            label="Japanese (ja)"
+            locale="ja"
+            separator="-"
+            value={jaDate}
+            onValueChange={setJaDate}
+            description="Auto-detects YMD order"
+            variant="bordered"
+            themeColor="secondary"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Time Input
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <TimeInput
+            label="24-hour (HH:mm)"
+            granularity="minute"
+            hourCycle={24}
+            value={time24}
+            onValueChange={setTime24}
+            variant="bordered"
+            themeColor="primary"
+          />
+          <TimeInput
+            label="12-hour (hh:mm AM)"
+            granularity="minute"
+            hourCycle={12}
+            value={time12}
+            onValueChange={setTime12}
+            variant="bordered"
+            themeColor="secondary"
+          />
+          <TimeInput
+            label="With seconds (HH:mm:ss)"
+            granularity="second"
+            hourCycle={24}
+            value={timeSeconds}
+            onValueChange={setTimeSeconds}
+            variant="bordered"
+            themeColor="tertiary"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          DateTime Input
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <DateTimeInput
+            label="Date + Time"
+            dateOrder="YMD"
+            separator="-"
+            granularity="minute"
+            hourCycle={24}
+            value={dateTime}
+            onValueChange={setDateTime}
+            description="Combined date and time input"
+            variant="bordered"
+            themeColor="success"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Validation
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <DateInput
+            label="Required date"
+            separator="-"
+            dateOrder="YMD"
+            value={validDate}
+            onValueChange={setValidDate}
+            isInvalid={validDate.length > 0 && validDate.length < 10}
+            errorMessage="Please enter a complete date"
+            variant="bordered"
+            themeColor="danger"
+          />
+          <DateInput
+            label="Disabled"
+            separator="-"
+            dateOrder="YMD"
+            defaultValue="2024-01-15"
+            isDisabled
+            variant="flat"
+          />
+        </View>
+      </View>
+
+      <View style={{ height: 40 }} />
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    width: '100%',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+})

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -171,6 +171,36 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/date-input')}
+            variant="outlined"
+            themeColor="secondary"
+          >
+            Date/Time Input
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
+            onPress={() => router.push('/otp-input')}
+            variant="outlined"
+            themeColor="primary"
+          >
+            OTP Input
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
+            onPress={() => router.push('/number-input')}
+            variant="outlined"
+            themeColor="secondary"
+          >
+            Number Input
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/menus')}
             variant="outlined"
             themeColor="secondary"

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -161,6 +161,16 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/input')}
+            variant="outlined"
+            themeColor="primary"
+          >
+            Input
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/menus')}
             variant="outlined"
             themeColor="secondary"

--- a/apps/demo/app/input.tsx
+++ b/apps/demo/app/input.tsx
@@ -23,6 +23,7 @@ export default function InputScreen() {
   const [search, setSearch] = useState('HeroUI patterns')
   const [notes, setNotes] = useState('')
   const [customValue, setCustomValue] = useState('')
+  const [password, setPassword] = useState('')
 
   return (
     <ScrollView
@@ -99,6 +100,23 @@ export default function InputScreen() {
             onValueChange={setSearch}
             isClearable
             description="Try clearing this field with the clear button."
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Secured
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <TextInput
+            label="Password"
+            placeholder="Enter your password"
+            value={password}
+            onValueChange={setPassword}
+            isSecured
+            description="isSecured sets secureTextEntry on the native input."
+            themeColor="tertiary"
           />
         </View>
       </View>

--- a/apps/demo/app/input.tsx
+++ b/apps/demo/app/input.tsx
@@ -1,0 +1,214 @@
+import { useXUIColors, useXUITheme } from '@xaui/native/core'
+import { StyleSheet, View, ScrollView, Text } from 'react-native'
+import { useState } from 'react'
+import { TextInput } from '@xaui/native/input'
+
+const variants = ['flat', 'faded', 'bordered', 'underlined'] as const
+const sizes = ['sm', 'md', 'lg'] as const
+const themeColors = [
+  'default',
+  'primary',
+  'secondary',
+  'tertiary',
+  'success',
+  'warning',
+  'danger',
+] as const
+
+export default function InputScreen() {
+  const colors = useXUIColors()
+  const theme = useXUITheme()
+
+  const [email, setEmail] = useState('')
+  const [search, setSearch] = useState('HeroUI patterns')
+  const [notes, setNotes] = useState('')
+  const [customValue, setCustomValue] = useState('')
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { gap: theme.spacing.lg }]}
+    >
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Variant
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {variants.map(variant => (
+            <TextInput
+              key={variant}
+              label={variant}
+              placeholder={`${variant} input`}
+              variant={variant}
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Size
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {sizes.map(size => (
+            <TextInput
+              key={size}
+              label={`Size ${size.toUpperCase()}`}
+              placeholder={`Input size ${size}`}
+              size={size}
+              variant="bordered"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Color
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {themeColors.map(themeColor => (
+            <TextInput
+              key={themeColor}
+              label={themeColor}
+              labelPlacement="inside"
+              placeholder={`${themeColor} themed input`}
+              themeColor={themeColor}
+              variant="faded"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Controlled
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <TextInput
+            label="Email"
+            placeholder="you@example.com"
+            value={email}
+            onValueChange={setEmail}
+            description="We'll only use this for account notifications."
+            themeColor="secondary"
+          />
+          <TextInput
+            label="Search"
+            value={search}
+            onValueChange={setSearch}
+            isClearable
+            description="Try clearing this field with the clear button."
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Validation
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <TextInput
+            label="Required username"
+            placeholder="Min 3 characters"
+            isInvalid={notes.length > 0 && notes.length < 3}
+            errorMessage="Username should be at least 3 characters"
+            value={notes}
+            onValueChange={setNotes}
+            variant="bordered"
+            themeColor="danger"
+          />
+          <TextInput
+            label="Disabled"
+            defaultValue="Cannot edit this field"
+            isDisabled
+            variant="flat"
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Custom Implementation
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <TextInput
+            label="Branded Search"
+            placeholder="Type to search"
+            value={customValue}
+            onValueChange={setCustomValue}
+            variant="faded"
+            radius="full"
+            isClearable
+            startContent={
+              <Text
+                style={{
+                  color: colors.foreground,
+                  fontWeight: '700',
+                  fontSize: 12,
+                }}
+              >
+                SRCH
+              </Text>
+            }
+            endContent={
+              <Text
+                style={{
+                  color: colors.foreground,
+                  opacity: 0.6,
+                  fontWeight: '600',
+                  fontSize: 12,
+                }}
+              >
+                CMD+K
+              </Text>
+            }
+            customAppearance={{
+              container: {
+                backgroundColor: 'transparent',
+              },
+              inputWrapper: {
+                borderWidth: 1,
+                borderColor: colors.foreground,
+                backgroundColor: colors.background,
+              },
+              label: {
+                fontWeight: '700',
+                letterSpacing: 0.4,
+              },
+              helperText: {
+                fontStyle: 'italic',
+              },
+            }}
+            description="Custom slots + customAppearance styles."
+          />
+          <TextInput
+            label="Inside Label"
+            labelPlacement="inside"
+            placeholder="Label is rendered inside"
+            size="sm"
+          />
+        </View>
+      </View>
+
+      <View style={{ height: 40 }} />
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    width: '100%',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+})

--- a/apps/demo/app/number-input.tsx
+++ b/apps/demo/app/number-input.tsx
@@ -1,0 +1,206 @@
+import { useXUIColors, useXUITheme } from '@xaui/native/core'
+import { StyleSheet, View, ScrollView, Text } from 'react-native'
+import { useState } from 'react'
+import { NumberInput } from '@xaui/native/input'
+
+const variants = ['flat', 'faded', 'bordered', 'underlined'] as const
+const themeColors = [
+  'default',
+  'primary',
+  'secondary',
+  'tertiary',
+  'success',
+  'warning',
+  'danger',
+] as const
+
+export default function NumberInputScreen() {
+  const colors = useXUIColors()
+  const theme = useXUITheme()
+
+  const [basic, setBasic] = useState<number | undefined>(0)
+  const [minMax, setMinMax] = useState<number | undefined>(50)
+  const [stepped, setStepped] = useState<number | undefined>(0)
+  const [currency, setCurrency] = useState<number | undefined>(99.99)
+  const [percent, setPercent] = useState<number | undefined>(0.25)
+  const [hidden, setHidden] = useState<number | undefined>(10)
+  const [validNum, setValidNum] = useState<number | undefined>(undefined)
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { gap: theme.spacing.lg }]}
+    >
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Basic
+        </Text>
+        <NumberInput
+          label="Quantity"
+          value={basic}
+          onValueChange={setBasic}
+          description="Default step of 1"
+          variant="bordered"
+          themeColor="primary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Min / Max
+        </Text>
+        <NumberInput
+          label="Value (0 - 100)"
+          value={minMax}
+          onValueChange={setMinMax}
+          minValue={0}
+          maxValue={100}
+          description="Clamped between 0 and 100"
+          variant="bordered"
+          themeColor="secondary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Custom Step
+        </Text>
+        <NumberInput
+          label="Step by 5"
+          value={stepped}
+          onValueChange={setStepped}
+          step={5}
+          description="Increments/decrements by 5"
+          variant="bordered"
+          themeColor="tertiary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Currency Formatting
+        </Text>
+        <NumberInput
+          label="Price"
+          value={currency}
+          onValueChange={setCurrency}
+          formatOptions={{ style: 'currency', currency: 'USD' }}
+          step={0.01}
+          minValue={0}
+          description="Formatted as USD"
+          variant="bordered"
+          themeColor="success"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Percentage
+        </Text>
+        <NumberInput
+          label="Discount"
+          value={percent}
+          onValueChange={setPercent}
+          formatOptions={{ style: 'percent' }}
+          step={0.05}
+          minValue={0}
+          maxValue={1}
+          description="Formatted as percentage"
+          variant="bordered"
+          themeColor="warning"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Hidden Stepper
+        </Text>
+        <NumberInput
+          label="Amount"
+          value={hidden}
+          onValueChange={setHidden}
+          hideStepper
+          description="Stepper buttons hidden"
+          variant="bordered"
+          themeColor="primary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Variant
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {variants.map(variant => (
+            <NumberInput
+              key={variant}
+              label={variant}
+              defaultValue={0}
+              variant={variant}
+              themeColor="primary"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Color
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {themeColors.map(themeColor => (
+            <NumberInput
+              key={themeColor}
+              label={themeColor}
+              defaultValue={0}
+              themeColor={themeColor}
+              variant="faded"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Validation
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <NumberInput
+            label="Required"
+            value={validNum}
+            onValueChange={setValidNum}
+            isInvalid={validNum === undefined}
+            errorMessage="Value is required"
+            variant="bordered"
+            themeColor="danger"
+          />
+          <NumberInput
+            label="Disabled"
+            defaultValue={42}
+            isDisabled
+            variant="flat"
+          />
+        </View>
+      </View>
+
+      <View style={{ height: 40 }} />
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    width: '100%',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+})

--- a/apps/demo/app/otp-input.tsx
+++ b/apps/demo/app/otp-input.tsx
@@ -1,0 +1,183 @@
+import { useXUIColors, useXUITheme } from '@xaui/native/core'
+import { StyleSheet, View, ScrollView, Text } from 'react-native'
+import { useState } from 'react'
+import { OTPInput } from '@xaui/native/input'
+
+const variants = ['flat', 'faded', 'bordered', 'underlined'] as const
+const sizes = ['sm', 'md', 'lg'] as const
+const themeColors = [
+  'default',
+  'primary',
+  'secondary',
+  'tertiary',
+  'success',
+  'warning',
+  'danger',
+] as const
+
+export default function OTPInputScreen() {
+  const colors = useXUIColors()
+  const theme = useXUITheme()
+
+  const [basic, setBasic] = useState('')
+  const [six, setSix] = useState('')
+  const [secured, setSecured] = useState('')
+  const [alpha, setAlpha] = useState('')
+  const [validOtp, setValidOtp] = useState('')
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { gap: theme.spacing.lg }]}
+    >
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Default (4-digit)
+        </Text>
+        <OTPInput
+          label="Verification Code"
+          value={basic}
+          onValueChange={setBasic}
+          description="Enter the 4-digit code"
+          variant="bordered"
+          themeColor="primary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          6-digit
+        </Text>
+        <OTPInput
+          length={6}
+          label="6-Digit Code"
+          value={six}
+          onValueChange={setSix}
+          description="Enter the 6-digit code"
+          variant="bordered"
+          themeColor="secondary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Variant
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {variants.map(variant => (
+            <OTPInput
+              key={variant}
+              label={variant}
+              variant={variant}
+              themeColor="primary"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Size
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {sizes.map(size => (
+            <OTPInput
+              key={size}
+              label={`Size ${size.toUpperCase()}`}
+              size={size}
+              variant="bordered"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Per Color
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          {themeColors.map(themeColor => (
+            <OTPInput
+              key={themeColor}
+              label={themeColor}
+              themeColor={themeColor}
+              variant="faded"
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Secured Mode
+        </Text>
+        <OTPInput
+          label="PIN"
+          isSecured
+          value={secured}
+          onValueChange={setSecured}
+          description="Characters are hidden"
+          variant="bordered"
+          themeColor="tertiary"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Alphanumeric
+        </Text>
+        <OTPInput
+          label="Alphanumeric Code"
+          allowedKeys={/^[a-zA-Z0-9]$/}
+          value={alpha}
+          onValueChange={setAlpha}
+          description="Accepts letters and numbers"
+          variant="bordered"
+          themeColor="success"
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Validation
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <OTPInput
+            label="Required Code"
+            value={validOtp}
+            onValueChange={setValidOtp}
+            isInvalid={validOtp.length > 0 && validOtp.length < 4}
+            errorMessage="Please enter all 4 digits"
+            variant="bordered"
+            themeColor="danger"
+          />
+          <OTPInput
+            label="Disabled"
+            defaultValue="12"
+            isDisabled
+            variant="flat"
+          />
+        </View>
+      </View>
+
+      <View style={{ height: 40 }} />
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    width: '100%',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+})

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -146,6 +146,11 @@
       "types": "./dist/card/index.d.ts",
       "import": "./dist/card/index.js",
       "require": "./dist/card/index.js"
+    },
+    "./input": {
+      "types": "./dist/input/index.d.ts",
+      "import": "./dist/input/index.js",
+      "require": "./dist/input/index.js"
     }
   },
   "files": [

--- a/packages/native/src/__tests__/components/input/date-time-input.test.tsx
+++ b/packages/native/src/__tests__/components/input/date-time-input.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  DateInputProps,
+  TimeInputProps,
+  DateTimeInputProps,
+  DateSeparator,
+  DateOrder,
+  TimeInputGranularity,
+} from '../../../components/input'
+import {
+  getDateOrder,
+  formatDateInput,
+  formatTimeInput,
+  getDatePlaceholder,
+  getTimePlaceholder,
+  getDateMaxLength,
+  getTimeMaxLength,
+} from '../../../components/input/date-time-input.hook'
+
+describe('Date/Time Input Types', () => {
+  it('exports DateInputProps type with separator and dateOrder', () => {
+    const props: DateInputProps = {
+      separator: '/',
+      dateOrder: 'DMY',
+      locale: 'fr',
+    }
+
+    expect(props.separator).toBe('/')
+    expect(props.dateOrder).toBe('DMY')
+    expect(props.locale).toBe('fr')
+  })
+
+  it('exports TimeInputProps type with granularity and hourCycle', () => {
+    const props: TimeInputProps = {
+      granularity: 'second',
+      hourCycle: 12,
+    }
+
+    expect(props.granularity).toBe('second')
+    expect(props.hourCycle).toBe(12)
+  })
+
+  it('exports DateTimeInputProps type with all date and time props', () => {
+    const props: DateTimeInputProps = {
+      separator: '.',
+      dateOrder: 'YMD',
+      locale: 'ja',
+      granularity: 'minute',
+      hourCycle: 24,
+    }
+
+    expect(props.separator).toBe('.')
+    expect(props.granularity).toBe('minute')
+  })
+
+  it('accepts all DateSeparator values', () => {
+    const separators: DateSeparator[] = ['-', '/', '.']
+    expect(separators).toHaveLength(3)
+  })
+
+  it('accepts all DateOrder values', () => {
+    const orders: DateOrder[] = ['YMD', 'DMY', 'MDY']
+    expect(orders).toHaveLength(3)
+  })
+
+  it('accepts all TimeInputGranularity values', () => {
+    const granularities: TimeInputGranularity[] = ['minute', 'second']
+    expect(granularities).toHaveLength(2)
+  })
+})
+
+describe('getDateOrder', () => {
+  it('returns MDY for en-US', () => {
+    expect(getDateOrder('en-US')).toBe('MDY')
+  })
+
+  it('returns DMY for fr', () => {
+    expect(getDateOrder('fr')).toBe('DMY')
+  })
+
+  it('returns YMD for ja', () => {
+    expect(getDateOrder('ja')).toBe('YMD')
+  })
+
+  it('returns DMY for de', () => {
+    expect(getDateOrder('de')).toBe('DMY')
+  })
+
+  it('returns YMD for ko', () => {
+    expect(getDateOrder('ko')).toBe('YMD')
+  })
+
+  it('returns YMD for zh', () => {
+    expect(getDateOrder('zh')).toBe('YMD')
+  })
+})
+
+describe('formatDateInput', () => {
+  it('formats YMD with dash separator', () => {
+    expect(formatDateInput('20240115', 'YMD', '-')).toBe('2024-01-15')
+  })
+
+  it('formats DMY with slash separator', () => {
+    expect(formatDateInput('15012024', 'DMY', '/')).toBe('15/01/2024')
+  })
+
+  it('formats MDY with dot separator', () => {
+    expect(formatDateInput('01152024', 'MDY', '.')).toBe('01.15.2024')
+  })
+
+  it('handles partial input', () => {
+    expect(formatDateInput('2024', 'YMD', '-')).toBe('2024')
+    expect(formatDateInput('202401', 'YMD', '-')).toBe('2024-01')
+  })
+
+  it('strips non-digit characters', () => {
+    expect(formatDateInput('2024/01/15', 'YMD', '-')).toBe('2024-01-15')
+  })
+
+  it('limits to 8 digits', () => {
+    expect(formatDateInput('202401151234', 'YMD', '-')).toBe('2024-01-15')
+  })
+})
+
+describe('formatTimeInput', () => {
+  it('formats 24h minute granularity', () => {
+    expect(formatTimeInput('1430', 'minute', 24)).toBe('14:30')
+  })
+
+  it('formats 24h second granularity', () => {
+    expect(formatTimeInput('143025', 'second', 24)).toBe('14:30:25')
+  })
+
+  it('handles partial time input', () => {
+    expect(formatTimeInput('14', 'minute', 24)).toBe('14')
+    expect(formatTimeInput('143', 'minute', 24)).toBe('14:3')
+  })
+
+  it('strips non-digit characters for time', () => {
+    expect(formatTimeInput('14:30', 'minute', 24)).toBe('14:30')
+  })
+})
+
+describe('getDatePlaceholder', () => {
+  it('returns YYYY-MM-DD for YMD with dash', () => {
+    expect(getDatePlaceholder('YMD', '-')).toBe('YYYY-MM-DD')
+  })
+
+  it('returns DD/MM/YYYY for DMY with slash', () => {
+    expect(getDatePlaceholder('DMY', '/')).toBe('DD/MM/YYYY')
+  })
+
+  it('returns MM.DD.YYYY for MDY with dot', () => {
+    expect(getDatePlaceholder('MDY', '.')).toBe('MM.DD.YYYY')
+  })
+})
+
+describe('getTimePlaceholder', () => {
+  it('returns HH:mm for 24h minute', () => {
+    expect(getTimePlaceholder('minute', 24)).toBe('HH:mm')
+  })
+
+  it('returns HH:mm:ss for 24h second', () => {
+    expect(getTimePlaceholder('second', 24)).toBe('HH:mm:ss')
+  })
+
+  it('returns hh:mm AM for 12h minute', () => {
+    expect(getTimePlaceholder('minute', 12)).toBe('hh:mm AM')
+  })
+
+  it('returns hh:mm:ss AM for 12h second', () => {
+    expect(getTimePlaceholder('second', 12)).toBe('hh:mm:ss AM')
+  })
+})
+
+describe('getDateMaxLength', () => {
+  it('returns 10 for single-char separator', () => {
+    expect(getDateMaxLength('-')).toBe(10)
+    expect(getDateMaxLength('/')).toBe(10)
+    expect(getDateMaxLength('.')).toBe(10)
+  })
+})
+
+describe('getTimeMaxLength', () => {
+  it('returns 5 for 24h minute', () => {
+    expect(getTimeMaxLength('minute', 24)).toBe(5)
+  })
+
+  it('returns 8 for 24h second', () => {
+    expect(getTimeMaxLength('second', 24)).toBe(8)
+  })
+
+  it('returns 8 for 12h minute', () => {
+    expect(getTimeMaxLength('minute', 12)).toBe(8)
+  })
+
+  it('returns 11 for 12h second', () => {
+    expect(getTimeMaxLength('second', 12)).toBe(11)
+  })
+})

--- a/packages/native/src/__tests__/components/input/number-input.test.tsx
+++ b/packages/native/src/__tests__/components/input/number-input.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  NumberInputProps,
+  NumberInputCustomAppearance,
+} from '../../../components/input'
+
+describe('NumberInput Types', () => {
+  it('exports NumberInputProps type with default values', () => {
+    const props: NumberInputProps = {}
+
+    expect(props).toBeDefined()
+    expect(props.value).toBeUndefined()
+  })
+
+  it('accepts numeric value', () => {
+    const props: NumberInputProps = { value: 42 }
+    expect(props.value).toBe(42)
+  })
+
+  it('accepts numeric defaultValue', () => {
+    const props: NumberInputProps = { defaultValue: 10 }
+    expect(props.defaultValue).toBe(10)
+  })
+
+  it('accepts onValueChange callback', () => {
+    const handler = (_value: number | undefined) => {}
+    const props: NumberInputProps = { onValueChange: handler }
+    expect(props.onValueChange).toBe(handler)
+  })
+
+  it('accepts minValue and maxValue', () => {
+    const props: NumberInputProps = { minValue: 0, maxValue: 100 }
+    expect(props.minValue).toBe(0)
+    expect(props.maxValue).toBe(100)
+  })
+
+  it('accepts step', () => {
+    const props: NumberInputProps = { step: 5 }
+    expect(props.step).toBe(5)
+  })
+
+  it('accepts decimal step', () => {
+    const props: NumberInputProps = { step: 0.1 }
+    expect(props.step).toBe(0.1)
+  })
+
+  it('accepts hideStepper', () => {
+    const props: NumberInputProps = { hideStepper: true }
+    expect(props.hideStepper).toBe(true)
+  })
+
+  it('accepts formatOptions', () => {
+    const props: NumberInputProps = {
+      formatOptions: {
+        style: 'currency',
+        currency: 'USD',
+      },
+    }
+
+    expect(props.formatOptions).toBeDefined()
+    expect(props.formatOptions!.style).toBe('currency')
+  })
+
+  it('accepts locale', () => {
+    const props: NumberInputProps = { locale: 'de-DE' }
+    expect(props.locale).toBe('de-DE')
+  })
+
+  it('accepts all variant values', () => {
+    const variants: NumberInputProps['variant'][] = [
+      'flat',
+      'faded',
+      'bordered',
+      'underlined',
+    ]
+    variants.forEach(variant => {
+      const props: NumberInputProps = { variant }
+      expect(props.variant).toBe(variant)
+    })
+  })
+
+  it('accepts all size values', () => {
+    const sizes: NumberInputProps['size'][] = ['sm', 'md', 'lg']
+    sizes.forEach(size => {
+      const props: NumberInputProps = { size }
+      expect(props.size).toBe(size)
+    })
+  })
+
+  it('accepts all theme color values', () => {
+    const themeColors: NumberInputProps['themeColor'][] = [
+      'default',
+      'primary',
+      'secondary',
+      'tertiary',
+      'danger',
+      'warning',
+      'success',
+    ]
+    themeColors.forEach(themeColor => {
+      const props: NumberInputProps = { themeColor }
+      expect(props.themeColor).toBe(themeColor)
+    })
+  })
+
+  it('accepts label and description', () => {
+    const props: NumberInputProps = {
+      label: 'Quantity',
+      description: 'Enter a number between 1 and 100',
+    }
+
+    expect(props.label).toBe('Quantity')
+    expect(props.description).toBe('Enter a number between 1 and 100')
+  })
+
+  it('accepts isInvalid with errorMessage', () => {
+    const props: NumberInputProps = {
+      isInvalid: true,
+      errorMessage: 'Value out of range',
+    }
+
+    expect(props.isInvalid).toBe(true)
+    expect(props.errorMessage).toBe('Value out of range')
+  })
+
+  it('accepts isDisabled and isReadOnly', () => {
+    const props: NumberInputProps = {
+      isDisabled: true,
+      isReadOnly: false,
+    }
+
+    expect(props.isDisabled).toBe(true)
+    expect(props.isReadOnly).toBe(false)
+  })
+
+  it('accepts isClearable', () => {
+    const props: NumberInputProps = { isClearable: true }
+    expect(props.isClearable).toBe(true)
+  })
+
+  it('exports NumberInputCustomAppearance type', () => {
+    const appearance: NumberInputCustomAppearance = {
+      container: { padding: 10 },
+      inputWrapper: { borderWidth: 2 },
+      stepperContainer: { gap: 8 },
+      stepperButton: { borderRadius: 4 },
+    }
+
+    expect(appearance).toBeDefined()
+    expect(appearance.stepperContainer).toBeDefined()
+  })
+
+  it('accepts percentage formatOptions', () => {
+    const props: NumberInputProps = {
+      formatOptions: {
+        style: 'percent',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      },
+    }
+
+    expect(props.formatOptions!.style).toBe('percent')
+  })
+})

--- a/packages/native/src/__tests__/components/input/otp-input.test.tsx
+++ b/packages/native/src/__tests__/components/input/otp-input.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  OTPInputProps,
+  OTPInputCustomAppearance,
+} from '../../../components/input'
+
+describe('OTPInput Types', () => {
+  it('exports OTPInputProps type with default values', () => {
+    const props: OTPInputProps = {}
+
+    expect(props).toBeDefined()
+    expect(props.length).toBeUndefined()
+    expect(props.value).toBeUndefined()
+  })
+
+  it('accepts length prop', () => {
+    const props: OTPInputProps = { length: 6 }
+    expect(props.length).toBe(6)
+  })
+
+  it('accepts controlled value', () => {
+    const props: OTPInputProps = {
+      value: '1234',
+      onValueChange: () => {},
+    }
+
+    expect(props.value).toBe('1234')
+  })
+
+  it('accepts uncontrolled defaultValue', () => {
+    const props: OTPInputProps = { defaultValue: '12' }
+    expect(props.defaultValue).toBe('12')
+  })
+
+  it('accepts onComplete callback', () => {
+    const handler = (_value: string) => {}
+    const props: OTPInputProps = { onComplete: handler }
+    expect(props.onComplete).toBe(handler)
+  })
+
+  it('accepts all variant values', () => {
+    const variants: OTPInputProps['variant'][] = [
+      'flat',
+      'faded',
+      'bordered',
+      'underlined',
+    ]
+    variants.forEach(variant => {
+      const props: OTPInputProps = { variant }
+      expect(props.variant).toBe(variant)
+    })
+  })
+
+  it('accepts all size values', () => {
+    const sizes: OTPInputProps['size'][] = ['sm', 'md', 'lg']
+    sizes.forEach(size => {
+      const props: OTPInputProps = { size }
+      expect(props.size).toBe(size)
+    })
+  })
+
+  it('accepts all theme color values', () => {
+    const themeColors: OTPInputProps['themeColor'][] = [
+      'default',
+      'primary',
+      'secondary',
+      'tertiary',
+      'danger',
+      'warning',
+      'success',
+    ]
+    themeColors.forEach(themeColor => {
+      const props: OTPInputProps = { themeColor }
+      expect(props.themeColor).toBe(themeColor)
+    })
+  })
+
+  it('accepts all radius values', () => {
+    const radii: OTPInputProps['radius'][] = ['none', 'sm', 'md', 'lg', 'full']
+    radii.forEach(radius => {
+      const props: OTPInputProps = { radius }
+      expect(props.radius).toBe(radius)
+    })
+  })
+
+  it('accepts isSecured prop', () => {
+    const props: OTPInputProps = { isSecured: true }
+    expect(props.isSecured).toBe(true)
+  })
+
+  it('accepts isDisabled prop', () => {
+    const props: OTPInputProps = { isDisabled: true }
+    expect(props.isDisabled).toBe(true)
+  })
+
+  it('accepts isInvalid with errorMessage', () => {
+    const props: OTPInputProps = {
+      isInvalid: true,
+      errorMessage: 'Invalid code',
+    }
+
+    expect(props.isInvalid).toBe(true)
+    expect(props.errorMessage).toBe('Invalid code')
+  })
+
+  it('accepts label and description', () => {
+    const props: OTPInputProps = {
+      label: 'Verification Code',
+      description: 'Enter the 4-digit code',
+    }
+
+    expect(props.label).toBe('Verification Code')
+    expect(props.description).toBe('Enter the 4-digit code')
+  })
+
+  it('accepts allowedKeys regex', () => {
+    const props: OTPInputProps = { allowedKeys: /^[a-zA-Z0-9]$/ }
+    expect(props.allowedKeys).toBeDefined()
+    expect(props.allowedKeys!.test('a')).toBe(true)
+    expect(props.allowedKeys!.test('1')).toBe(true)
+    expect(props.allowedKeys!.test('!')).toBe(false)
+  })
+
+  it('exports OTPInputCustomAppearance type', () => {
+    const appearance: OTPInputCustomAppearance = {
+      container: { padding: 10 },
+      segmentContainer: { gap: 12 },
+      segment: { borderWidth: 2 },
+      segmentText: { fontWeight: 'bold' },
+      label: { fontSize: 16 },
+      helperText: { fontStyle: 'italic' },
+    }
+
+    expect(appearance).toBeDefined()
+    expect(appearance.segment).toBeDefined()
+  })
+
+  it('accepts fullWidth prop', () => {
+    const props: OTPInputProps = { fullWidth: true }
+    expect(props.fullWidth).toBe(true)
+  })
+})

--- a/packages/native/src/components/input/date-time-input.hook.ts
+++ b/packages/native/src/components/input/date-time-input.hook.ts
@@ -1,0 +1,175 @@
+import type {
+  DateOrder,
+  DateSeparator,
+  TimeInputGranularity,
+} from './date-time-input.type'
+
+const YMD_LOCALES = ['ja', 'zh', 'ko', 'hu', 'lt', 'mn']
+const MDY_LOCALES = ['en-US', 'en-PH', 'en-BZ']
+
+export const getDateOrder = (locale: string): DateOrder => {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    const parts = formatter.formatToParts(new Date(2000, 0, 2))
+    const order = parts
+      .filter(p => p.type === 'year' || p.type === 'month' || p.type === 'day')
+      .map(p => p.type)
+
+    if (order[0] === 'year') return 'YMD'
+    if (order[0] === 'month') return 'MDY'
+    return 'DMY'
+  } catch {
+    const lang = locale.split('-')[0]
+    if (YMD_LOCALES.includes(locale) || YMD_LOCALES.includes(lang)) return 'YMD'
+    if (MDY_LOCALES.includes(locale)) return 'MDY'
+    return 'DMY'
+  }
+}
+
+const insertAtPositions = (
+  digits: string,
+  positions: number[],
+  char: string
+): string => {
+  let result = ''
+  let digitIndex = 0
+
+  for (let i = 0; i < positions.length; i++) {
+    const segLen = positions[i]
+    const segment = digits.slice(digitIndex, digitIndex + segLen)
+    if (!segment) break
+    if (i > 0) result += char
+    result += segment
+    digitIndex += segLen
+  }
+
+  return result
+}
+
+export const formatDateInput = (
+  text: string,
+  dateOrder: DateOrder,
+  separator: DateSeparator
+): string => {
+  const digits = text.replace(/\D/g, '').slice(0, 8)
+  const segments =
+    dateOrder === 'YMD' ? [4, 2, 2] : [2, 2, 4]
+
+  return insertAtPositions(digits, segments, separator)
+}
+
+export const formatTimeInput = (
+  text: string,
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): string => {
+  const cleaned = text.replace(/[^0-9aApPmM ]/g, '')
+  const digits = cleaned.replace(/\D/g, '')
+  const maxDigits = granularity === 'second' ? 6 : 4
+  const trimmed = digits.slice(0, maxDigits)
+  const segments =
+    granularity === 'second' ? [2, 2, 2] : [2, 2]
+  let result = insertAtPositions(trimmed, segments, ':')
+
+  if (hourCycle === 12 && trimmed.length >= 4) {
+    const ampmMatch = cleaned.match(/[aApP][mM]?/i)
+    if (ampmMatch) {
+      const period = ampmMatch[0].toUpperCase().startsWith('P') ? 'PM' : 'AM'
+      result += ' ' + period
+    }
+  }
+
+  return result
+}
+
+export const formatDateTimeInput = (
+  text: string,
+  dateOrder: DateOrder,
+  separator: DateSeparator,
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): string => {
+  const digits = text.replace(/[^0-9aApPmM]/g, '').replace(/[aApPmM]/g, '')
+  const dateDigitCount = 8
+  const timeDigitCount = granularity === 'second' ? 6 : 4
+  const maxDigits = dateDigitCount + timeDigitCount
+  const trimmed = digits.replace(/\D/g, '').slice(0, maxDigits)
+
+  const datePart = trimmed.slice(0, dateDigitCount)
+  const timePart = trimmed.slice(dateDigitCount)
+
+  let result = formatDateInput(datePart, dateOrder, separator)
+
+  if (timePart) {
+    const timeSegments =
+      granularity === 'second' ? [2, 2, 2] : [2, 2]
+    result += ' ' + insertAtPositions(timePart, timeSegments, ':')
+
+    if (hourCycle === 12 && timePart.length >= 4) {
+      const ampmMatch = text.match(/[aApP][mM]?/i)
+      if (ampmMatch) {
+        const period = ampmMatch[0].toUpperCase().startsWith('P')
+          ? 'PM'
+          : 'AM'
+        result += ' ' + period
+      }
+    }
+  }
+
+  return result
+}
+
+export const getDatePlaceholder = (
+  dateOrder: DateOrder,
+  separator: DateSeparator
+): string => {
+  const parts: Record<DateOrder, string[]> = {
+    YMD: ['YYYY', 'MM', 'DD'],
+    DMY: ['DD', 'MM', 'YYYY'],
+    MDY: ['MM', 'DD', 'YYYY'],
+  }
+  return parts[dateOrder].join(separator)
+}
+
+export const getTimePlaceholder = (
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): string => {
+  const hour = hourCycle === 12 ? 'hh' : 'HH'
+  const base = `${hour}:mm`
+  const withSeconds = granularity === 'second' ? `${base}:ss` : base
+  return hourCycle === 12 ? `${withSeconds} AM` : withSeconds
+}
+
+export const getDateTimePlaceholder = (
+  dateOrder: DateOrder,
+  separator: DateSeparator,
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): string => {
+  return `${getDatePlaceholder(dateOrder, separator)} ${getTimePlaceholder(granularity, hourCycle)}`
+}
+
+export const getDateMaxLength = (separator: DateSeparator): number => {
+  return 8 + 2 * separator.length
+}
+
+export const getTimeMaxLength = (
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): number => {
+  const base = granularity === 'second' ? 8 : 5
+  return hourCycle === 12 ? base + 3 : base
+}
+
+export const getDateTimeMaxLength = (
+  separator: DateSeparator,
+  granularity: TimeInputGranularity,
+  hourCycle: 12 | 24
+): number => {
+  return getDateMaxLength(separator) + 1 + getTimeMaxLength(granularity, hourCycle)
+}

--- a/packages/native/src/components/input/date-time-input.tsx
+++ b/packages/native/src/components/input/date-time-input.tsx
@@ -1,0 +1,174 @@
+import React, { forwardRef, useCallback, useMemo } from 'react'
+import { TextInput as RNTextInput } from 'react-native'
+import { TextInput } from './input'
+import type {
+  DateInputProps,
+  TimeInputProps,
+  DateTimeInputProps,
+} from './date-time-input.type'
+import {
+  getDateOrder,
+  getDatePlaceholder,
+  getTimePlaceholder,
+  getDateTimePlaceholder,
+  getDateMaxLength,
+  getTimeMaxLength,
+  getDateTimeMaxLength,
+  formatDateInput,
+  formatTimeInput,
+  formatDateTimeInput,
+} from './date-time-input.hook'
+
+export const DateInput = forwardRef<
+  React.ElementRef<typeof RNTextInput>,
+  DateInputProps
+>(
+  (
+    {
+      separator = '-',
+      dateOrder,
+      locale = 'en-US',
+      placeholder,
+      maxLength,
+      onChangeText,
+      onValueChange,
+      ...props
+    },
+    ref
+  ) => {
+    const resolvedOrder = useMemo(
+      () => dateOrder ?? getDateOrder(locale),
+      [dateOrder, locale]
+    )
+
+    const handleChangeText = useCallback(
+      (text: string) => {
+        const formatted = formatDateInput(text, resolvedOrder, separator)
+        onChangeText?.(formatted)
+        onValueChange?.(formatted)
+      },
+      [resolvedOrder, separator, onChangeText, onValueChange]
+    )
+
+    return (
+      <TextInput
+        ref={ref}
+        placeholder={
+          placeholder ?? getDatePlaceholder(resolvedOrder, separator)
+        }
+        keyboardType="number-pad"
+        autoCapitalize="none"
+        autoCorrect={false}
+        maxLength={maxLength ?? getDateMaxLength(separator)}
+        onChangeText={handleChangeText}
+        {...props}
+      />
+    )
+  }
+)
+
+export const TimeInput = forwardRef<
+  React.ElementRef<typeof RNTextInput>,
+  TimeInputProps
+>(
+  (
+    {
+      granularity = 'minute',
+      hourCycle = 24,
+      placeholder,
+      maxLength,
+      onChangeText,
+      onValueChange,
+      ...props
+    },
+    ref
+  ) => {
+    const handleChangeText = useCallback(
+      (text: string) => {
+        const formatted = formatTimeInput(text, granularity, hourCycle)
+        onChangeText?.(formatted)
+        onValueChange?.(formatted)
+      },
+      [granularity, hourCycle, onChangeText, onValueChange]
+    )
+
+    return (
+      <TextInput
+        ref={ref}
+        placeholder={
+          placeholder ?? getTimePlaceholder(granularity, hourCycle)
+        }
+        keyboardType="number-pad"
+        autoCapitalize="none"
+        autoCorrect={false}
+        maxLength={maxLength ?? getTimeMaxLength(granularity, hourCycle)}
+        onChangeText={handleChangeText}
+        {...props}
+      />
+    )
+  }
+)
+
+export const DateTimeInput = forwardRef<
+  React.ElementRef<typeof RNTextInput>,
+  DateTimeInputProps
+>(
+  (
+    {
+      separator = '-',
+      dateOrder,
+      locale = 'en-US',
+      granularity = 'minute',
+      hourCycle = 24,
+      placeholder,
+      maxLength,
+      onChangeText,
+      onValueChange,
+      ...props
+    },
+    ref
+  ) => {
+    const resolvedOrder = useMemo(
+      () => dateOrder ?? getDateOrder(locale),
+      [dateOrder, locale]
+    )
+
+    const handleChangeText = useCallback(
+      (text: string) => {
+        const formatted = formatDateTimeInput(
+          text,
+          resolvedOrder,
+          separator,
+          granularity,
+          hourCycle
+        )
+        onChangeText?.(formatted)
+        onValueChange?.(formatted)
+      },
+      [resolvedOrder, separator, granularity, hourCycle, onChangeText, onValueChange]
+    )
+
+    return (
+      <TextInput
+        ref={ref}
+        placeholder={
+          placeholder ??
+          getDateTimePlaceholder(resolvedOrder, separator, granularity, hourCycle)
+        }
+        keyboardType="number-pad"
+        autoCapitalize="none"
+        autoCorrect={false}
+        maxLength={
+          maxLength ??
+          getDateTimeMaxLength(separator, granularity, hourCycle)
+        }
+        onChangeText={handleChangeText}
+        {...props}
+      />
+    )
+  }
+)
+
+DateInput.displayName = 'DateInput'
+TimeInput.displayName = 'TimeInput'
+DateTimeInput.displayName = 'DateTimeInput'

--- a/packages/native/src/components/input/date-time-input.type.ts
+++ b/packages/native/src/components/input/date-time-input.type.ts
@@ -1,0 +1,66 @@
+import type { TextInputProps } from './input.type'
+
+export type DateSeparator = '-' | '/' | '.'
+
+export type DateOrder = 'YMD' | 'DMY' | 'MDY'
+
+export type TimeInputGranularity = 'minute' | 'second'
+
+export type DateInputProps = TextInputProps & {
+  /**
+   * Separator character between date segments.
+   * @default '-'
+   */
+  separator?: DateSeparator
+  /**
+   * Date segment ordering.
+   * Auto-detected from locale if not provided.
+   */
+  dateOrder?: DateOrder
+  /**
+   * Locale string used to auto-detect date order.
+   * @default 'en-US'
+   */
+  locale?: string
+}
+
+export type TimeInputProps = TextInputProps & {
+  /**
+   * Smallest time unit shown in the placeholder.
+   * @default 'minute'
+   */
+  granularity?: TimeInputGranularity
+  /**
+   * 12-hour or 24-hour format placeholder hint.
+   * @default 24
+   */
+  hourCycle?: 12 | 24
+}
+
+export type DateTimeInputProps = TextInputProps & {
+  /**
+   * Separator character between date segments.
+   * @default '-'
+   */
+  separator?: DateSeparator
+  /**
+   * Date segment ordering.
+   * Auto-detected from locale if not provided.
+   */
+  dateOrder?: DateOrder
+  /**
+   * Locale string used to auto-detect date order.
+   * @default 'en-US'
+   */
+  locale?: string
+  /**
+   * Smallest time unit shown in the placeholder.
+   * @default 'minute'
+   */
+  granularity?: TimeInputGranularity
+  /**
+   * 12-hour or 24-hour format placeholder hint.
+   * @default 24
+   */
+  hourCycle?: 12 | 24
+}

--- a/packages/native/src/components/input/index.ts
+++ b/packages/native/src/components/input/index.ts
@@ -1,0 +1,8 @@
+export { TextInput } from './input'
+export type {
+  TextInputProps,
+  TextInputVariant,
+  TextInputSize,
+  TextInputLabelPlacement,
+  TextInputCustomAppearance,
+} from './input.type'

--- a/packages/native/src/components/input/index.ts
+++ b/packages/native/src/components/input/index.ts
@@ -1,4 +1,7 @@
 export { TextInput } from './input'
+export { DateInput, TimeInput, DateTimeInput } from './date-time-input'
+export { OTPInput } from './otp-input'
+export { NumberInput } from './number-input'
 export type {
   TextInputProps,
   TextInputVariant,
@@ -6,3 +9,17 @@ export type {
   TextInputLabelPlacement,
   TextInputCustomAppearance,
 } from './input.type'
+export type {
+  DateInputProps,
+  TimeInputProps,
+  DateTimeInputProps,
+  TimeInputGranularity,
+  DateSeparator,
+  DateOrder,
+} from './date-time-input.type'
+export type { OTPInputProps, OTPInputCustomAppearance } from './otp-input.type'
+export type {
+  NumberInputProps,
+  NumberInputCustomAppearance,
+} from './number-input.type'
+export { getDateOrder } from './date-time-input.hook'

--- a/packages/native/src/components/input/input.hook.ts
+++ b/packages/native/src/components/input/input.hook.ts
@@ -1,0 +1,179 @@
+import { useMemo } from 'react'
+import { getSafeThemeColor, withOpacity, withPaletteNumber } from '@xaui/core'
+import { useXUITheme } from '../../core'
+import type { Radius, ThemeColor } from '../../types'
+import type { TextInputSize, TextInputVariant } from './input.type'
+
+type InputSizeStyles = {
+  minHeight: number
+  fontSize: number
+  paddingHorizontal: number
+  paddingVertical: number
+  slotGap: number
+  labelSize: number
+  helperSize: number
+}
+
+type InputVariantStyles = {
+  container: {
+    backgroundColor?: string
+    borderColor?: string
+    borderWidth?: number
+    borderBottomWidth?: number
+    borderRadius?: number
+  }
+  unfocusedBorderColor: string
+  focusedBorderColor: string
+  textColor: string
+  placeholderColor: string
+  labelColor: string
+  helperColor: string
+}
+
+const sizeMap: Record<TextInputSize, InputSizeStyles> = {
+  sm: {
+    minHeight: 40,
+    fontSize: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    slotGap: 8,
+    labelSize: 13,
+    helperSize: 12,
+  },
+  md: {
+    minHeight: 46,
+    fontSize: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    slotGap: 10,
+    labelSize: 14,
+    helperSize: 13,
+  },
+  lg: {
+    minHeight: 52,
+    fontSize: 17,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    slotGap: 12,
+    labelSize: 15,
+    helperSize: 15,
+  },
+}
+
+export const useTextInputSizeStyles = (size: TextInputSize) => {
+  return useMemo(() => sizeMap[size], [size])
+}
+
+export const useTextInputRadiusStyles = (radius: Radius) => {
+  const theme = useXUITheme()
+
+  return useMemo(() => {
+    if (radius === 'full') {
+      return { borderRadius: theme.borderRadius.full }
+    }
+
+    return { borderRadius: theme.borderRadius[radius] }
+  }, [radius, theme.borderRadius])
+}
+
+type InputVariantParams = {
+  themeColor: ThemeColor
+  variant: TextInputVariant
+  isFocused: boolean
+  isInvalid: boolean
+  isDisabled: boolean
+}
+
+export const useTextInputVariantStyles = ({
+  themeColor,
+  variant,
+  isFocused,
+  isInvalid,
+  isDisabled,
+}: InputVariantParams): InputVariantStyles => {
+  const theme = useXUITheme()
+  const safeThemeColor = getSafeThemeColor(themeColor)
+  const colorScheme = theme.colors[safeThemeColor]
+
+  return useMemo(() => {
+    const focusColor = isInvalid ? theme.colors.danger.main : colorScheme.main
+    const neutralBorder = withOpacity(theme.colors.foreground, 0.1)
+    const textColor = isDisabled
+      ? withOpacity(theme.colors.foreground, 0.55)
+      : theme.colors.foreground
+    const placeholderColor = withOpacity(theme.colors.foreground, 0.45)
+    const labelColor = isInvalid
+      ? theme.colors.danger.main
+      : isFocused
+        ? colorScheme.main
+        : withOpacity(theme.colors.foreground, 0.8)
+    const helperColor = isInvalid
+      ? theme.colors.danger.main
+      : withOpacity(theme.colors.foreground, 0.72)
+
+    if (variant === 'underlined') {
+      return {
+        container: {
+          backgroundColor: 'transparent',
+          borderColor: focusColor,
+          borderBottomWidth: isFocused || isInvalid ? 2 : 1,
+        },
+        unfocusedBorderColor: neutralBorder,
+        focusedBorderColor: focusColor,
+        textColor,
+        placeholderColor,
+        labelColor,
+        helperColor,
+      }
+    }
+
+    if (variant === 'bordered') {
+      return {
+        container: {
+          backgroundColor: theme.colors.background,
+          borderColor: isFocused || isInvalid ? focusColor : neutralBorder,
+          borderWidth: theme.borderWidth.md,
+        },
+        unfocusedBorderColor: neutralBorder,
+        focusedBorderColor: focusColor,
+        textColor,
+        placeholderColor,
+        labelColor,
+        helperColor,
+      }
+    }
+
+    if (variant === 'faded') {
+      return {
+        container: {
+          backgroundColor: withOpacity(colorScheme.background, 0.68),
+          borderColor: isFocused || isInvalid ? focusColor : 'transparent',
+          borderWidth: isFocused || isInvalid ? theme.borderWidth.md : 0,
+        },
+        unfocusedBorderColor: 'transparent',
+        focusedBorderColor: focusColor,
+        textColor,
+        placeholderColor,
+        labelColor,
+        helperColor,
+      }
+    }
+
+    return {
+      container: {
+        backgroundColor: colorScheme.background,
+        borderColor:
+          isFocused || isInvalid
+            ? withPaletteNumber(focusColor, 500)
+            : 'transparent',
+        borderWidth: isFocused || isInvalid ? theme.borderWidth.md : 0,
+      },
+      unfocusedBorderColor: 'transparent',
+      focusedBorderColor: withPaletteNumber(focusColor, 500),
+      textColor,
+      placeholderColor,
+      labelColor,
+      helperColor,
+    }
+  }, [colorScheme, isDisabled, isFocused, isInvalid, theme, variant])
+}

--- a/packages/native/src/components/input/input.style.ts
+++ b/packages/native/src/components/input/input.style.ts
@@ -1,0 +1,46 @@
+import { StyleSheet } from 'react-native'
+
+export const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    gap: 6,
+  },
+  noFullWidth: {
+    alignSelf: 'flex-start',
+  },
+  inputContainer: {
+    gap: 6,
+  },
+  label: {
+    fontWeight: '500',
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  underlinedWrapper: {
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    paddingHorizontal: 0,
+  },
+  slot: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  input: {
+    flex: 1,
+    padding: 0,
+    includeFontPadding: false,
+  },
+  clearButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 6,
+  },
+  helperText: {
+    fontWeight: '400',
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+})

--- a/packages/native/src/components/input/input.tsx
+++ b/packages/native/src/components/input/input.tsx
@@ -34,6 +34,7 @@ export const TextInput = forwardRef<React.ElementRef<typeof RNTextInput>, TextIn
       variant = 'flat',
       size = 'md',
       radius = 'md',
+      isSecured = false,
       isClearable = false,
       isDisabled = false,
       isReadOnly = false,
@@ -51,6 +52,7 @@ export const TextInput = forwardRef<React.ElementRef<typeof RNTextInput>, TextIn
     const borderAnimation = useRef(new Animated.Value(0)).current
 
     const inputValue = isControlled ? (value ?? '') : internalValue
+    const secureTextEntry = nativeProps.secureTextEntry ?? isSecured
     const sizeStyles = useTextInputSizeStyles(size)
     const radiusStyles = useTextInputRadiusStyles(radius)
     const variantStyles = useTextInputVariantStyles({
@@ -74,6 +76,7 @@ export const TextInput = forwardRef<React.ElementRef<typeof RNTextInput>, TextIn
       !!inputValue &&
       !isDisabled &&
       !isReadOnly &&
+      !secureTextEntry &&
       nativeProps.editable !== false
 
     const editable = nativeProps.editable ?? (!isDisabled && !isReadOnly)
@@ -218,6 +221,7 @@ export const TextInput = forwardRef<React.ElementRef<typeof RNTextInput>, TextIn
                     onBlur?.(event)
                   }}
                   editable={editable}
+                  secureTextEntry={secureTextEntry}
                   placeholderTextColor={variantStyles.placeholderColor}
                   style={[
                     styles.input,

--- a/packages/native/src/components/input/input.tsx
+++ b/packages/native/src/components/input/input.tsx
@@ -1,0 +1,269 @@
+import React, { forwardRef, useMemo, useState, useRef, useEffect } from 'react'
+import {
+  Pressable,
+  Text,
+  TextInput as RNTextInput,
+  View,
+  Animated,
+} from 'react-native'
+import { CloseIcon } from '@xaui/icons'
+import type { TextInputProps } from './input.type'
+import {
+  useTextInputRadiusStyles,
+  useTextInputSizeStyles,
+  useTextInputVariantStyles,
+} from './input.hook'
+import { styles } from './input.style'
+
+export const TextInput = forwardRef<React.ElementRef<typeof RNTextInput>, TextInputProps>(
+  (
+    {
+      value,
+      defaultValue,
+      onValueChange,
+      onChangeText,
+      onFocus,
+      onBlur,
+      label,
+      labelPlacement = 'outside',
+      description,
+      errorMessage,
+      startContent,
+      endContent,
+      themeColor = 'primary',
+      variant = 'flat',
+      size = 'md',
+      radius = 'md',
+      isClearable = false,
+      isDisabled = false,
+      isReadOnly = false,
+      isInvalid = false,
+      fullWidth = true,
+      customAppearance,
+      ...nativeProps
+    },
+    forwardedRef
+  ) => {
+    const isControlled = typeof value === 'string'
+    const [internalValue, setInternalValue] = useState(defaultValue ?? '')
+    const [isFocused, setIsFocused] = useState(false)
+    const internalRef = useRef<RNTextInput>(null)
+    const borderAnimation = useRef(new Animated.Value(0)).current
+
+    const inputValue = isControlled ? (value ?? '') : internalValue
+    const sizeStyles = useTextInputSizeStyles(size)
+    const radiusStyles = useTextInputRadiusStyles(radius)
+    const variantStyles = useTextInputVariantStyles({
+      themeColor,
+      variant,
+      isFocused,
+      isInvalid,
+      isDisabled,
+    })
+
+    useEffect(() => {
+      Animated.timing(borderAnimation, {
+        toValue: isFocused || isInvalid ? 1 : 0,
+        duration: 200,
+        useNativeDriver: false,
+      }).start()
+    }, [borderAnimation, isFocused, isInvalid])
+
+    const showClearButton =
+      isClearable &&
+      !!inputValue &&
+      !isDisabled &&
+      !isReadOnly &&
+      nativeProps.editable !== false
+
+    const editable = nativeProps.editable ?? (!isDisabled && !isReadOnly)
+
+    const helperText = useMemo(() => {
+      if (isInvalid && errorMessage) {
+        return errorMessage
+      }
+
+      return description
+    }, [description, errorMessage, isInvalid])
+
+    const handleChangeText = (text: string) => {
+      if (!isControlled) {
+        setInternalValue(text)
+      }
+
+      onValueChange?.(text)
+      onChangeText?.(text)
+    }
+
+    const handleClear = () => {
+      if (!isControlled) {
+        setInternalValue('')
+      }
+
+      onValueChange?.('')
+      onChangeText?.('')
+    }
+
+    const handleWrapperPress = () => {
+      if (isDisabled || isReadOnly || nativeProps.editable === false) return
+
+      const inputRef = (forwardedRef as React.RefObject<RNTextInput>) || internalRef
+
+      if (typeof forwardedRef === 'function') {
+        internalRef.current?.focus()
+      } else if (inputRef?.current) {
+        inputRef.current.focus()
+      }
+    }
+
+    return (
+      <View
+        style={[
+          styles.container,
+          !fullWidth && styles.noFullWidth,
+          isDisabled && styles.disabled,
+          customAppearance?.container,
+        ]}
+      >
+        <View style={[styles.inputContainer, customAppearance?.inputContainer]}>
+          {label && labelPlacement === 'outside' && (
+            <Text
+              style={[
+                styles.label,
+                {
+                  color: variantStyles.labelColor,
+                  fontSize: sizeStyles.labelSize,
+                },
+                customAppearance?.label,
+              ]}
+            >
+              {label}
+            </Text>
+          )}
+
+          <Pressable onPress={handleWrapperPress} disabled={isDisabled || isReadOnly}>
+            <Animated.View
+              style={[
+                styles.inputWrapper,
+                {
+                  minHeight: sizeStyles.minHeight,
+                  paddingVertical: sizeStyles.paddingVertical,
+                  paddingHorizontal: sizeStyles.paddingHorizontal,
+                  gap: sizeStyles.slotGap,
+                  backgroundColor: variantStyles.container.backgroundColor,
+                  borderWidth:
+                    variant === 'underlined' ? 0 : variantStyles.container.borderWidth,
+                  ...(variant === 'underlined' && {
+                    borderBottomWidth: variantStyles.container.borderBottomWidth,
+                  }),
+                  borderRadius:
+                    variant === 'underlined' ? 0 : radiusStyles.borderRadius,
+                  ...(variant === 'underlined'
+                    ? {
+                        borderBottomColor: borderAnimation.interpolate({
+                          inputRange: [0, 1],
+                          outputRange: [
+                            variantStyles.unfocusedBorderColor,
+                            variantStyles.focusedBorderColor,
+                          ],
+                        }),
+                      }
+                    : {
+                        borderColor: borderAnimation.interpolate({
+                          inputRange: [0, 1],
+                          outputRange: [
+                            variantStyles.unfocusedBorderColor,
+                            variantStyles.focusedBorderColor,
+                          ],
+                        }),
+                      }),
+                },
+                variant === 'underlined' && styles.underlinedWrapper,
+                customAppearance?.inputWrapper,
+              ]}
+            >
+              {startContent && <View style={styles.slot}>{startContent}</View>}
+
+              <View style={{ flex: 1, gap: labelPlacement === 'inside' && label ? 2 : 0 }}>
+                {label && labelPlacement === 'inside' && (
+                  <Text
+                    style={[
+                      styles.label,
+                      {
+                        color: variantStyles.labelColor,
+                        fontSize: sizeStyles.helperSize,
+                        paddingBottom: 2,
+                      },
+                      customAppearance?.label,
+                    ]}
+                  >
+                    {label}
+                  </Text>
+                )}
+
+                <RNTextInput
+                  ref={
+                    typeof forwardedRef === 'function'
+                      ? internalRef
+                      : forwardedRef || internalRef
+                  }
+                  value={inputValue}
+                  onChangeText={handleChangeText}
+                  onFocus={event => {
+                    setIsFocused(true)
+                    onFocus?.(event)
+                  }}
+                  onBlur={event => {
+                    setIsFocused(false)
+                    onBlur?.(event)
+                  }}
+                  editable={editable}
+                  placeholderTextColor={variantStyles.placeholderColor}
+                  style={[
+                    styles.input,
+                    {
+                      color: variantStyles.textColor,
+                      fontSize: sizeStyles.fontSize,
+                    },
+                    customAppearance?.input,
+                  ]}
+                  {...nativeProps}
+                />
+              </View>
+
+              {showClearButton ? (
+                <Pressable
+                  onPress={handleClear}
+                  accessibilityLabel="Clear input"
+                  accessibilityRole="button"
+                  style={styles.clearButton}
+                >
+                  <CloseIcon size={16} color={variantStyles.placeholderColor} />
+                </Pressable>
+              ) : (
+                endContent && <View style={styles.slot}>{endContent}</View>
+              )}
+            </Animated.View>
+          </Pressable>
+        </View>
+
+        {helperText && (
+          <Text
+            style={[
+              styles.helperText,
+              {
+                color: variantStyles.helperColor,
+                fontSize: sizeStyles.helperSize,
+              },
+              customAppearance?.helperText,
+            ]}
+          >
+            {helperText}
+          </Text>
+        )}
+      </View>
+    )
+  }
+)
+
+TextInput.displayName = 'TextInput'

--- a/packages/native/src/components/input/input.type.ts
+++ b/packages/native/src/components/input/input.type.ts
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react'
+import type {
+  StyleProp,
+  TextInputProps as RNTextInputProps,
+  TextStyle,
+  ViewStyle,
+} from 'react-native'
+import type { Radius, ThemeColor } from '../../types'
+
+export type TextInputVariant = 'flat' | 'faded' | 'bordered' | 'underlined'
+export type TextInputSize = 'sm' | 'md' | 'lg'
+export type TextInputLabelPlacement = 'outside' | 'inside'
+
+export type TextInputCustomAppearance = {
+  container?: StyleProp<ViewStyle>
+  inputContainer?: StyleProp<ViewStyle>
+  inputWrapper?: StyleProp<ViewStyle>
+  label?: StyleProp<TextStyle>
+  input?: StyleProp<TextStyle>
+  helperText?: StyleProp<TextStyle>
+}
+
+export type TextInputProps = Omit<
+  RNTextInputProps,
+  'value' | 'defaultValue' | 'style'
+> & {
+  /**
+   * Controlled value of the input.
+   */
+  value?: string
+  /**
+   * Uncontrolled default value of the input.
+   */
+  defaultValue?: string
+  /**
+   * Called when the input value changes.
+   */
+  onValueChange?: (value: string) => void
+  /**
+   * Input label.
+   */
+  label?: ReactNode
+  /**
+   * Label position relative to the field.
+   * @default 'outside'
+   */
+  labelPlacement?: TextInputLabelPlacement
+  /**
+   * Helper text displayed below the input.
+   */
+  description?: ReactNode
+  /**
+   * Error text displayed below the input when invalid.
+   */
+  errorMessage?: ReactNode
+  /**
+   * Start slot content.
+   */
+  startContent?: ReactNode
+  /**
+   * End slot content.
+   */
+  endContent?: ReactNode
+  /**
+   * Theme color used for focus/active states.
+   * @default 'primary'
+   */
+  themeColor?: ThemeColor
+  /**
+   * Visual style variant.
+   * @default 'flat'
+   */
+  variant?: TextInputVariant
+  /**
+   * Input size.
+   * @default 'md'
+   */
+  size?: TextInputSize
+  /**
+   * Input radius.
+   * @default 'md'
+   */
+  radius?: Radius
+  /**
+   * Whether to show a clear button when input has value.
+   * @default false
+   */
+  isClearable?: boolean
+  /**
+   * Whether the input is disabled.
+   * @default false
+   */
+  isDisabled?: boolean
+  /**
+   * Whether the input is read-only.
+   * @default false
+   */
+  isReadOnly?: boolean
+  /**
+   * Whether the input is invalid.
+   * @default false
+   */
+  isInvalid?: boolean
+  /**
+   * Whether the component should take full available width.
+   * @default true
+   */
+  fullWidth?: boolean
+  /**
+   * Optional custom styles for input parts.
+   */
+  customAppearance?: TextInputCustomAppearance
+}

--- a/packages/native/src/components/input/input.type.ts
+++ b/packages/native/src/components/input/input.type.ts
@@ -82,6 +82,11 @@ export type TextInputProps = Omit<
    */
   radius?: Radius
   /**
+   * Whether the input should be secured (password mode).
+   * @default false
+   */
+  isSecured?: boolean
+  /**
    * Whether to show a clear button when input has value.
    * @default false
    */

--- a/packages/native/src/components/input/number-input.hook.ts
+++ b/packages/native/src/components/input/number-input.hook.ts
@@ -1,0 +1,132 @@
+import { useCallback, useMemo, useState } from 'react'
+
+type UseNumberInputStateParams = {
+  value?: number
+  defaultValue?: number
+  onValueChange?: (value: number | undefined) => void
+  minValue?: number
+  maxValue?: number
+  step: number
+  formatOptions?: Intl.NumberFormatOptions
+  locale: string
+}
+
+export const useNumberInputState = ({
+  value,
+  defaultValue,
+  onValueChange,
+  minValue,
+  maxValue,
+  step,
+  formatOptions,
+  locale,
+}: UseNumberInputStateParams) => {
+  const isControlled = typeof value === 'number'
+  const [internalValue, setInternalValue] = useState<number | undefined>(
+    defaultValue
+  )
+  const [isEditing, setIsEditing] = useState(false)
+  const [rawText, setRawText] = useState('')
+
+  const currentValue = isControlled ? value : internalValue
+
+  const formatter = useMemo(() => {
+    if (!formatOptions) return null
+    return new Intl.NumberFormat(locale, formatOptions)
+  }, [formatOptions, locale])
+
+  const displayValue = useMemo(() => {
+    if (isEditing) return rawText
+    if (currentValue === undefined) return ''
+    if (formatter) return formatter.format(currentValue)
+    return String(currentValue)
+  }, [currentValue, formatter, isEditing, rawText])
+
+  const updateValue = useCallback(
+    (newValue: number | undefined) => {
+      if (!isControlled) {
+        setInternalValue(newValue)
+      }
+      onValueChange?.(newValue)
+    },
+    [isControlled, onValueChange]
+  )
+
+  const clamp = useCallback(
+    (num: number): number => {
+      let clamped = num
+      if (minValue !== undefined && clamped < minValue) clamped = minValue
+      if (maxValue !== undefined && clamped > maxValue) clamped = maxValue
+      return clamped
+    },
+    [minValue, maxValue]
+  )
+
+  const handleTextChange = useCallback(
+    (text: string) => {
+      setRawText(text)
+
+      if (text === '' || text === '-') return
+
+      const parsed = parseFloat(text)
+      if (isNaN(parsed)) return
+
+      updateValue(parsed)
+    },
+    [updateValue]
+  )
+
+  const handleFocus = useCallback(() => {
+    setIsEditing(true)
+    setRawText(currentValue !== undefined ? String(currentValue) : '')
+  }, [currentValue])
+
+  const handleBlur = useCallback(() => {
+    setIsEditing(false)
+
+    if (rawText === '' || rawText === '-') {
+      updateValue(undefined)
+      return
+    }
+
+    const parsed = parseFloat(rawText)
+    if (isNaN(parsed)) {
+      updateValue(undefined)
+      return
+    }
+
+    updateValue(clamp(parsed))
+  }, [rawText, clamp, updateValue])
+
+  const handleClear = useCallback(() => {
+    setRawText('')
+    updateValue(undefined)
+  }, [updateValue])
+
+  const canIncrement = maxValue === undefined || (currentValue ?? 0) + step <= maxValue
+  const canDecrement = minValue === undefined || (currentValue ?? 0) - step >= minValue
+
+  const handleIncrement = useCallback(() => {
+    const base = currentValue ?? 0
+    const newValue = clamp(base + step)
+    updateValue(newValue)
+  }, [currentValue, step, clamp, updateValue])
+
+  const handleDecrement = useCallback(() => {
+    const base = currentValue ?? 0
+    const newValue = clamp(base - step)
+    updateValue(newValue)
+  }, [currentValue, step, clamp, updateValue])
+
+  return {
+    displayValue,
+    handleTextChange,
+    handleFocus,
+    handleBlur,
+    handleClear,
+    handleIncrement,
+    handleDecrement,
+    canIncrement,
+    canDecrement,
+  }
+}

--- a/packages/native/src/components/input/number-input.style.ts
+++ b/packages/native/src/components/input/number-input.style.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native'
+
+export const numberInputStyles = StyleSheet.create({
+  stepperContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  stepperButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+  },
+  stepperDisabled: {
+    opacity: 0.4,
+  },
+})

--- a/packages/native/src/components/input/number-input.tsx
+++ b/packages/native/src/components/input/number-input.tsx
@@ -48,7 +48,6 @@ export const NumberInput = forwardRef<
       handleTextChange,
       handleFocus,
       handleBlur,
-      handleClear,
       handleIncrement,
       handleDecrement,
       canIncrement,
@@ -81,8 +80,7 @@ export const NumberInput = forwardRef<
             accessibilityRole="button"
             style={[
               numberInputStyles.stepperButton,
-              (!canDecrement || isDisabled) &&
-                numberInputStyles.stepperDisabled,
+              (!canDecrement || isDisabled) && numberInputStyles.stepperDisabled,
               customAppearance?.stepperButton,
             ]}
           >
@@ -95,8 +93,7 @@ export const NumberInput = forwardRef<
             accessibilityRole="button"
             style={[
               numberInputStyles.stepperButton,
-              (!canIncrement || isDisabled) &&
-                numberInputStyles.stepperDisabled,
+              (!canIncrement || isDisabled) && numberInputStyles.stepperDisabled,
               customAppearance?.stepperButton,
             ]}
           >
@@ -112,7 +109,6 @@ export const NumberInput = forwardRef<
         onChangeText={handleTextChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        onValueChange={isClearable && !displayValue ? undefined : handleClear}
         label={label}
         labelPlacement={labelPlacement}
         description={description}

--- a/packages/native/src/components/input/number-input.tsx
+++ b/packages/native/src/components/input/number-input.tsx
@@ -1,0 +1,138 @@
+import React, { forwardRef } from 'react'
+import { Pressable, TextInput as RNTextInput, View } from 'react-native'
+import { AddIcon, RemoveIcon } from '@xaui/icons'
+import { withOpacity } from '@xaui/core'
+import { useXUITheme } from '../../core'
+import { TextInput } from './input'
+import type { NumberInputProps } from './number-input.type'
+import { useNumberInputState } from './number-input.hook'
+import { numberInputStyles } from './number-input.style'
+
+export const NumberInput = forwardRef<
+  React.ElementRef<typeof RNTextInput>,
+  NumberInputProps
+>(
+  (
+    {
+      value,
+      defaultValue,
+      onValueChange,
+      minValue,
+      maxValue,
+      step = 1,
+      hideStepper = false,
+      formatOptions,
+      locale = 'en-US',
+      label,
+      labelPlacement = 'outside',
+      description,
+      errorMessage,
+      placeholder,
+      themeColor = 'primary',
+      variant = 'flat',
+      size = 'md',
+      radius = 'md',
+      isDisabled = false,
+      isReadOnly = false,
+      isInvalid = false,
+      isClearable = false,
+      fullWidth = true,
+      customAppearance,
+    },
+    ref
+  ) => {
+    const theme = useXUITheme()
+
+    const {
+      displayValue,
+      handleTextChange,
+      handleFocus,
+      handleBlur,
+      handleClear,
+      handleIncrement,
+      handleDecrement,
+      canIncrement,
+      canDecrement,
+    } = useNumberInputState({
+      value,
+      defaultValue,
+      onValueChange,
+      minValue,
+      maxValue,
+      step,
+      formatOptions,
+      locale,
+    })
+
+    const iconColor = withOpacity(theme.colors.foreground, 0.7)
+
+    const stepperContent =
+      hideStepper || isReadOnly ? undefined : (
+        <View
+          style={[
+            numberInputStyles.stepperContainer,
+            customAppearance?.stepperContainer,
+          ]}
+        >
+          <Pressable
+            onPress={handleDecrement}
+            disabled={isDisabled || !canDecrement}
+            accessibilityLabel="Decrease value"
+            accessibilityRole="button"
+            style={[
+              numberInputStyles.stepperButton,
+              (!canDecrement || isDisabled) &&
+                numberInputStyles.stepperDisabled,
+              customAppearance?.stepperButton,
+            ]}
+          >
+            <RemoveIcon size={16} color={iconColor} />
+          </Pressable>
+          <Pressable
+            onPress={handleIncrement}
+            disabled={isDisabled || !canIncrement}
+            accessibilityLabel="Increase value"
+            accessibilityRole="button"
+            style={[
+              numberInputStyles.stepperButton,
+              (!canIncrement || isDisabled) &&
+                numberInputStyles.stepperDisabled,
+              customAppearance?.stepperButton,
+            ]}
+          >
+            <AddIcon size={16} color={iconColor} />
+          </Pressable>
+        </View>
+      )
+
+    return (
+      <TextInput
+        ref={ref}
+        value={displayValue}
+        onChangeText={handleTextChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onValueChange={isClearable && !displayValue ? undefined : handleClear}
+        label={label}
+        labelPlacement={labelPlacement}
+        description={description}
+        errorMessage={errorMessage}
+        placeholder={placeholder}
+        themeColor={themeColor}
+        variant={variant}
+        size={size}
+        radius={radius}
+        isDisabled={isDisabled}
+        isReadOnly={isReadOnly}
+        isInvalid={isInvalid}
+        isClearable={isClearable}
+        fullWidth={fullWidth}
+        keyboardType="numeric"
+        endContent={stepperContent}
+        customAppearance={customAppearance}
+      />
+    )
+  }
+)
+
+NumberInput.displayName = 'NumberInput'

--- a/packages/native/src/components/input/number-input.type.ts
+++ b/packages/native/src/components/input/number-input.type.ts
@@ -1,0 +1,125 @@
+import type { StyleProp, ViewStyle } from 'react-native'
+import type { Radius, ThemeColor } from '../../types'
+import type {
+  TextInputCustomAppearance,
+  TextInputLabelPlacement,
+  TextInputSize,
+  TextInputVariant,
+} from './input.type'
+
+export type NumberInputCustomAppearance = TextInputCustomAppearance & {
+  stepperContainer?: StyleProp<ViewStyle>
+  stepperButton?: StyleProp<ViewStyle>
+}
+
+export type NumberInputProps = {
+  /**
+   * Controlled numeric value.
+   */
+  value?: number
+  /**
+   * Uncontrolled default numeric value.
+   */
+  defaultValue?: number
+  /**
+   * Called when the numeric value changes.
+   */
+  onValueChange?: (value: number | undefined) => void
+  /**
+   * Minimum allowed value.
+   */
+  minValue?: number
+  /**
+   * Maximum allowed value.
+   */
+  maxValue?: number
+  /**
+   * Step increment/decrement amount.
+   * @default 1
+   */
+  step?: number
+  /**
+   * Whether to hide the stepper buttons.
+   * @default false
+   */
+  hideStepper?: boolean
+  /**
+   * Intl.NumberFormat options for display formatting.
+   */
+  formatOptions?: Intl.NumberFormatOptions
+  /**
+   * Locale for number formatting.
+   * @default 'en-US'
+   */
+  locale?: string
+  /**
+   * Input label.
+   */
+  label?: string
+  /**
+   * Label position relative to the field.
+   * @default 'outside'
+   */
+  labelPlacement?: TextInputLabelPlacement
+  /**
+   * Helper text displayed below the input.
+   */
+  description?: string
+  /**
+   * Error text displayed below the input when invalid.
+   */
+  errorMessage?: string
+  /**
+   * Placeholder text.
+   */
+  placeholder?: string
+  /**
+   * Theme color used for focus/active states.
+   * @default 'primary'
+   */
+  themeColor?: ThemeColor
+  /**
+   * Visual style variant.
+   * @default 'flat'
+   */
+  variant?: TextInputVariant
+  /**
+   * Input size.
+   * @default 'md'
+   */
+  size?: TextInputSize
+  /**
+   * Input radius.
+   * @default 'md'
+   */
+  radius?: Radius
+  /**
+   * Whether the input is disabled.
+   * @default false
+   */
+  isDisabled?: boolean
+  /**
+   * Whether the input is read-only.
+   * @default false
+   */
+  isReadOnly?: boolean
+  /**
+   * Whether the input is invalid.
+   * @default false
+   */
+  isInvalid?: boolean
+  /**
+   * Whether to show a clear button.
+   * @default false
+   */
+  isClearable?: boolean
+  /**
+   * Whether the component should take full available width.
+   * @default true
+   */
+  fullWidth?: boolean
+  /**
+   * Optional custom styles for input parts.
+   */
+  customAppearance?: NumberInputCustomAppearance
+}

--- a/packages/native/src/components/input/otp-input.hook.ts
+++ b/packages/native/src/components/input/otp-input.hook.ts
@@ -1,0 +1,122 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { TextInput as RNTextInput } from 'react-native'
+import type { TextInputSize } from './input.type'
+
+type OTPSegmentSize = {
+  width: number
+  height: number
+  fontSize: number
+}
+
+const segmentSizeMap: Record<TextInputSize, OTPSegmentSize> = {
+  sm: { width: 40, height: 40, fontSize: 16 },
+  md: { width: 48, height: 48, fontSize: 20 },
+  lg: { width: 56, height: 56, fontSize: 24 },
+}
+
+export const useOTPSegmentSizeStyles = (size: TextInputSize) => {
+  return useMemo(() => segmentSizeMap[size], [size])
+}
+
+type UseOTPInputStateParams = {
+  length: number
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+  onComplete?: (value: string) => void
+  allowedKeys: RegExp
+}
+
+export const useOTPInputState = ({
+  length,
+  value,
+  defaultValue,
+  onValueChange,
+  onComplete,
+  allowedKeys,
+}: UseOTPInputStateParams) => {
+  const isControlled = typeof value === 'string'
+  const [internalValue, setInternalValue] = useState(
+    defaultValue ?? ''
+  )
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const refs = useRef<(RNTextInput | null)[]>([])
+
+  const currentValue = isControlled ? value : internalValue
+  const segments = useMemo(() => {
+    const chars = currentValue.split('')
+    return Array.from({ length }, (_, i) => chars[i] ?? '')
+  }, [currentValue, length])
+
+  const updateValue = useCallback(
+    (newValue: string) => {
+      if (!isControlled) {
+        setInternalValue(newValue)
+      }
+      onValueChange?.(newValue)
+      if (newValue.length === length) {
+        onComplete?.(newValue)
+      }
+    },
+    [isControlled, length, onValueChange, onComplete]
+  )
+
+  const handleSegmentChange = useCallback(
+    (index: number, text: string) => {
+      if (!text) return
+      const char = text.slice(-1)
+      if (!allowedKeys.test(char)) return
+
+      const chars = currentValue.split('')
+      while (chars.length < length) chars.push('')
+      chars[index] = char
+      const newValue = chars.join('').replace(/\s+$/, '')
+      updateValue(newValue)
+
+      if (index < length - 1) {
+        refs.current[index + 1]?.focus()
+      }
+    },
+    [allowedKeys, currentValue, length, updateValue]
+  )
+
+  const handleSegmentKeyPress = useCallback(
+    (index: number, key: string) => {
+      if (key !== 'Backspace') return
+
+      const chars = currentValue.split('')
+      while (chars.length < length) chars.push('')
+
+      if (chars[index]) {
+        chars[index] = ''
+        updateValue(chars.join('').replace(/\s+$/, ''))
+        return
+      }
+
+      if (index > 0) {
+        chars[index - 1] = ''
+        updateValue(chars.join('').replace(/\s+$/, ''))
+        refs.current[index - 1]?.focus()
+      }
+    },
+    [currentValue, length, updateValue]
+  )
+
+  const handleSegmentFocus = useCallback((index: number) => {
+    setActiveIndex(index)
+  }, [])
+
+  const handleSegmentBlur = useCallback(() => {
+    setActiveIndex(-1)
+  }, [])
+
+  return {
+    segments,
+    activeIndex,
+    refs,
+    handleSegmentChange,
+    handleSegmentKeyPress,
+    handleSegmentFocus,
+    handleSegmentBlur,
+  }
+}

--- a/packages/native/src/components/input/otp-input.style.ts
+++ b/packages/native/src/components/input/otp-input.style.ts
@@ -1,0 +1,43 @@
+import { StyleSheet } from 'react-native'
+
+export const otpStyles = StyleSheet.create({
+  container: {
+    gap: 6,
+  },
+  fullWidth: {
+    width: '100%',
+  },
+  segmentContainer: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  segment: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  segmentText: {
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  securedDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  hiddenInput: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    opacity: 0,
+  },
+  label: {
+    fontWeight: '500',
+  },
+  helperText: {
+    fontWeight: '400',
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+})

--- a/packages/native/src/components/input/otp-input.tsx
+++ b/packages/native/src/components/input/otp-input.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useRef } from 'react'
+import {
+  Animated,
+  Pressable,
+  Text,
+  TextInput as RNTextInput,
+  View,
+} from 'react-native'
+import type { OTPInputProps } from './otp-input.type'
+import { useOTPInputState, useOTPSegmentSizeStyles } from './otp-input.hook'
+import {
+  useTextInputRadiusStyles,
+  useTextInputVariantStyles,
+} from './input.hook'
+import { otpStyles } from './otp-input.style'
+
+const OTPSegment = ({
+  char,
+  isActive,
+  isSecured,
+  isDisabled,
+  variantStyles,
+  sizeStyles,
+  radiusStyles,
+  customSegment,
+  customSegmentText,
+  inputRef,
+  onChangeText,
+  onKeyPress,
+  onFocus,
+  onBlur,
+}: {
+  char: string
+  isActive: boolean
+  isSecured: boolean
+  isDisabled: boolean
+  variantStyles: ReturnType<typeof useTextInputVariantStyles>
+  sizeStyles: ReturnType<typeof useOTPSegmentSizeStyles>
+  radiusStyles: { borderRadius: number }
+  customSegment?: OTPInputProps['customAppearance']
+  customSegmentText?: OTPInputProps['customAppearance']
+  inputRef: (ref: RNTextInput | null) => void
+  onChangeText: (text: string) => void
+  onKeyPress: (key: string) => void
+  onFocus: () => void
+  onBlur: () => void
+}) => {
+  const borderAnimation = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    Animated.timing(borderAnimation, {
+      toValue: isActive ? 1 : 0,
+      duration: 200,
+      useNativeDriver: false,
+    }).start()
+  }, [borderAnimation, isActive])
+
+  return (
+    <Pressable
+      onPress={() => {
+        if (!isDisabled) {
+          const inputEl = inputRef as unknown as { current: RNTextInput | null }
+          if (typeof inputEl !== 'function') return
+        }
+      }}
+      disabled={isDisabled}
+    >
+      <Animated.View
+        style={[
+          otpStyles.segment,
+          {
+            width: sizeStyles.width,
+            height: sizeStyles.height,
+            backgroundColor: variantStyles.container.backgroundColor,
+            borderWidth: variantStyles.container.borderWidth ?? 0,
+            borderRadius: radiusStyles.borderRadius,
+            borderColor: borderAnimation.interpolate({
+              inputRange: [0, 1],
+              outputRange: [
+                variantStyles.unfocusedBorderColor,
+                variantStyles.focusedBorderColor,
+              ],
+            }),
+          },
+          customSegment?.segment,
+        ]}
+      >
+        {char && isSecured ? (
+          <View
+            style={[
+              otpStyles.securedDot,
+              { backgroundColor: variantStyles.textColor },
+            ]}
+          />
+        ) : (
+          <Text
+            style={[
+              otpStyles.segmentText,
+              {
+                color: variantStyles.textColor,
+                fontSize: sizeStyles.fontSize,
+              },
+              customSegmentText?.segmentText,
+            ]}
+          >
+            {char}
+          </Text>
+        )}
+        <RNTextInput
+          ref={inputRef}
+          style={otpStyles.hiddenInput}
+          value={char}
+          onChangeText={onChangeText}
+          onKeyPress={e => onKeyPress(e.nativeEvent.key)}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          maxLength={2}
+          keyboardType="number-pad"
+          editable={!isDisabled}
+          caretHidden
+        />
+      </Animated.View>
+    </Pressable>
+  )
+}
+
+export const OTPInput = ({
+  length = 4,
+  value,
+  defaultValue,
+  onValueChange,
+  onComplete,
+  variant = 'flat',
+  size = 'md',
+  radius = 'md',
+  themeColor = 'primary',
+  isDisabled = false,
+  isInvalid = false,
+  isSecured = false,
+  errorMessage,
+  description,
+  label,
+  allowedKeys = /^[0-9]$/,
+  customAppearance,
+  fullWidth = false,
+}: OTPInputProps) => {
+  const sizeStyles = useOTPSegmentSizeStyles(size)
+  const radiusStyles = useTextInputRadiusStyles(radius)
+  const variantStyles = useTextInputVariantStyles({
+    themeColor,
+    variant,
+    isFocused: false,
+    isInvalid,
+    isDisabled,
+  })
+
+  const {
+    segments,
+    activeIndex,
+    refs,
+    handleSegmentChange,
+    handleSegmentKeyPress,
+    handleSegmentFocus,
+    handleSegmentBlur,
+  } = useOTPInputState({
+    length,
+    value,
+    defaultValue,
+    onValueChange,
+    onComplete,
+    allowedKeys,
+  })
+
+  const helperText = isInvalid && errorMessage ? errorMessage : description
+  const helperColor = isInvalid
+    ? variantStyles.helperColor
+    : variantStyles.helperColor
+
+  const activeVariantStyles = useTextInputVariantStyles({
+    themeColor,
+    variant,
+    isFocused: true,
+    isInvalid,
+    isDisabled,
+  })
+
+  return (
+    <View
+      style={[
+        otpStyles.container,
+        fullWidth && otpStyles.fullWidth,
+        isDisabled && otpStyles.disabled,
+        customAppearance?.container,
+      ]}
+    >
+      {label && (
+        <Text
+          style={[
+            otpStyles.label,
+            {
+              color: variantStyles.labelColor,
+              fontSize: 14,
+            },
+            customAppearance?.label,
+          ]}
+        >
+          {label}
+        </Text>
+      )}
+
+      <View
+        style={[otpStyles.segmentContainer, customAppearance?.segmentContainer]}
+      >
+        {segments.map((char, index) => (
+          <OTPSegment
+            key={index}
+            char={char}
+            isActive={activeIndex === index}
+            isSecured={isSecured}
+            isDisabled={isDisabled}
+            variantStyles={
+              activeIndex === index ? activeVariantStyles : variantStyles
+            }
+            sizeStyles={sizeStyles}
+            radiusStyles={radiusStyles}
+            customSegment={customAppearance}
+            customSegmentText={customAppearance}
+            inputRef={ref => {
+              refs.current[index] = ref
+            }}
+            onChangeText={text => handleSegmentChange(index, text)}
+            onKeyPress={key => handleSegmentKeyPress(index, key)}
+            onFocus={() => handleSegmentFocus(index)}
+            onBlur={handleSegmentBlur}
+          />
+        ))}
+      </View>
+
+      {helperText && (
+        <Text
+          style={[
+            otpStyles.helperText,
+            { color: helperColor, fontSize: 13 },
+            customAppearance?.helperText,
+          ]}
+        >
+          {helperText}
+        </Text>
+      )}
+    </View>
+  )
+}
+
+OTPInput.displayName = 'OTPInput'

--- a/packages/native/src/components/input/otp-input.type.ts
+++ b/packages/native/src/components/input/otp-input.type.ts
@@ -1,0 +1,97 @@
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native'
+import type { Radius, ThemeColor } from '../../types'
+import type { TextInputSize, TextInputVariant } from './input.type'
+
+export type OTPInputCustomAppearance = {
+  container?: StyleProp<ViewStyle>
+  segmentContainer?: StyleProp<ViewStyle>
+  segment?: StyleProp<ViewStyle>
+  segmentText?: StyleProp<TextStyle>
+  label?: StyleProp<TextStyle>
+  helperText?: StyleProp<TextStyle>
+}
+
+export type OTPInputProps = {
+  /**
+   * Number of OTP segments.
+   * @default 4
+   */
+  length?: number
+  /**
+   * Controlled value of the OTP input.
+   */
+  value?: string
+  /**
+   * Uncontrolled default value.
+   */
+  defaultValue?: string
+  /**
+   * Called when the OTP value changes.
+   */
+  onValueChange?: (value: string) => void
+  /**
+   * Called when all segments are filled.
+   */
+  onComplete?: (value: string) => void
+  /**
+   * Visual style variant.
+   * @default 'flat'
+   */
+  variant?: TextInputVariant
+  /**
+   * Input size.
+   * @default 'md'
+   */
+  size?: TextInputSize
+  /**
+   * Input radius.
+   * @default 'md'
+   */
+  radius?: Radius
+  /**
+   * Theme color used for focus/active states.
+   * @default 'primary'
+   */
+  themeColor?: ThemeColor
+  /**
+   * Whether the input is disabled.
+   * @default false
+   */
+  isDisabled?: boolean
+  /**
+   * Whether the input is invalid.
+   * @default false
+   */
+  isInvalid?: boolean
+  /**
+   * Whether to hide entered characters.
+   * @default false
+   */
+  isSecured?: boolean
+  /**
+   * Error text displayed below the input when invalid.
+   */
+  errorMessage?: string
+  /**
+   * Helper text displayed below the input.
+   */
+  description?: string
+  /**
+   * Input label.
+   */
+  label?: string
+  /**
+   * Regex to filter allowed key input.
+   * @default /^[0-9]$/
+   */
+  allowedKeys?: RegExp
+  /**
+   * Optional custom styles for input parts.
+   */
+  customAppearance?: OTPInputCustomAppearance
+  /**
+   * Whether the component should take full available width.
+   * @default false
+   */
+  fullWidth?: boolean
+}

--- a/packages/native/tsup.config.ts
+++ b/packages/native/tsup.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(options => {
       'carousel/index': 'src/components/carousel/index.ts',
       'card/index': 'src/components/card/index.ts',
       'skeleton/index': 'src/components/skeleton/index.ts',
+      'input/index': 'src/components/input/index.ts',
     },
     format: ['cjs', 'esm'],
     dts: !isWatch,


### PR DESCRIPTION
## Summary
This PR expands the native input package with specialized input primitives and demo coverage.

## Changes
- Added `DateInput`, `TimeInput`, and `DateTimeInput`
- Added locale-aware date order detection and date/time formatting helpers
- Added `OTPInput` with segmented entry, secure mode, and key filtering
- Added `NumberInput` with stepper controls, min/max clamping, and Intl formatting
- Added `TextInput` `isSecured` prop and disabled clear action when secure entry is enabled
- Exported new components/types from `packages/native/src/components/input/index.ts`
- Added demo routes/screens for:
  - `date-input`
  - `otp-input`
  - `number-input`
- Added tests for date-time input helpers/types, OTP types, and number input types
- Updated changeset to patch only `@xaui/native`

## Testing
- Added:
  - `packages/native/src/__tests__/components/input/date-time-input.test.tsx`
  - `packages/native/src/__tests__/components/input/otp-input.test.tsx`
  - `packages/native/src/__tests__/components/input/number-input.test.tsx`
- Test run status: not executed in this step.

## Notes
- `.changeset/input-improvements.md` was updated to remove demo package bump.