### PR TITLE
Add Typography lineHeight prop and Center docs preview

### DIFF
--- a/.changeset/add-line-height-to-typography.md
+++ b/.changeset/add-line-height-to-typography.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+Add a `lineHeight` prop to `Typography` so text line spacing can be controlled directly via component props.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # XAUI Library
 
-> [!WARNING]
-> **🚧 BETA VERSION — ACTIVE DEVELOPMENT 🚧**
->
-> This library is evolving rapidly. Public APIs may change without notice as the project matures.
-
 XAUI is a Flutter-inspired component system targeting React Native and hybrid web/native experiences within a Turborepo monorepo. The thematic core (`@xaui/core`) centralises tokens, dynamic theming, and motion primitives. Platform-specific packages build on that foundation to deliver native-ready components.
 
 **[Documentation → ui.xtartapp.com](https://ui.xtartapp.com)**

--- a/apps/docs/components/screenshots/center-screenshots.tsx
+++ b/apps/docs/components/screenshots/center-screenshots.tsx
@@ -1,0 +1,28 @@
+export function CenterScreenshots() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold tracking-tight md:text-2xl">Preview</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="overflow-hidden rounded-2xl border-4 border-gray-200 bg-white p-4">
+          <div className="mb-2 text-xs text-zinc-500">Basic center</div>
+          <div className="flex h-40 items-center justify-center rounded-xl bg-sky-50">
+            <span className="rounded-md bg-white px-3 py-1 text-sm text-zinc-700 shadow-sm">
+              Perfectly centered
+            </span>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border-4 border-gray-200 bg-white p-4">
+          <div className="mb-2 text-xs text-zinc-500">fullWidth + center</div>
+          <div className="h-40 rounded-xl bg-slate-100">
+            <div className="flex h-full w-full items-center justify-center rounded-xl border border-dashed border-slate-300">
+              <span className="rounded-md bg-white px-3 py-1 text-sm text-zinc-700 shadow-sm">
+                Center full width
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/components/screenshots/component-screenshots.tsx
+++ b/apps/docs/components/screenshots/component-screenshots.tsx
@@ -9,6 +9,7 @@ import { BottomTabBarScreenshots } from './bottom-tab-bar-screenshots'
 import { ButtonScreenshots } from './button-screenshots'
 import { CardScreenshots } from './card-screenshots'
 import { CarouselScreenshots } from './carousel-screenshots'
+import { CenterScreenshots } from './center-screenshots'
 import { CheckboxScreenshots } from './checkbox-screenshots'
 import { ChipScreenshots } from './chip-screenshots'
 import { DateInputScreenshots } from './date-input-screenshots'
@@ -57,6 +58,7 @@ const screenshotsMap: Record<string, React.FC> = {
   button: ButtonScreenshots,
   card: CardScreenshots,
   carousel: CarouselScreenshots,
+  center: CenterScreenshots,
   checkbox: CheckboxScreenshots,
   chip: ChipScreenshots,
   'date-input': DateInputScreenshots,

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -9925,6 +9925,12 @@ export function ToolbarCustomAppearanceExample() {
         description: 'Overflow handling when maxLines is set',
       },
       {
+        name: 'lineHeight',
+        type: 'number',
+        defaultValue: '-',
+        description: 'Custom line height for the text',
+      },
+      {
         name: 'style',
         type: 'StyleProp<TextStyle>',
         defaultValue: '-',
@@ -10393,6 +10399,20 @@ export function CenterCardExample() {
   )
 }`,
       },
+      {
+        title: 'Full Width Center',
+        description: 'Stretch the centered container to full width with fullWidth.',
+        code: `import { Center } from '@xaui/native/view'
+import { Typography } from '@xaui/native/typography'
+
+export function CenterFullWidthExample() {
+  return (
+    <Center fullWidth style={{ minHeight: 120, backgroundColor: '#f1f5f9' }}>
+      <Typography>Centered on full width</Typography>
+    </Center>
+  )
+}`,
+      },
     ],
   },
 
@@ -10636,6 +10656,20 @@ export function FixedContainerExample() {
   return (
     <SizedBox width={80} height={80}>
       <View style={{ flex: 1, backgroundColor: '#4f46e5', borderRadius: 8 }} />
+    </SizedBox>
+  )
+}`,
+      },
+      {
+        title: 'String Dimensions and Full Width',
+        description: 'Use string dimensions and fullWidth for responsive sizing.',
+        code: `import { SizedBox } from '@xaui/native/view'
+import { View } from 'react-native'
+
+export function SizedBoxResponsiveExample() {
+  return (
+    <SizedBox fullWidth height="40%">
+      <View style={{ flex: 1, backgroundColor: '#e0e7ff', borderRadius: 8 }} />
     </SizedBox>
   )
 }`,

--- a/packages/native/src/components/typography/typography.tsx
+++ b/packages/native/src/components/typography/typography.tsx
@@ -14,6 +14,7 @@ export const Typography: React.FC<TypographyProps> = ({
   overflow = 'clip',
   color,
   letterSpacing,
+  lineHeight,
   fontWeight,
   fontStyle,
   textDecorationLine,
@@ -27,6 +28,7 @@ export const Typography: React.FC<TypographyProps> = ({
   const textStyleOverrides = {
     color: color ?? inheritedStyle.color ?? themeColorValue,
     letterSpacing,
+    lineHeight,
     fontWeight: fontWeight ?? inheritedStyle.fontWeight,
     fontStyle: fontStyle ?? inheritedStyle.fontStyle,
     textDecorationLine,
@@ -47,7 +49,9 @@ export const Typography: React.FC<TypographyProps> = ({
         variantStyles,
         resolvedAlign && { textAlign: resolvedAlign },
         textStyleOverrides,
-        inheritedStyle.spacing != null ? { marginRight: inheritedStyle.spacing } : undefined,
+        inheritedStyle.spacing != null
+          ? { marginRight: inheritedStyle.spacing }
+          : undefined,
         style,
       ]}
     >

--- a/packages/native/src/components/typography/typography.type.ts
+++ b/packages/native/src/components/typography/typography.type.ts
@@ -61,6 +61,10 @@ export type TypographyProps = {
    */
   letterSpacing?: number
   /**
+   * Line height for the text.
+   */
+  lineHeight?: TextStyle['lineHeight']
+  /**
    * The text weight.
    */
   fontWeight?: TextStyle['fontWeight']


### PR DESCRIPTION
## Summary
- add `lineHeight` support to `Typography` (`TypographyProps` + component style application)
- add/update docs for `Center` in `apps/docs` by introducing a dedicated screenshots preview and wiring it into the screenshots map
- update docs metadata examples/props in `component-props` and include a changeset for `@xaui/native`

## Testing
- pnpm --filter @xaui/native exec eslint src/components/typography/typography.tsx src/components/typography/typography.type.ts
- pnpm --filter docs exec eslint lib/data/component-props.ts
- pnpm --filter docs exec eslint components/screenshots/center-screenshots.tsx components/screenshots/component-screenshots.tsx