### PR TITLE
fix: restrict TypographyVariant to supported tokens

### DIFF
--- a/.changeset/strict-typography-variant-type.md
+++ b/.changeset/strict-typography-variant-type.md
@@ -1,0 +1,6 @@
+---
+'@xaui/native': patch
+---
+
+Tighten `TypographyVariant` typing to documented variants only by removing the
+generic `string` fallback.

--- a/packages/native/src/components/typography/typography.type.ts
+++ b/packages/native/src/components/typography/typography.type.ts
@@ -18,7 +18,6 @@ export type TypographyVariant =
   | 'bodyLarge'
   | 'bodyMedium'
   | 'bodySmall'
-  | string
 
 export type TypographyProps = {
   /**


### PR DESCRIPTION
## Summary
- remove the generic `string` fallback from `TypographyVariant` so typings only allow documented typography variants
- add a changeset for `@xaui/native` as a patch release to capture this typing fix

## Validation
- ran `pnpm --filter @xaui/native type-check`