### PR TITLE
fix(button): startContent and endContent not rendering with default spinnerPlacement

### DIFF
--- a/.changeset/fix-button-start-end-content.md
+++ b/.changeset/fix-button-start-end-content.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+fix(button): startContent and endContent props not rendering due to inverted visibility conditions

--- a/apps/demo/app/buttons.tsx
+++ b/apps/demo/app/buttons.tsx
@@ -97,6 +97,76 @@ export default function ButtonsScreen() {
           </Button>
         </View>
       </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>
+          Start & End Content
+        </Text>
+        <View style={{ gap: theme.spacing.md }}>
+          <Button
+            themeColor="primary"
+            variant="solid"
+            startContent={<Text style={styles.icon}>★</Text>}
+          >
+            Start Icon
+          </Button>
+          <Button
+            themeColor="secondary"
+            variant="solid"
+            endContent={<Text style={styles.icon}>→</Text>}
+          >
+            End Icon
+          </Button>
+          <Button
+            themeColor="success"
+            variant="outlined"
+            startContent={<Text style={styles.iconOutlined}>✓</Text>}
+            endContent={<Text style={styles.iconOutlined}>↗</Text>}
+          >
+            Both Sides
+          </Button>
+          <Button
+            themeColor="danger"
+            variant="flat"
+            startContent={<Text style={styles.iconFlat}>✕</Text>}
+          >
+            Delete
+          </Button>
+          <Button
+            themeColor="warning"
+            variant="light"
+            endContent={<Text style={styles.iconLight}>⚡</Text>}
+          >
+            Quick Action
+          </Button>
+          <Button
+            isLoading={isLoading}
+            spinnerPlacement="start"
+            startContent={<Text style={styles.icon}>★</Text>}
+            onPress={() => {
+              setIsLoading(true)
+              setTimeout(() => setIsLoading(false), 1500)
+            }}
+            variant="solid"
+            themeColor="primary"
+          >
+            Spinner Start (hides startContent)
+          </Button>
+          <Button
+            isLoading={isLoading}
+            spinnerPlacement="end"
+            endContent={<Text style={styles.icon}>→</Text>}
+            onPress={() => {
+              setIsLoading(true)
+              setTimeout(() => setIsLoading(false), 1500)
+            }}
+            variant="solid"
+            themeColor="secondary"
+          >
+            Spinner End (hides endContent)
+          </Button>
+        </View>
+      </View>
     </ScrollView>
   )
 }
@@ -115,5 +185,22 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     marginBottom: 12,
+  },
+  icon: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  iconOutlined: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  iconFlat: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  iconLight: {
+    fontSize: 14,
+    fontWeight: 'bold',
   },
 })

--- a/packages/native/src/components/button/button.tsx
+++ b/packages/native/src/components/button/button.tsx
@@ -86,7 +86,7 @@ export const Button: React.FC<ButtonProps> = ({
           ]}
         >
           <View style={styles.contentContainer}>
-            {startContent && !isLoading && spinnerPlacement !== 'start' && (
+            {startContent && (!isLoading || spinnerPlacement !== 'start') && (
               <View style={styles.startContent}>{startContent}</View>
             )}
 
@@ -109,7 +109,7 @@ export const Button: React.FC<ButtonProps> = ({
               <View style={styles.spinner}>{spinner}</View>
             )}
 
-            {endContent && !isLoading && spinnerPlacement !== 'end' && (
+            {endContent && (!isLoading || spinnerPlacement !== 'end') && (
               <View style={styles.endContent}>{endContent}</View>
             )}
           </View>


### PR DESCRIPTION
## What

Fix `startContent` and `endContent` props on the `Button` component — both were never rendering under the default configuration.

## Why

The visibility conditions were logically inverted:

- `startContent && !isLoading && spinnerPlacement !== 'start'` — since `spinnerPlacement` defaults to `'start'`, this was always `false`, making `startContent` invisible at all times
- Same issue for `endContent` when loading was active but the spinner was at the opposite side

## How

Corrected both conditions to hide the content slot only when the spinner actively occupies it:

```ts
// before
startContent && !isLoading && spinnerPlacement !== 'start'
endContent   && !isLoading && spinnerPlacement !== 'end'

// after
startContent && (!isLoading || spinnerPlacement !== 'start')
endContent   && (!isLoading || spinnerPlacement !== 'end')
```

Also added a **"Start & End Content"** section in the demo (`apps/demo/app/buttons.tsx`) with examples covering:
- `startContent` only
- `endContent` only
- Both sides simultaneously
- `flat` and `light` variants
- Spinner interaction at `start` and `end` placements