### PR TITLE
Restore fullWidth behavior for native view utilities

### DIFF
--- a/.changeset/remove-full-width-in-view-utils.md
+++ b/.changeset/remove-full-width-in-view-utils.md
@@ -2,4 +2,4 @@
 '@xaui/native': patch
 ---
 
-Simplify native view layout primitives by removing `fullWidth` from `Column`, `Padding`, `Margin`, and `Center`, and make these components default to `flex: 1` for consistent space usage in vertical layouts.
+Keep `Column`, `Padding`, `Margin`, and `Center` defaulting to `flex: 1`, and standardize `fullWidth` to apply only `width: '100%'` for predictable layout behavior.

--- a/.changeset/remove-full-width-in-view-utils.md
+++ b/.changeset/remove-full-width-in-view-utils.md
@@ -1,5 +1,0 @@
----
-'@xaui/native': patch
----
-
-Keep `Column`, `Padding`, `Margin`, and `Center` defaulting to `flex: 1`, and standardize `fullWidth` to apply only `width: '100%'` for predictable layout behavior.

--- a/.changeset/restore-fullwidth-view-utils.md
+++ b/.changeset/restore-fullwidth-view-utils.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+Restore `fullWidth` on `Column`, `Padding`, `Margin`, and `Center` with a simplified behavior that applies only `width: '100%'`. Keep default `flex: 1` layout behavior and update docs/types to match.

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -10131,6 +10131,12 @@ export function TextSpanInheritedStyleExample() {
         description: 'Reverse the order of children',
       },
       {
+        name: 'fullWidth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Expand to full available width',
+      },
+      {
         name: 'style',
         type: 'ViewStyle',
         defaultValue: '-',
@@ -10346,6 +10352,12 @@ export function WeightedSpacerExample() {
         description: 'Content to center inside the container',
       },
       {
+        name: 'fullWidth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Expand to full available width',
+      },
+      {
         name: 'style',
         type: 'StyleProp<ViewStyle>',
         defaultValue: '-',
@@ -10430,6 +10442,12 @@ export function CenterCardExample() {
         description: 'Left padding',
       },
       {
+        name: 'fullWidth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Expand to full available width',
+      },
+      {
         name: 'style',
         type: 'StyleProp<ViewStyle>',
         defaultValue: '-',
@@ -10512,6 +10530,12 @@ export function DirectionalPaddingExample() {
         type: 'number',
         defaultValue: '-',
         description: 'Left margin',
+      },
+      {
+        name: 'fullWidth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Expand to full available width',
       },
       {
         name: 'style',

--- a/packages/native/src/__tests__/components/view/center/center.test.tsx
+++ b/packages/native/src/__tests__/components/view/center/center.test.tsx
@@ -5,9 +5,11 @@ describe('Center Types', () => {
   it('exports CenterProps type', () => {
     const props: CenterProps = {
       children: 'Center',
+      fullWidth: true,
     }
 
     expect(props).toBeDefined()
+    expect(props.fullWidth).toBe(true)
   })
 
   it('accepts style props', () => {

--- a/packages/native/src/__tests__/components/view/column/column.test.tsx
+++ b/packages/native/src/__tests__/components/view/column/column.test.tsx
@@ -9,10 +9,12 @@ describe('Column Types', () => {
       crossAxisAlignment: 'center',
       spacing: 8,
       reverse: false,
+      fullWidth: true,
     }
 
     expect(props).toBeDefined()
     expect(props.spacing).toBe(8)
+    expect(props.fullWidth).toBe(true)
   })
 
   it('accepts style props', () => {

--- a/packages/native/src/components/view/center/center.tsx
+++ b/packages/native/src/components/view/center/center.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { View } from 'react-native'
 import type { CenterProps } from './center.type'
 
-export const Center: React.FC<CenterProps> = ({ children, style }) => {
+export const Center: React.FC<CenterProps> = ({ children, fullWidth, style }) => {
+  const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
+
   return (
     <View
       style={[
@@ -11,6 +13,7 @@ export const Center: React.FC<CenterProps> = ({ children, style }) => {
           alignItems: 'center',
           justifyContent: 'center',
         },
+        fullWidthStyle,
         style,
       ]}
     >

--- a/packages/native/src/components/view/center/center.type.ts
+++ b/packages/native/src/components/view/center/center.type.ts
@@ -7,6 +7,11 @@ export type CenterProps = {
    */
   children: ReactNode
   /**
+   * Whether the centered container should take the full width of its parent.
+   * @default false
+   */
+  fullWidth?: boolean
+  /**
    * Additional style for the container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/column/column.tsx
+++ b/packages/native/src/components/view/column/column.tsx
@@ -9,9 +9,11 @@ export const Column: React.FC<ColumnProps> = ({
   crossAxisAlignment,
   spacing,
   reverse = false,
+  fullWidth,
   style,
 }) => {
   const gapStyle = spacing === undefined ? undefined : { gap: spacing }
+  const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
 
   return (
     <View
@@ -22,6 +24,7 @@ export const Column: React.FC<ColumnProps> = ({
           justifyContent: resolveMainAxisAlignment(mainAxisAlignment),
           alignItems: resolveCrossAxisAlignment(crossAxisAlignment),
         },
+        fullWidthStyle,
         gapStyle,
         style,
       ]}

--- a/packages/native/src/components/view/layout-types.ts
+++ b/packages/native/src/components/view/layout-types.ts
@@ -46,4 +46,4 @@ export type RowProps = {
   style?: ViewStyle
 }
 
-export type ColumnProps = Omit<RowProps, 'fullWidth'>
+export type ColumnProps = RowProps

--- a/packages/native/src/components/view/margin/margin.tsx
+++ b/packages/native/src/components/view/margin/margin.tsx
@@ -11,8 +11,11 @@ export const Margin: React.FC<MarginProps> = ({
   right,
   bottom,
   left,
+  fullWidth,
   style,
 }) => {
+  const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
+
   return (
     <View
       style={[
@@ -26,6 +29,7 @@ export const Margin: React.FC<MarginProps> = ({
           marginBottom: bottom,
           marginLeft: left,
         },
+        fullWidthStyle,
         style,
       ]}
     >

--- a/packages/native/src/components/view/margin/margin.type.ts
+++ b/packages/native/src/components/view/margin/margin.type.ts
@@ -35,6 +35,11 @@ export type MarginProps = {
    */
   left?: number
   /**
+   * Whether the margin container should take the full width of its parent.
+   * @default false
+   */
+  fullWidth?: boolean
+  /**
    * Custom style for the margin container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/padding/padding.tsx
+++ b/packages/native/src/components/view/padding/padding.tsx
@@ -11,8 +11,11 @@ export const Padding: React.FC<PaddingProps> = ({
   right,
   bottom,
   left,
+  fullWidth,
   style,
 }) => {
+  const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
+
   return (
     <View
       style={[
@@ -26,6 +29,7 @@ export const Padding: React.FC<PaddingProps> = ({
           paddingBottom: bottom,
           paddingLeft: left,
         },
+        fullWidthStyle,
         style,
       ]}
     >

--- a/packages/native/src/components/view/padding/padding.type.ts
+++ b/packages/native/src/components/view/padding/padding.type.ts
@@ -35,6 +35,11 @@ export type PaddingProps = {
    */
   left?: number
   /**
+   * Whether the padding container should take the full width of its parent.
+   * @default false
+   */
+  fullWidth?: boolean
+  /**
    * Custom style for the padding container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/surface/surface.tsx
+++ b/packages/native/src/components/view/surface/surface.tsx
@@ -34,11 +34,7 @@ export const Surface: React.FC<SurfaceProps> = ({
     <View
       style={[
         radiusStyle,
-        fullWidth && {
-          flexShrink: 1,
-          flexBasis: 'auto',
-          width: '100%',
-        },
+        fullWidth && { flexShrink: 1, flexBasis: 'auto', width: '100%' },
         {
           backgroundColor: background,
           padding,


### PR DESCRIPTION
## Summary
- restore `fullWidth` support for `Column`, `Padding`, `Margin`, and `Center` in `@xaui/native/view` while keeping their default `flex: 1` behavior
- standardize `fullWidth` so it only applies `width: '100%'`, and update related prop types and tests
- update docs prop tables for layout components and add a changeset for the `@xaui/native` patch release

## Testing
- pnpm --filter @xaui/native exec eslint src/components/view/column/column.tsx src/components/view/layout-types.ts src/components/view/padding/padding.tsx src/components/view/padding/padding.type.ts src/components/view/margin/margin.tsx src/components/view/margin/margin.type.ts src/components/view/center/center.tsx src/components/view/center/center.type.ts src/__tests__/components/view/column/column.test.tsx src/__tests__/components/view/center/center.test.tsx
- pnpm --filter docs exec eslint lib/data/component-props.ts lib/data/components.ts
- pnpm --filter @xaui/native exec vitest run src/__tests__/components/view/column/column.test.tsx src/__tests__/components/view/center/center.test.tsx src/__tests__/components/view/padding/padding.test.tsx