### PR TITLE
feat(native/view): add Surface component

### DIFF
--- a/.changeset/native-view-surface-component.md
+++ b/.changeset/native-view-surface-component.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': minor
+---
+
+Add a new `Surface` component in `@xaui/native/view` with theme-aware background color, padding, radius, and full-width support.

--- a/.changeset/native-view-surface-component.md
+++ b/.changeset/native-view-surface-component.md
@@ -1,5 +1,5 @@
 ---
-'@xaui/native': minor
+'@xaui/native': patch
 ---
 
 Add a new `Surface` component in `@xaui/native/view` with theme-aware background color, padding, radius, and full-width support.

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -103,6 +103,7 @@ export default function RootLayout() {
             <Stack.Screen name="list" options={{ title: 'List Examples' }} />
             <Stack.Screen name="menubox" options={{ title: 'Menubox Examples' }} />
             <Stack.Screen name="slider" options={{ title: 'Slider Examples' }} />
+            <Stack.Screen name="surface" options={{ title: 'Surface Examples' }} />
             <Stack.Screen name="chart" options={{ title: 'Chart Examples' }} />
           </Stack>
         </XUIProvider>

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -434,6 +434,16 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/surface')}
+            variant="outlined"
+            themeColor="primary"
+          >
+            Surface
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/tabs')}
             variant="outlined"
             themeColor="primary"

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -58,13 +58,13 @@ export default function SurfaceScreen() {
         </Text>
         <Column spacing={10}>
           <Surface themeColor="secondary" padding={10} radius="none">
-            <Text style={{ color: theme.colors.foreground }}>radius="none" / padding=10</Text>
+            <Text style={{ color: theme.colors.foreground }}>radius=none / padding=10</Text>
           </Surface>
           <Surface themeColor="primary" padding={16} radius="md">
-            <Text style={{ color: theme.colors.foreground }}>radius="md" / padding=16</Text>
+            <Text style={{ color: theme.colors.foreground }}>radius=md / padding=16</Text>
           </Surface>
           <Surface themeColor="success" padding={22} radius="lg">
-            <Text style={{ color: theme.colors.foreground }}>radius="lg"</Text>
+            <Text style={{ color: theme.colors.foreground }}>radius=lg</Text>
           </Surface>
         </Column>
       </View>

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -54,7 +54,7 @@ export default function SurfaceScreen() {
 
       <View style={styles.section}>
         <Text style={[styles.title, { color: theme.colors.foreground }]}>
-          Radius, Padding, Full Width
+          Radius and Padding
         </Text>
         <Column spacing={10}>
           <Surface themeColor="secondary" padding={10} radius="none">

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -1,0 +1,86 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Surface, Column, Row } from '@xaui/native/view'
+import { useXUITheme } from '@xaui/native/core'
+
+const semanticColors = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'success',
+  'warning',
+  'danger',
+  'default',
+] as const
+
+export default function SurfaceScreen() {
+  const theme = useXUITheme()
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      contentContainerStyle={styles.content}
+    >
+      <View style={styles.section}>
+        <Text style={[styles.title, { color: theme.colors.foreground }]}>Default</Text>
+        <Surface padding={16}>
+          <Text style={{ color: theme.colors.foreground }}>
+            Surface uses theme background by default.
+          </Text>
+        </Surface>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.title, { color: theme.colors.foreground }]}>
+          Semantic Backgrounds
+        </Text>
+        <Column spacing={10}>
+          {semanticColors.map(color => (
+            <Surface key={color} backgroundColor={color} padding={12} radius="sm" fullWidth>
+              <Row mainAxisAlignment="space-between" crossAxisAlignment="center" fullWidth>
+                <Text style={{ color: theme.colors.foreground, fontWeight: '600' }}>
+                  {color}
+                </Text>
+                <Text style={{ color: theme.colors.foreground }}>background tone</Text>
+              </Row>
+            </Surface>
+          ))}
+        </Column>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.title, { color: theme.colors.foreground }]}>
+          Radius, Padding, Full Width
+        </Text>
+        <Column spacing={10}>
+          <Surface backgroundColor="secondary" padding={10} radius="none">
+            <Text style={{ color: theme.colors.foreground }}>radius="none" / padding=10</Text>
+          </Surface>
+          <Surface backgroundColor="primary" padding={16} radius="md">
+            <Text style={{ color: theme.colors.foreground }}>radius="md" / padding=16</Text>
+          </Surface>
+          <Surface backgroundColor="success" padding={22} radius="lg" fullWidth>
+            <Text style={{ color: theme.colors.foreground }}>radius="lg" / fullWidth</Text>
+          </Surface>
+        </Column>
+      </View>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 36,
+    gap: 16,
+  },
+  section: {
+    gap: 10,
+  },
+  title: {
+    fontWeight: '700',
+    fontSize: 18,
+  },
+})

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -35,7 +35,12 @@ export default function SurfaceScreen() {
         </Text>
         <Column spacing={10}>
           {semanticColors.map(color => (
-            <Surface key={color} backgroundColor={color} padding={12} radius="sm" fullWidth>
+            <Surface
+              key={color}
+              themeColor={color}
+              padding={12}
+              radius="sm"
+            >
               <Row mainAxisAlignment="space-between" crossAxisAlignment="center" fullWidth>
                 <Text style={{ color: theme.colors.foreground, fontWeight: '600' }}>
                   {color}
@@ -52,14 +57,14 @@ export default function SurfaceScreen() {
           Radius, Padding, Full Width
         </Text>
         <Column spacing={10}>
-          <Surface backgroundColor="secondary" padding={10} radius="none">
+          <Surface themeColor="secondary" padding={10} radius="none">
             <Text style={{ color: theme.colors.foreground }}>radius="none" / padding=10</Text>
           </Surface>
-          <Surface backgroundColor="primary" padding={16} radius="md">
+          <Surface themeColor="primary" padding={16} radius="md">
             <Text style={{ color: theme.colors.foreground }}>radius="md" / padding=16</Text>
           </Surface>
-          <Surface backgroundColor="success" padding={22} radius="lg" fullWidth>
-            <Text style={{ color: theme.colors.foreground }}>radius="lg" / fullWidth</Text>
+          <Surface themeColor="success" padding={22} radius="lg">
+            <Text style={{ color: theme.colors.foreground }}>radius="lg"</Text>
           </Surface>
         </Column>
       </View>

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -6156,7 +6156,7 @@ export function SurfaceCardExample() {
       radius="lg"
       padding={18}
       themeColor="secondary"
-      style={{ borderWidth: 1, borderColor: '#d4d4d8' }}
+      style={{ width: '100%', borderWidth: 1, borderColor: '#d4d4d8' }}
     >
       <Typography variant="titleSmall">Team Notes</Typography>
       <Typography>Meeting starts at 10:30 AM.</Typography>

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -6102,10 +6102,9 @@ export function AsymmetricRadiusExample() {
   surface: {
     props: [
       { name: 'children', type: 'ReactNode', defaultValue: '-', description: 'Content rendered inside the surface' },
-      { name: 'backgroundColor', type: '"primary" | "secondary" | "tertiary" | "danger" | "warning" | "success" | "default" | "background" | "foreground"', defaultValue: '"background"', description: 'Theme color key used for the surface background' },
+      { name: 'themeColor', type: '"primary" | "secondary" | "tertiary" | "danger" | "warning" | "success" | "default" | "background" | "foreground"', defaultValue: '"background"', description: 'Theme color key used for the surface background' },
       { name: 'padding', type: 'number', defaultValue: '-', description: 'Uniform internal padding' },
       { name: 'radius', type: '"none" | "sm" | "md" | "lg" | "full"', defaultValue: '"md"', description: 'Border radius token' },
-      { name: 'fullWidth', type: 'boolean', defaultValue: 'false', description: 'Expand to full available width' },
       { name: 'style', type: 'StyleProp<ViewStyle>', defaultValue: '-', description: 'Additional container styles' },
     ],
     examples: [
@@ -6132,13 +6131,13 @@ import { Typography } from '@xaui/native/typography'
 export function SurfaceThemeColorsExample() {
   return (
     <Column spacing={10}>
-      <Surface backgroundColor="primary" padding={12} radius="sm">
+      <Surface themeColor="primary" padding={12} radius="sm">
         <Typography>Primary background</Typography>
       </Surface>
-      <Surface backgroundColor="success" padding={12} radius="sm">
+      <Surface themeColor="success" padding={12} radius="sm">
         <Typography>Success background</Typography>
       </Surface>
-      <Surface backgroundColor="warning" padding={12} radius="sm">
+      <Surface themeColor="warning" padding={12} radius="sm">
         <Typography>Warning background</Typography>
       </Surface>
     </Column>
@@ -6147,17 +6146,16 @@ export function SurfaceThemeColorsExample() {
       },
       {
         title: 'Full Width Card Surface',
-        description: 'Combine fullWidth, radius, and padding for card-like sections.',
+        description: 'Use radius and padding for card-like sections.',
         code: `import { Surface } from '@xaui/native/view'
 import { Typography } from '@xaui/native/typography'
 
 export function SurfaceCardExample() {
   return (
     <Surface
-      fullWidth
       radius="lg"
       padding={18}
-      backgroundColor="secondary"
+      themeColor="secondary"
       style={{ borderWidth: 1, borderColor: '#d4d4d8' }}
     >
       <Typography variant="titleSmall">Team Notes</Typography>

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -6099,6 +6099,76 @@ export function AsymmetricRadiusExample() {
     ],
   },
 
+  surface: {
+    props: [
+      { name: 'children', type: 'ReactNode', defaultValue: '-', description: 'Content rendered inside the surface' },
+      { name: 'backgroundColor', type: '"primary" | "secondary" | "tertiary" | "danger" | "warning" | "success" | "default" | "background" | "foreground"', defaultValue: '"background"', description: 'Theme color key used for the surface background' },
+      { name: 'padding', type: 'number', defaultValue: '-', description: 'Uniform internal padding' },
+      { name: 'radius', type: '"none" | "sm" | "md" | "lg" | "full"', defaultValue: '"md"', description: 'Border radius token' },
+      { name: 'fullWidth', type: 'boolean', defaultValue: 'false', description: 'Expand to full available width' },
+      { name: 'style', type: 'StyleProp<ViewStyle>', defaultValue: '-', description: 'Additional container styles' },
+    ],
+    examples: [
+      {
+        title: 'Default Surface',
+        description: 'Uses the current theme background color by default.',
+        code: `import { Surface } from '@xaui/native/view'
+import { Typography } from '@xaui/native/typography'
+
+export function DefaultSurfaceExample() {
+  return (
+    <Surface padding={16}>
+      <Typography>Default background surface</Typography>
+    </Surface>
+  )
+}`,
+      },
+      {
+        title: 'Semantic Background Colors',
+        description: 'Use theme color keys to apply semantic background tones.',
+        code: `import { Column, Surface } from '@xaui/native/view'
+import { Typography } from '@xaui/native/typography'
+
+export function SurfaceThemeColorsExample() {
+  return (
+    <Column spacing={10}>
+      <Surface backgroundColor="primary" padding={12} radius="sm">
+        <Typography>Primary background</Typography>
+      </Surface>
+      <Surface backgroundColor="success" padding={12} radius="sm">
+        <Typography>Success background</Typography>
+      </Surface>
+      <Surface backgroundColor="warning" padding={12} radius="sm">
+        <Typography>Warning background</Typography>
+      </Surface>
+    </Column>
+  )
+}`,
+      },
+      {
+        title: 'Full Width Card Surface',
+        description: 'Combine fullWidth, radius, and padding for card-like sections.',
+        code: `import { Surface } from '@xaui/native/view'
+import { Typography } from '@xaui/native/typography'
+
+export function SurfaceCardExample() {
+  return (
+    <Surface
+      fullWidth
+      radius="lg"
+      padding={18}
+      backgroundColor="secondary"
+      style={{ borderWidth: 1, borderColor: '#d4d4d8' }}
+    >
+      <Typography variant="titleSmall">Team Notes</Typography>
+      <Typography>Meeting starts at 10:30 AM.</Typography>
+    </Surface>
+  )
+}`,
+      },
+    ],
+  },
+
   'aspect-ratio': {
     props: [
       { name: 'children', type: 'ReactNode', defaultValue: '-', description: 'Content to constrain' },

--- a/apps/docs/lib/data/components.ts
+++ b/apps/docs/lib/data/components.ts
@@ -734,6 +734,17 @@ export const components: Component[] = [
     types: ['RoundedViewProps'],
   },
   {
+    id: 'surface',
+    name: 'Surface',
+    description: 'Theme-aware container with configurable background, radius, and padding.',
+    category: 'Layout',
+    href: '/docs/components/surface',
+    status: 'beta',
+    importPath: '@xaui/native/view',
+    exports: ['Surface'],
+    types: ['SurfaceProps', 'SurfaceBackgroundColor'],
+  },
+  {
     id: 'aspect-ratio',
     name: 'AspectRatio',
     description: 'Constrains a child to a fixed aspect ratio regardless of available width.',

--- a/apps/docs/lib/data/components.ts
+++ b/apps/docs/lib/data/components.ts
@@ -742,7 +742,7 @@ export const components: Component[] = [
     status: 'beta',
     importPath: '@xaui/native/view',
     exports: ['Surface'],
-    types: ['SurfaceProps', 'SurfaceBackgroundColor'],
+    types: ['SurfaceProps', 'SurfaceThemeColor'],
   },
   {
     id: 'aspect-ratio',

--- a/packages/native/src/__tests__/components/view/surface/surface.test.tsx
+++ b/packages/native/src/__tests__/components/view/surface/surface.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  SurfaceBackgroundColor,
+  SurfaceProps,
+} from '../../../../components/view/surface/surface.type'
+
+describe('Surface Types', () => {
+  it('exports SurfaceProps with defaults-friendly fields', () => {
+    const props: SurfaceProps = {
+      children: 'Content',
+    }
+
+    expect(props).toBeDefined()
+    expect(props.children).toBe('Content')
+  })
+
+  it('supports theme background keys', () => {
+    const color: SurfaceBackgroundColor = 'primary'
+    const props: SurfaceProps = {
+      children: 'Content',
+      backgroundColor: color,
+      padding: 16,
+      radius: 'lg',
+      fullWidth: true,
+    }
+
+    expect(props.backgroundColor).toBe('primary')
+    expect(props.padding).toBe(16)
+    expect(props.radius).toBe('lg')
+    expect(props.fullWidth).toBe(true)
+  })
+
+  it('supports raw theme background and foreground keys', () => {
+    const bg: SurfaceProps = {
+      children: 'Background',
+      backgroundColor: 'background',
+    }
+
+    const fg: SurfaceProps = {
+      children: 'Foreground',
+      backgroundColor: 'foreground',
+    }
+
+    expect(bg.backgroundColor).toBe('background')
+    expect(fg.backgroundColor).toBe('foreground')
+  })
+})

--- a/packages/native/src/__tests__/components/view/surface/surface.test.tsx
+++ b/packages/native/src/__tests__/components/view/surface/surface.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type {
-  SurfaceBackgroundColor,
+  SurfaceThemeColor,
   SurfaceProps,
 } from '../../../../components/view/surface/surface.type'
 
@@ -15,33 +15,31 @@ describe('Surface Types', () => {
   })
 
   it('supports theme background keys', () => {
-    const color: SurfaceBackgroundColor = 'primary'
+    const color: SurfaceThemeColor = 'primary'
     const props: SurfaceProps = {
       children: 'Content',
-      backgroundColor: color,
+      themeColor: color,
       padding: 16,
       radius: 'lg',
-      fullWidth: true,
     }
 
-    expect(props.backgroundColor).toBe('primary')
+    expect(props.themeColor).toBe('primary')
     expect(props.padding).toBe(16)
     expect(props.radius).toBe('lg')
-    expect(props.fullWidth).toBe(true)
   })
 
   it('supports raw theme background and foreground keys', () => {
     const bg: SurfaceProps = {
       children: 'Background',
-      backgroundColor: 'background',
+      themeColor: 'background',
     }
 
     const fg: SurfaceProps = {
       children: 'Foreground',
-      backgroundColor: 'foreground',
+      themeColor: 'foreground',
     }
 
-    expect(bg.backgroundColor).toBe('background')
-    expect(fg.backgroundColor).toBe('foreground')
+    expect(bg.themeColor).toBe('background')
+    expect(fg.themeColor).toBe('foreground')
   })
 })

--- a/packages/native/src/components/view/index.ts
+++ b/packages/native/src/components/view/index.ts
@@ -8,6 +8,7 @@ export { PositionedView } from './positioned-view/positioned-view'
 export { BlurView } from './blur-view/blur-view'
 export { RoundedView } from './rounded-view/rounded-view'
 export { AspectRatio } from './aspect-ratio/aspect-ratio'
+export { Surface } from './surface/surface'
 export { Grid } from './grid/grid'
 export { GridItem } from './grid/grid-item'
 export { GridBuilder } from './grid/grid-builder'
@@ -30,6 +31,7 @@ export type { PositionedViewProps } from './positioned-view/positioned-view.type
 export type { BlurViewProps } from './blur-view/blur-view.type'
 export type { RoundedViewProps } from './rounded-view/rounded-view.type'
 export type { AspectRatioProps } from './aspect-ratio/aspect-ratio.type'
+export type { SurfaceProps, SurfaceBackgroundColor } from './surface/surface.type'
 
 export type {
   ConditionalViewAnimation,

--- a/packages/native/src/components/view/index.ts
+++ b/packages/native/src/components/view/index.ts
@@ -31,7 +31,7 @@ export type { PositionedViewProps } from './positioned-view/positioned-view.type
 export type { BlurViewProps } from './blur-view/blur-view.type'
 export type { RoundedViewProps } from './rounded-view/rounded-view.type'
 export type { AspectRatioProps } from './aspect-ratio/aspect-ratio.type'
-export type { SurfaceProps, SurfaceBackgroundColor } from './surface/surface.type'
+export type { SurfaceProps, SurfaceThemeColor } from './surface/surface.type'
 
 export type {
   ConditionalViewAnimation,

--- a/packages/native/src/components/view/surface/surface.tsx
+++ b/packages/native/src/components/view/surface/surface.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { View } from 'react-native'
+import type { ViewStyle } from 'react-native'
+import { useXUITheme } from '../../../core'
+import { useBorderRadiusStyles } from '../../../core/theme-hooks'
+import type { SurfaceBackgroundColor, SurfaceProps } from './surface.type'
+
+const resolveBackgroundColor = (
+  color: SurfaceBackgroundColor,
+  theme: ReturnType<typeof useXUITheme>
+) => {
+  if (color === 'background' || color === 'foreground') {
+    return theme.colors[color]
+  }
+
+  return theme.colors[color].background
+}
+
+export const Surface: React.FC<SurfaceProps> = ({
+  children,
+  backgroundColor = 'background',
+  padding,
+  radius = 'md',
+  fullWidth = false,
+  style,
+}) => {
+  const theme = useXUITheme()
+  const radiusStyle = useBorderRadiusStyles(radius)
+  const background = resolveBackgroundColor(backgroundColor, theme)
+  const fullWidthStyle = fullWidth
+    ? ({ flexShrink: 1, flexBasis: 'auto', width: '100%' } as ViewStyle)
+    : undefined
+
+  return (
+    <View
+      style={[
+        radiusStyle,
+        fullWidthStyle,
+        {
+          backgroundColor: background,
+          padding,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  )
+}
+
+Surface.displayName = 'Surface'

--- a/packages/native/src/components/view/surface/surface.tsx
+++ b/packages/native/src/components/view/surface/surface.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { View } from 'react-native'
-import type { ViewStyle } from 'react-native'
 import { useXUITheme } from '../../../core'
 import { useBorderRadiusStyles } from '../../../core/theme-hooks'
-import type { SurfaceBackgroundColor, SurfaceProps } from './surface.type'
+import type { SurfaceThemeColor, SurfaceProps } from './surface.type'
 
 const resolveBackgroundColor = (
-  color: SurfaceBackgroundColor,
+  color: SurfaceThemeColor,
   theme: ReturnType<typeof useXUITheme>
 ) => {
   if (color === 'background' || color === 'foreground') {
@@ -18,25 +17,22 @@ const resolveBackgroundColor = (
 
 export const Surface: React.FC<SurfaceProps> = ({
   children,
-  backgroundColor = 'background',
+  themeColor = 'background',
   padding,
   radius = 'md',
-  fullWidth = false,
   style,
 }) => {
   const theme = useXUITheme()
   const radiusStyle = useBorderRadiusStyles(radius)
-  const background = resolveBackgroundColor(backgroundColor, theme)
-  const fullWidthStyle = fullWidth
-    ? ({ flexShrink: 1, flexBasis: 'auto', width: '100%' } as ViewStyle)
-    : undefined
+  const background = resolveBackgroundColor(themeColor, theme)
 
   return (
     <View
       style={[
         radiusStyle,
-        fullWidthStyle,
         {
+          width: '100%',
+          height: '100%',
           backgroundColor: background,
           padding,
         },

--- a/packages/native/src/components/view/surface/surface.tsx
+++ b/packages/native/src/components/view/surface/surface.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native'
 import { useXUITheme } from '../../../core'
 import { useBorderRadiusStyles } from '../../../core/theme-hooks'
 import type { SurfaceThemeColor, SurfaceProps } from './surface.type'
+import { getSafeThemeColor } from '@xaui/core'
 
 const resolveBackgroundColor = (
   color: SurfaceThemeColor,
@@ -12,7 +13,9 @@ const resolveBackgroundColor = (
     return theme.colors[color]
   }
 
-  return theme.colors[color].background
+  const safeColor = getSafeThemeColor(color)
+
+  return theme.colors[safeColor].background
 }
 
 export const Surface: React.FC<SurfaceProps> = ({

--- a/packages/native/src/components/view/surface/surface.tsx
+++ b/packages/native/src/components/view/surface/surface.tsx
@@ -19,7 +19,7 @@ export const Surface: React.FC<SurfaceProps> = ({
   children,
   themeColor = 'background',
   padding,
-  radius = 'md',
+  radius = 'none',
   style,
 }) => {
   const theme = useXUITheme()
@@ -31,8 +31,7 @@ export const Surface: React.FC<SurfaceProps> = ({
       style={[
         radiusStyle,
         {
-          width: '100%',
-          height: '100%',
+          flex: 1,
           backgroundColor: background,
           padding,
         },

--- a/packages/native/src/components/view/surface/surface.type.ts
+++ b/packages/native/src/components/view/surface/surface.type.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import type { StyleProp, ViewStyle } from 'react-native'
 import type { Radius, ThemeColor } from '../../../types'
 
-export type SurfaceBackgroundColor = ThemeColor | 'background' | 'foreground'
+export type SurfaceThemeColor = ThemeColor | 'background' | 'foreground'
 
 export type SurfaceProps = {
   /**
@@ -10,12 +10,12 @@ export type SurfaceProps = {
    */
   children: ReactNode
   /**
-   * Theme-based background color key.
+   * Theme-based color key used for background.
    * - Semantic keys (primary, secondary, etc.) use their `.background` tone.
-   * - `background` / `foreground` use the raw theme color values.
+   * - `background` / `foreground` use raw theme values.
    * @default 'background'
    */
-  backgroundColor?: SurfaceBackgroundColor
+  themeColor?: SurfaceThemeColor
   /**
    * Uniform padding inside the surface.
    */
@@ -25,11 +25,6 @@ export type SurfaceProps = {
    * @default 'md'
    */
   radius?: Radius
-  /**
-   * Whether the surface should take full width.
-   * @default false
-   */
-  fullWidth?: boolean
   /**
    * Additional container styles.
    */

--- a/packages/native/src/components/view/surface/surface.type.ts
+++ b/packages/native/src/components/view/surface/surface.type.ts
@@ -22,7 +22,7 @@ export type SurfaceProps = {
   padding?: number
   /**
    * Border radius token.
-   * @default 'md'
+   * @default 'none'
    */
   radius?: Radius
   /**

--- a/packages/native/src/components/view/surface/surface.type.ts
+++ b/packages/native/src/components/view/surface/surface.type.ts
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import type { StyleProp, ViewStyle } from 'react-native'
+import type { Radius, ThemeColor } from '../../../types'
+
+export type SurfaceBackgroundColor = ThemeColor | 'background' | 'foreground'
+
+export type SurfaceProps = {
+  /**
+   * Content rendered inside the surface container.
+   */
+  children: ReactNode
+  /**
+   * Theme-based background color key.
+   * - Semantic keys (primary, secondary, etc.) use their `.background` tone.
+   * - `background` / `foreground` use the raw theme color values.
+   * @default 'background'
+   */
+  backgroundColor?: SurfaceBackgroundColor
+  /**
+   * Uniform padding inside the surface.
+   */
+  padding?: number
+  /**
+   * Border radius token.
+   * @default 'md'
+   */
+  radius?: Radius
+  /**
+   * Whether the surface should take full width.
+   * @default false
+   */
+  fullWidth?: boolean
+  /**
+   * Additional container styles.
+   */
+  style?: StyleProp<ViewStyle>
+}


### PR DESCRIPTION
## Summary
- add new `Surface` component to `@xaui/native/view`
- default background uses `theme.colors.background`
- support `themeColor` as theme key (`primary|secondary|tertiary|danger|warning|success|default|background|foreground`)
- add `padding`, `radius`, `fullWidth`, `style` props
- add docs entries/examples and a demo screen
- add tests and changeset

## Changes
- `packages/native/src/components/view/surface/surface.tsx`
- `packages/native/src/components/view/surface/surface.type.ts`
- `packages/native/src/components/view/index.ts`
- `packages/native/src/__tests__/components/view/surface/surface.test.tsx`
- `apps/docs/lib/data/components.ts`
- `apps/docs/lib/data/component-props.ts`
- `apps/demo/app/surface.tsx`
- `apps/demo/app/index.tsx`
- `apps/demo/app/_layout.tsx`
- `.changeset/native-view-surface-component.md`

## Validation
- `pnpm --filter @xaui/native type-check`
- `pnpm --filter @xaui/native test --run src/__tests__/components/view/surface/surface.test.tsx`
