### PR TITLE
fix(core): make PartialXUITheme fields optional

### DIFF
--- a/.changeset/core-optional-partial-theme.md
+++ b/.changeset/core-optional-partial-theme.md
@@ -1,0 +1,5 @@
+---
+'@xaui/core': patch
+---
+
+Make `PartialXUITheme` properties optional to allow partial theme overrides.

--- a/packages/core/src/theme/theme-config.ts
+++ b/packages/core/src/theme/theme-config.ts
@@ -103,16 +103,16 @@ export interface XUITheme {
 }
 
 export type PartialXUITheme = {
-  readonly mode: 'light' | 'dark'
-  readonly palette: typeof colors
-  colors: Partial<ThemeColors>
-  spacing: Partial<ThemeSpacing>
-  borderRadius: Partial<ThemeBorderRadius>
-  borderWidth: Partial<ThemeBorderWidth>
-  fontSizes: Partial<ThemeFontSizes>
-  fontWeights: Partial<ThemeFontWeights>
-  fontFamilies: Partial<ThemeFontFamilies>
-  shadows: Partial<ThemeShadows>
+  readonly mode?: 'light' | 'dark'
+  readonly palette?: typeof colors
+  colors?: Partial<ThemeColors>
+  spacing?: Partial<ThemeSpacing>
+  borderRadius?: Partial<ThemeBorderRadius>
+  borderWidth?: Partial<ThemeBorderWidth>
+  fontSizes?: Partial<ThemeFontSizes>
+  fontWeights?: Partial<ThemeFontWeights>
+  fontFamilies?: Partial<ThemeFontFamilies>
+  shadows?: Partial<ThemeShadows>
 }
 
 export const baseTheme = {


### PR DESCRIPTION
## Summary
- merge latest `main` into this branch
- make `PartialXUITheme` fields optional in core theme config
- add a new `@xaui/core` patch changeset

## Changes
- `packages/core/src/theme/theme-config.ts`
- `.changeset/core-optional-partial-theme.md`

## Why
- allows truly partial theme overrides without requiring full object shapes
