### PR TITLE
Add fullWidth and string dimensions support to SizedBox

### DIFF
--- a/.changeset/sized-box-fullwidth-string-dimensions.md
+++ b/.changeset/sized-box-fullwidth-string-dimensions.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+Add `fullWidth` support to `SizedBox` with a simplified behavior that applies only `width: '100%'`, and allow string dimension values for `width`/`height` (`number | string`).

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -10586,15 +10586,21 @@ export function DirectionalMarginExample() {
       },
       {
         name: 'width',
-        type: 'number',
+        type: 'number | string',
         defaultValue: '-',
-        description: 'Fixed width in pixels',
+        description: 'Width value (number in px or string, e.g. "100%")',
       },
       {
         name: 'height',
-        type: 'number',
+        type: 'number | string',
         defaultValue: '-',
-        description: 'Fixed height in pixels',
+        description: 'Height value (number in px or string, e.g. "50%")',
+      },
+      {
+        name: 'fullWidth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Expand to full available width',
       },
       {
         name: 'style',

--- a/packages/native/src/__tests__/components/view/sized-box/sized-box.test.tsx
+++ b/packages/native/src/__tests__/components/view/sized-box/sized-box.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import type { SizedBoxProps } from '../../../../components/view/sized-box/sized-box.type'
+
+describe('SizedBox Types', () => {
+  it('exports SizedBoxProps type', () => {
+    const props: SizedBoxProps = {
+      children: 'SizedBox',
+      width: '100%',
+      height: 80,
+      fullWidth: true,
+    }
+
+    expect(props).toBeDefined()
+    expect(props.width).toBe('100%')
+    expect(props.fullWidth).toBe(true)
+  })
+
+  it('accepts style props', () => {
+    const props: SizedBoxProps = {
+      children: 'SizedBox',
+      style: { minHeight: 40 },
+    }
+
+    expect(props.style).toBeDefined()
+  })
+})

--- a/packages/native/src/components/view/sized-box/sized-box.tsx
+++ b/packages/native/src/components/view/sized-box/sized-box.tsx
@@ -6,8 +6,11 @@ export const SizedBox: React.FC<SizedBoxProps> = ({
   children,
   width,
   height,
+  fullWidth,
   style,
 }) => {
+  const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
+
   return (
     <View
       style={[
@@ -15,6 +18,7 @@ export const SizedBox: React.FC<SizedBoxProps> = ({
           width,
           height,
         },
+        fullWidthStyle,
         style,
       ]}
     >

--- a/packages/native/src/components/view/sized-box/sized-box.type.ts
+++ b/packages/native/src/components/view/sized-box/sized-box.type.ts
@@ -9,11 +9,16 @@ export type SizedBoxProps = {
   /**
    * Width of the box.
    */
-  width?: number
+  width?: ViewStyle['width']
   /**
    * Height of the box.
    */
-  height?: number
+  height?: ViewStyle['height']
+  /**
+   * Whether the box should take the full width of its parent.
+   * @default false
+   */
+  fullWidth?: boolean
   /**
    * Custom style for the box.
    */


### PR DESCRIPTION
## Summary
- add `fullWidth` support to `SizedBox` in `@xaui/native/view`, with a simplified behavior that applies only `width: '100%'`
- extend `SizedBox` dimensions to accept string values (`number | string`) for `width` and `height`
- add/update docs and tests for the new `SizedBox` API, and include a patch changeset for `@xaui/native`

## Testing
- pnpm --filter @xaui/native exec eslint src/components/view/sized-box/sized-box.tsx src/components/view/sized-box/sized-box.type.ts src/__tests__/components/view/sized-box/sized-box.test.tsx
- pnpm --filter docs exec eslint lib/data/component-props.ts
- pnpm --filter @xaui/native exec vitest run src/__tests__/components/view/sized-box/sized-box.test.tsx