### PR TITLE
feat(native/typography): add TextSpan container with inherited text styles

### DIFF
--- a/.changeset/three-chefs-kick.md
+++ b/.changeset/three-chefs-kick.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+Add a new `TextSpan` typography primitive to compose grouped text content and share inherited text styles (`color`, `fontWeight`, `fontStyle`, `textTransform`) with nested `Typography`.

--- a/apps/demo/app/typography.tsx
+++ b/apps/demo/app/typography.tsx
@@ -1,5 +1,5 @@
 import { useXUIColors, useXUITheme } from '@xaui/native/core'
-import { Typography } from '@xaui/native/typography'
+import { TextSpan, Typography } from '@xaui/native/typography'
 import { ScrollView, StyleSheet, View } from 'react-native'
 
 export default function TypographyScreen() {
@@ -71,16 +71,42 @@ export default function TypographyScreen() {
             {'maxLines=1 overflow="ellipsis"'}
           </Typography>
           <Typography maxLines={1} overflow="ellipsis">
-            This is a very long text that will be truncated after one line with
-            an ellipsis at the end.
+            This is a very long text that will be truncated after one line with an
+            ellipsis at the end.
           </Typography>
           <Typography variant="bodySmall" themeColor="secondary">
             {'maxLines=2 overflow="clip"'}
           </Typography>
           <Typography maxLines={2} overflow="clip">
-            This is a very long text that will be clipped after two lines
-            without any indicator that there is more content below this point.
+            This is a very long text that will be clipped after two lines without any
+            indicator that there is more content below this point.
           </Typography>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Typography variant="subtitleLarge" style={styles.sectionTitle}>
+          TextSpan
+        </Typography>
+        <View style={{ gap: theme.spacing.sm }}>
+          <TextSpan
+            color={colors.primary.main}
+            fontWeight="700"
+            textTransform="uppercase"
+            spacing={6}
+            align="center"
+            backgroundColor={colors.primary.background}
+          >
+            <Typography>Voici un texte avec</Typography>
+            <Typography letterSpacing={0.5}>une portion stylée</Typography>
+            <Typography
+              fontStyle="italic"
+              textTransform="none"
+              color={colors.foreground}
+            >
+              à l&apos;intérieur de TextSpan.
+            </Typography>
+          </TextSpan>
         </View>
       </View>
     </ScrollView>
@@ -100,5 +126,11 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontWeight: 'bold',
     marginBottom: 12,
+  },
+  textSpanContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    borderRadius: 8,
+    padding: 8,
   },
 })

--- a/apps/docs/app/docs/components/[componentId]/page.tsx
+++ b/apps/docs/app/docs/components/[componentId]/page.tsx
@@ -139,6 +139,7 @@ export default async function ComponentPage({ params }: ComponentPageProps) {
     component.id === 'list' ||
     component.id === 'pager' ||
     component.id === 'tabs' ||
+    component.id === 'text-span' ||
     component.id === 'stepper'
   const usageCode = needsChildren
     ? `import { ${primaryExport} } from '${component.importPath}'\n\nexport function Example() {\n  return (\n    <${primaryExport}>\n      {/* children */}\n    </${primaryExport}>\n  )\n}`

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -5487,6 +5487,50 @@ export function TypographyAlignmentExample() {
     ],
   },
 
+  'text-span': {
+    props: [
+      { name: 'children', type: 'ReactNode', defaultValue: '-', description: 'Content to render inside the span container' },
+      { name: 'color', type: 'TextStyle["color"]', defaultValue: '-', description: 'Inherited text color for nested Typography children' },
+      { name: 'fontWeight', type: 'TextStyle["fontWeight"]', defaultValue: '-', description: 'Inherited font weight for nested Typography children' },
+      { name: 'fontStyle', type: 'TextStyle["fontStyle"]', defaultValue: '-', description: 'Inherited font style for nested Typography children' },
+      { name: 'textTransform', type: 'TextStyle["textTransform"]', defaultValue: '-', description: 'Inherited text transform for nested Typography children' },
+      { name: 'spacing', type: 'number', defaultValue: '-', description: 'Gap between direct children' },
+      { name: 'align', type: '"start" | "center" | "end" | "stretch" | "baseline"', defaultValue: '"start"', description: 'Cross-axis alignment for children' },
+      { name: 'backgroundColor', type: 'ViewStyle["backgroundColor"]', defaultValue: '-', description: 'Background color of the container' },
+      { name: 'style', type: 'StyleProp<ViewStyle>', defaultValue: '-', description: 'Additional container styles' },
+    ],
+    examples: [
+      {
+        title: 'Basic',
+        description: 'Group text nodes and keep consistent spacing/alignment.',
+        code: `import { TextSpan, Typography } from '@xaui/native/typography'
+
+export function TextSpanBasicExample() {
+  return (
+    <TextSpan spacing={8} align="baseline">
+      <Typography>Order total:</Typography>
+      <Typography variant="titleSmall">$24.99</Typography>
+    </TextSpan>
+  )
+}`,
+      },
+      {
+        title: 'Inherited Text Styles',
+        description: 'Apply shared text styles to nested Typography elements.',
+        code: `import { TextSpan, Typography } from '@xaui/native/typography'
+
+export function TextSpanInheritedStyleExample() {
+  return (
+    <TextSpan color="#1d4ed8" fontWeight="700" textTransform="uppercase" spacing={6}>
+      <Typography variant="caption">status</Typography>
+      <Typography variant="bodyMedium">active</Typography>
+    </TextSpan>
+  )
+}`,
+      },
+    ],
+  },
+
   column: {
     props: [
       { name: 'children', type: 'ReactNode', defaultValue: '-', description: 'Content to arrange vertically' },

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -5495,8 +5495,8 @@ export function TypographyAlignmentExample() {
       { name: 'fontStyle', type: 'TextStyle["fontStyle"]', defaultValue: '-', description: 'Inherited font style for nested Typography children' },
       { name: 'textTransform', type: 'TextStyle["textTransform"]', defaultValue: '-', description: 'Inherited text transform for nested Typography children' },
       { name: 'spacing', type: 'number', defaultValue: '-', description: 'Gap between direct children' },
-      { name: 'align', type: '"start" | "center" | "end" | "stretch" | "baseline"', defaultValue: '"start"', description: 'Cross-axis alignment for children' },
-      { name: 'backgroundColor', type: 'ViewStyle["backgroundColor"]', defaultValue: '-', description: 'Background color of the container' },
+      { name: 'align', type: '"left" | "center" | "right" | "justify"', defaultValue: '-', description: 'Text alignment for grouped text' },
+      { name: 'backgroundColor', type: 'ViewStyle["backgroundColor"]', defaultValue: '-', description: 'Background color of the text span container' },
       { name: 'style', type: 'StyleProp<ViewStyle>', defaultValue: '-', description: 'Additional container styles' },
     ],
     examples: [
@@ -5507,7 +5507,7 @@ export function TypographyAlignmentExample() {
 
 export function TextSpanBasicExample() {
   return (
-    <TextSpan spacing={8} align="baseline">
+    <TextSpan spacing={8} align="justify">
       <Typography>Order total:</Typography>
       <Typography variant="titleSmall">$24.99</Typography>
     </TextSpan>

--- a/apps/docs/lib/data/components.ts
+++ b/apps/docs/lib/data/components.ts
@@ -586,6 +586,18 @@ export const components: Component[] = [
     types: ['TypographyProps', 'TypographyVariant', 'TypographyAlign'],
   },
   {
+    id: 'text-span',
+    name: 'TextSpan',
+    description:
+      'Inline text-group container that shares style context with nested Typography.',
+    category: 'Data Display',
+    href: '/docs/components/text-span',
+    status: 'beta',
+    importPath: '@xaui/native/typography',
+    exports: ['TextSpan'],
+    types: ['TextSpanProps', 'TextSpanAlign'],
+  },
+  {
     id: 'column',
     name: 'Column',
     description: 'Vertical flex layout with configurable alignment and spacing.',

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -87,6 +87,7 @@ This table lists all public components exported by `@xaui/native` and their impo
 | `AutocompleteItem` | Suggestion item for `Autocomplete`. | `import { AutocompleteItem } from '@xaui/native/autocomplete'` |
 | `DatePicker` | Date selection input/picker. | `import { DatePicker } from '@xaui/native/datepicker'` |
 | `Typography` | Themed text component with variants. | `import { Typography } from '@xaui/native/typography'` |
+| `TextSpan` | Text group primitive that shares inherited styles across nested typography. | `import { TextSpan } from '@xaui/native/typography'` |
 | `Column` | Vertical flex layout helper. | `import { Column } from '@xaui/native/view'` |
 | `Row` | Horizontal flex layout helper. | `import { Row } from '@xaui/native/view'` |
 | `Spacer` | Flexible space element in layouts. | `import { Spacer } from '@xaui/native/view'` |

--- a/packages/native/src/__tests__/components/typography/text-span.test.tsx
+++ b/packages/native/src/__tests__/components/typography/text-span.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TextSpan, Typography } from '../../../components/typography'
+
+vi.mock('../../../core', () => ({
+  useXUITheme: () => ({
+    colors: {
+      primary: { main: '#1976d2', foreground: '#ffffff', background: '#e3f2fd' },
+      secondary: { main: '#9c27b0', foreground: '#ffffff', background: '#f3e5f5' },
+      tertiary: { main: '#00796b', foreground: '#ffffff', background: '#e0f2f1' },
+      danger: { main: '#d32f2f', foreground: '#ffffff', background: '#ffebee' },
+      warning: { main: '#f57c00', foreground: '#000000', background: '#fff3e0' },
+      success: { main: '#388e3c', foreground: '#ffffff', background: '#e8f5e9' },
+      default: { main: '#ffffff', foreground: '#111827', background: '#f5f5f5' },
+      background: '#ffffff',
+      foreground: '#111827',
+    },
+    fontFamilies: {
+      heading: 'System',
+      body: 'System',
+      mono: 'monospace',
+    },
+    fontWeights: {
+      light: '300',
+      normal: '400',
+      medium: '500',
+      semibold: '600',
+      bold: '700',
+    },
+    fontSizes: {
+      xs: 12,
+      sm: 14,
+      md: 16,
+      lg: 18,
+      xl: 20,
+      '2xl': 24,
+      '3xl': 30,
+      '4xl': 36,
+    },
+  }),
+}))
+
+describe('TextSpan', () => {
+  it('propagates align to nested Typography', () => {
+    const { getByText } = render(
+      <TextSpan align="right">
+        <Typography>Texte aligne</Typography>
+      </TextSpan>
+    )
+
+    const text = getByText('Texte aligne') as HTMLElement
+    expect(text.style.textAlign).toBe('right')
+  })
+
+  it('allows nested Typography to override inherited align', () => {
+    const { getByText } = render(
+      <TextSpan align="right">
+        <Typography align="left">Priorite locale</Typography>
+      </TextSpan>
+    )
+
+    const text = getByText('Priorite locale') as HTMLElement
+    expect(text.style.textAlign).toBe('left')
+  })
+})

--- a/packages/native/src/components/typography/index.ts
+++ b/packages/native/src/components/typography/index.ts
@@ -1,6 +1,8 @@
 export { Typography } from './typography'
+export { TextSpan } from './text-span'
 export type {
   TypographyProps,
   TypographyVariant,
   TypographyAlign,
 } from './typography.type'
+export type { TextSpanProps, TextSpanAlign } from './text-span.type'

--- a/packages/native/src/components/typography/text-span.context.ts
+++ b/packages/native/src/components/typography/text-span.context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+import type { TextStyle } from 'react-native'
+
+export type TextSpanInheritedTextStyle = {
+  color?: TextStyle['color']
+  fontWeight?: TextStyle['fontWeight']
+  fontStyle?: TextStyle['fontStyle']
+  textTransform?: TextStyle['textTransform']
+}
+
+export const TextSpanContext = createContext<TextSpanInheritedTextStyle>({})
+
+export const useTextSpanInheritedStyle = () => {
+  return useContext(TextSpanContext)
+}

--- a/packages/native/src/components/typography/text-span.context.ts
+++ b/packages/native/src/components/typography/text-span.context.ts
@@ -1,11 +1,13 @@
 import { createContext, useContext } from 'react'
 import type { TextStyle } from 'react-native'
+import type { TypographyAlign } from './typography.type'
 
 export type TextSpanInheritedTextStyle = {
   color?: TextStyle['color']
   fontWeight?: TextStyle['fontWeight']
   fontStyle?: TextStyle['fontStyle']
   textTransform?: TextStyle['textTransform']
+  align?: TypographyAlign
 }
 
 export const TextSpanContext = createContext<TextSpanInheritedTextStyle>({})

--- a/packages/native/src/components/typography/text-span.tsx
+++ b/packages/native/src/components/typography/text-span.tsx
@@ -3,12 +3,14 @@ import { View } from 'react-native'
 import { TextSpanContext } from './text-span.context'
 import type { TextSpanAlign, TextSpanProps } from './text-span.type'
 
-const alignToItems: Record<TextSpanAlign, 'baseline' | 'center' | 'flex-end' | 'flex-start' | 'stretch'> = {
-  start: 'flex-start',
+const alignToJustifyContent: Record<
+  TextSpanAlign,
+  'center' | 'flex-end' | 'flex-start' | 'space-between'
+> = {
+  left: 'flex-start',
   center: 'center',
-  end: 'flex-end',
-  stretch: 'stretch',
-  baseline: 'baseline',
+  right: 'flex-end',
+  justify: 'space-between',
 }
 
 export const TextSpan: React.FC<TextSpanProps> = ({
@@ -18,7 +20,7 @@ export const TextSpan: React.FC<TextSpanProps> = ({
   fontStyle,
   textTransform,
   spacing,
-  align = 'start',
+  align,
   backgroundColor,
   style,
 }: TextSpanProps) => {
@@ -27,6 +29,7 @@ export const TextSpan: React.FC<TextSpanProps> = ({
     fontWeight,
     fontStyle,
     textTransform,
+    align,
   }
 
   return (
@@ -34,7 +37,10 @@ export const TextSpan: React.FC<TextSpanProps> = ({
       <View
         style={[
           {
-            alignItems: alignToItems[align],
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            ...(align ? { justifyContent: alignToJustifyContent[align] } : {}),
             ...(typeof spacing === 'number' ? { gap: spacing } : {}),
             ...(backgroundColor ? { backgroundColor } : {}),
           },

--- a/packages/native/src/components/typography/text-span.tsx
+++ b/packages/native/src/components/typography/text-span.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { View } from 'react-native'
+import { TextSpanContext } from './text-span.context'
+import type { TextSpanAlign, TextSpanProps } from './text-span.type'
+
+const alignToItems: Record<TextSpanAlign, 'baseline' | 'center' | 'flex-end' | 'flex-start' | 'stretch'> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  stretch: 'stretch',
+  baseline: 'baseline',
+}
+
+export const TextSpan: React.FC<TextSpanProps> = ({
+  children,
+  color,
+  fontWeight,
+  fontStyle,
+  textTransform,
+  spacing,
+  align = 'start',
+  backgroundColor,
+  style,
+}: TextSpanProps) => {
+  const inheritedTextStyle = {
+    color,
+    fontWeight,
+    fontStyle,
+    textTransform,
+  }
+
+  return (
+    <TextSpanContext.Provider value={inheritedTextStyle}>
+      <View
+        style={[
+          {
+            alignItems: alignToItems[align],
+            ...(typeof spacing === 'number' ? { gap: spacing } : {}),
+            ...(backgroundColor ? { backgroundColor } : {}),
+          },
+          style,
+        ]}
+      >
+        {children}
+      </View>
+    </TextSpanContext.Provider>
+  )
+}
+
+TextSpan.displayName = 'TextSpan'

--- a/packages/native/src/components/typography/text-span.type.ts
+++ b/packages/native/src/components/typography/text-span.type.ts
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react'
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native'
+import type { TypographyAlign } from './typography.type'
 
-export type TextSpanAlign = 'baseline' | 'center' | 'end' | 'start' | 'stretch'
+export type TextSpanAlign = TypographyAlign
 
 export type TextSpanProps = {
   /**
@@ -25,12 +26,11 @@ export type TextSpanProps = {
    */
   textTransform?: TextStyle['textTransform']
   /**
-   * Spacing between children in the container.
+   * Spacing between children.
    */
   spacing?: number
   /**
-   * Cross-axis alignment for children.
-   * @default 'start'
+   * Text alignment for all nested typography unless overridden.
    */
   align?: TextSpanAlign
   /**

--- a/packages/native/src/components/typography/text-span.type.ts
+++ b/packages/native/src/components/typography/text-span.type.ts
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native'
+
+export type TextSpanAlign = 'baseline' | 'center' | 'end' | 'start' | 'stretch'
+
+export type TextSpanProps = {
+  /**
+   * The content to display inside the text span.
+   */
+  children: ReactNode
+  /**
+   * Inherited text color for nested Typography.
+   */
+  color?: TextStyle['color']
+  /**
+   * Inherited text weight for nested Typography.
+   */
+  fontWeight?: TextStyle['fontWeight']
+  /**
+   * Inherited text style for nested Typography.
+   */
+  fontStyle?: TextStyle['fontStyle']
+  /**
+   * Inherited text transform for nested Typography.
+   */
+  textTransform?: TextStyle['textTransform']
+  /**
+   * Spacing between children in the container.
+   */
+  spacing?: number
+  /**
+   * Cross-axis alignment for children.
+   * @default 'start'
+   */
+  align?: TextSpanAlign
+  /**
+   * Background color for the text span container.
+   */
+  backgroundColor?: ViewStyle['backgroundColor']
+  /**
+   * Custom styles for the text span container.
+   */
+  style?: StyleProp<ViewStyle>
+}

--- a/packages/native/src/components/typography/typography.tsx
+++ b/packages/native/src/components/typography/typography.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { Text } from 'react-native'
 import { styles } from './typography.style'
+import { useTextSpanInheritedStyle } from './text-span.context'
 import { useTypographyColor, useTypographyVariantStyles } from './typography.hook'
 import type { TypographyProps } from './typography.type'
 
@@ -11,11 +12,25 @@ export const Typography: React.FC<TypographyProps> = ({
   variant = 'bodyMedium',
   maxLines,
   overflow = 'clip',
+  color,
+  letterSpacing,
+  fontWeight,
+  fontStyle,
+  textDecorationLine,
+  textTransform,
   style,
 }: TypographyProps) => {
-  const color = useTypographyColor(themeColor)
+  const inheritedStyle = useTextSpanInheritedStyle()
+  const themeColorValue = useTypographyColor(themeColor)
   const variantStyles = useTypographyVariantStyles(variant)
-  const colorStyle = { color }
+  const textStyleOverrides = {
+    color: color ?? inheritedStyle.color ?? themeColorValue,
+    letterSpacing,
+    fontWeight: fontWeight ?? inheritedStyle.fontWeight,
+    fontStyle: fontStyle ?? inheritedStyle.fontStyle,
+    textDecorationLine,
+    textTransform: textTransform ?? inheritedStyle.textTransform,
+  }
   const ellipsizeMode = useMemo(() => {
     if (!maxLines) return undefined
     if (overflow === 'clip') return 'clip'
@@ -30,7 +45,7 @@ export const Typography: React.FC<TypographyProps> = ({
         styles.text,
         variantStyles,
         align && { textAlign: align },
-        colorStyle,
+        textStyleOverrides,
         style,
       ]}
     >

--- a/packages/native/src/components/typography/typography.tsx
+++ b/packages/native/src/components/typography/typography.tsx
@@ -23,6 +23,7 @@ export const Typography: React.FC<TypographyProps> = ({
   const inheritedStyle = useTextSpanInheritedStyle()
   const themeColorValue = useTypographyColor(themeColor)
   const variantStyles = useTypographyVariantStyles(variant)
+  const resolvedAlign = align ?? inheritedStyle.align
   const textStyleOverrides = {
     color: color ?? inheritedStyle.color ?? themeColorValue,
     letterSpacing,
@@ -44,7 +45,7 @@ export const Typography: React.FC<TypographyProps> = ({
       style={[
         styles.text,
         variantStyles,
-        align && { textAlign: align },
+        resolvedAlign && { textAlign: resolvedAlign },
         textStyleOverrides,
         style,
       ]}

--- a/packages/native/src/components/typography/typography.type.ts
+++ b/packages/native/src/components/typography/typography.type.ts
@@ -52,4 +52,28 @@ export type TypographyProps = {
    * Custom styles for the text.
    */
   style?: StyleProp<TextStyle>
+  /**
+   * Custom text color override.
+   */
+  color?: TextStyle['color']
+  /**
+   * The spacing between characters.
+   */
+  letterSpacing?: number
+  /**
+   * The text weight.
+   */
+  fontWeight?: TextStyle['fontWeight']
+  /**
+   * The text style.
+   */
+  fontStyle?: TextStyle['fontStyle']
+  /**
+   * Text decoration line.
+   */
+  textDecorationLine?: TextStyle['textDecorationLine']
+  /**
+   * Text transform mode.
+   */
+  textTransform?: TextStyle['textTransform']
 }


### PR DESCRIPTION
- add TextSpan component as a View container for Typography children
  - add TextSpan props: color, fontWeight, fontStyle, textTransform, spacing, align, backgroundColor, style
  - implement TextSpan -> Typography style inheritance via internal context
  - extend Typography props with text overrides: color, letterSpacing, fontWeight, fontStyle, textDecorationLine,
  textTransform
  - preserve Typography prop precedence over inherited TextSpan values
  - export TextSpan and related types from typography index
  - update demo typography screen to showcase TextSpan container + inherited styling