### PR TITLE
feat(docs): add GitHub link with star count to sidebar header

### DIFF
--- a/apps/demo/app/expansion-panel.tsx
+++ b/apps/demo/app/expansion-panel.tsx
@@ -15,7 +15,7 @@ export default function ExpansionPanelScreen() {
         <Text style={[styles.content, { color: theme.palette.fuchsia[500] }]}>
           Toggle Mode
         </Text>
-        <ExpansionPanel variant="splitted" defaultExpandedKeys={['intro']}>
+        <ExpansionPanel variant="bordered" defaultExpandedKeys={['intro']}>
           <ExpansionPanelItem itemKey="intro" title="What is XAUI?">
             <Text style={{ color: colors.foreground }}>
               XAUI is a cross-platform UI kit for React Native and hybrid apps.

--- a/apps/docs/components/layout/sidebar.tsx
+++ b/apps/docs/components/layout/sidebar.tsx
@@ -4,25 +4,52 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { navigation } from '@/lib/data/navigation'
-import { Search } from 'lucide-react'
-import { useState } from 'react'
+import { Search, Star, Github } from 'lucide-react'
+import { useState, useEffect } from 'react'
 import { SearchDialog } from './search-dialog'
 
 export function Sidebar() {
   const pathname = usePathname()
   const [searchOpen, setSearchOpen] = useState(false)
+  const [stars, setStars] = useState<number | null>(null)
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/rygrams/xaui')
+      .then(res => res.json())
+      .then(data => setStars(data.stargazers_count))
+      .catch(() => null)
+  }, [])
+
+  const formatStars = (count: number) => {
+    if (count >= 1000) return `${(count / 1000).toFixed(1)}k`
+    return String(count)
+  }
 
   return (
     <>
       <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r bg-background">
         <div className="flex h-full flex-col">
-          <div className="flex h-14 items-center border-b px-4">
+          <div className="flex h-14 items-center justify-between border-b px-4">
             <Link href="/" className="flex items-center gap-2 font-semibold">
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
                 X
               </div>
               <span>Xaui</span>
             </Link>
+            <a
+              href="https://github.com/rygrams/xaui"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <Github className="h-4 w-4" />
+              {stars !== null && (
+                <>
+                  <Star className="h-3 w-3 fill-current" />
+                  <span>{formatStars(stars)}</span>
+                </>
+              )}
+            </a>
           </div>
 
           <div className="px-3 py-2">


### PR DESCRIPTION
### What

  Added a GitHub link button in the top-right of the docs sidebar header, displaying the repo's live star count fetched from the GitHub API.

###  Why

  Gives visitors a quick way to star/visit the repo directly from the documentation, improving visibility and discoverability of the project.

###  How

  - Added a useEffect in Sidebar that fetches stargazers_count from the GitHub API (rygrams/xaui)
  - Renders an outlined pill button (border + rounded-md) with the Github icon and, once loaded, a filled Star icon + formatted count (e.g.
  1.2k)
  - If the fetch fails (rate limit, offline…), only the GitHub icon is shown — no broken state
  - Also fixes a minor demo variant: ExpansionPanel switched from splitted to bordered in the expansion-panel demo screen