### PR TITLE
docs(native): document noGrowth prop for view layout components

### DIFF
--- a/.changeset/fuzzy-keys-smile.md
+++ b/.changeset/fuzzy-keys-smile.md
@@ -1,5 +1,5 @@
 ---
-'docs': patch
+'@xaui/native': patch
 ---
 
-docs(view): document the `noGrowth` prop for Column, Center, Padding, Margin, and RoundedView.
+native(view): document the `noGrowth` prop for Column, Center, Padding, Margin, and RoundedView.

--- a/.changeset/fuzzy-keys-smile.md
+++ b/.changeset/fuzzy-keys-smile.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+docs(view): document the `noGrowth` prop for Column, Center, Padding, Margin, and RoundedView.

--- a/.changeset/fuzzy-keys-smile.md
+++ b/.changeset/fuzzy-keys-smile.md
@@ -2,4 +2,4 @@
 '@xaui/native': patch
 ---
 
-native(view): document the `noGrowth` prop for Column, Center, Padding, Margin, and RoundedView.
+native(view): add `noGrowth` prop for Column, Center, Padding, Margin, and RoundedView.

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -10143,6 +10143,12 @@ export function TextSpanInheritedStyleExample() {
         description: 'Expand to full available width',
       },
       {
+        name: 'noGrowth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Disable automatic flex growth (`flex: 1`)',
+      },
+      {
         name: 'style',
         type: 'ViewStyle',
         defaultValue: '-',
@@ -10364,6 +10370,12 @@ export function WeightedSpacerExample() {
         description: 'Expand to full available width',
       },
       {
+        name: 'noGrowth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Disable automatic flex growth (`flex: 1`)',
+      },
+      {
         name: 'style',
         type: 'StyleProp<ViewStyle>',
         defaultValue: '-',
@@ -10468,6 +10480,12 @@ export function CenterFullWidthExample() {
         description: 'Expand to full available width',
       },
       {
+        name: 'noGrowth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Disable automatic flex growth (`flex: 1`)',
+      },
+      {
         name: 'style',
         type: 'StyleProp<ViewStyle>',
         defaultValue: '-',
@@ -10556,6 +10574,12 @@ export function DirectionalPaddingExample() {
         type: 'boolean',
         defaultValue: 'false',
         description: 'Expand to full available width',
+      },
+      {
+        name: 'noGrowth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Disable automatic flex growth (`flex: 1`)',
       },
       {
         name: 'style',
@@ -10893,6 +10917,12 @@ export function UnlockableBlurExample() {
         type: 'boolean',
         defaultValue: 'false',
         description: 'Expand to full available width',
+      },
+      {
+        name: 'noGrowth',
+        type: 'boolean',
+        defaultValue: 'false',
+        description: 'Disable automatic flex growth (`flex: 1`)',
       },
       {
         name: 'backgroundColor',

--- a/packages/native/src/components/view/center/center.tsx
+++ b/packages/native/src/components/view/center/center.tsx
@@ -2,14 +2,19 @@ import React from 'react'
 import { View } from 'react-native'
 import type { CenterProps } from './center.type'
 
-export const Center: React.FC<CenterProps> = ({ children, fullWidth, style }) => {
+export const Center: React.FC<CenterProps> = ({
+  children,
+  fullWidth,
+  style,
+  noGrowth = false,
+}) => {
   const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
 
   return (
     <View
       style={[
         {
-          flex: 1,
+          flex: noGrowth ? undefined : 1,
           alignItems: 'center',
           justifyContent: 'center',
         },

--- a/packages/native/src/components/view/center/center.type.ts
+++ b/packages/native/src/components/view/center/center.type.ts
@@ -12,6 +12,11 @@ export type CenterProps = {
    */
   fullWidth?: boolean
   /**
+   * If true, the centered container will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+  /**
    * Additional style for the container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/center/center.type.ts
+++ b/packages/native/src/components/view/center/center.type.ts
@@ -12,7 +12,7 @@ export type CenterProps = {
    */
   fullWidth?: boolean
   /**
-   * If true, the centered container will grow to fill available space.
+   * If true, disables automatic growth (e.g. prevents using flex: 1 to fill available space).
    * @default false
    */
   noGrowth?: boolean

--- a/packages/native/src/components/view/column/column.tsx
+++ b/packages/native/src/components/view/column/column.tsx
@@ -11,6 +11,7 @@ export const Column: React.FC<ColumnProps> = ({
   reverse = false,
   fullWidth,
   style,
+  noGrowth = false,
 }) => {
   const gapStyle = spacing === undefined ? undefined : { gap: spacing }
   const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
@@ -19,7 +20,7 @@ export const Column: React.FC<ColumnProps> = ({
     <View
       style={[
         {
-          flex: 1,
+          flex: noGrowth ? undefined : 1,
           flexDirection: reverse ? 'column-reverse' : 'column',
           justifyContent: resolveMainAxisAlignment(mainAxisAlignment),
           alignItems: resolveCrossAxisAlignment(crossAxisAlignment),

--- a/packages/native/src/components/view/layout-types.ts
+++ b/packages/native/src/components/view/layout-types.ts
@@ -40,15 +40,17 @@ export type RowProps = {
    * @default false
    */
   fullWidth?: boolean
-  /**
-   * If true, the container will grow to fill available space.
-   * @default false
-   */
-  noGrowth?: boolean
+
   /**
    * Custom style for the row container.
    */
   style?: ViewStyle
 }
 
-export type ColumnProps = RowProps
+export type ColumnProps = RowProps & {
+  /**
+   * If true, the container will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+}

--- a/packages/native/src/components/view/layout-types.ts
+++ b/packages/native/src/components/view/layout-types.ts
@@ -41,6 +41,11 @@ export type RowProps = {
    */
   fullWidth?: boolean
   /**
+   * If true, the container will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+  /**
    * Custom style for the row container.
    */
   style?: ViewStyle

--- a/packages/native/src/components/view/margin/margin.tsx
+++ b/packages/native/src/components/view/margin/margin.tsx
@@ -13,6 +13,7 @@ export const Margin: React.FC<MarginProps> = ({
   left,
   fullWidth,
   style,
+  noGrowth = false,
 }) => {
   const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
 
@@ -20,7 +21,7 @@ export const Margin: React.FC<MarginProps> = ({
     <View
       style={[
         {
-          flex: 1,
+          flex: noGrowth ? undefined : 1,
           margin: all,
           marginHorizontal: horizontal,
           marginVertical: vertical,

--- a/packages/native/src/components/view/margin/margin.type.ts
+++ b/packages/native/src/components/view/margin/margin.type.ts
@@ -40,6 +40,11 @@ export type MarginProps = {
    */
   fullWidth?: boolean
   /**
+   * If true, the margin container will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+  /**
    * Custom style for the margin container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/padding/padding.tsx
+++ b/packages/native/src/components/view/padding/padding.tsx
@@ -13,6 +13,7 @@ export const Padding: React.FC<PaddingProps> = ({
   left,
   fullWidth,
   style,
+  noGrowth = false,
 }) => {
   const fullWidthStyle = fullWidth ? { width: '100%' as const } : undefined
 
@@ -20,7 +21,7 @@ export const Padding: React.FC<PaddingProps> = ({
     <View
       style={[
         {
-          flex: 1,
+          flex: noGrowth ? undefined : 1,
           padding: all,
           paddingHorizontal: horizontal,
           paddingVertical: vertical,

--- a/packages/native/src/components/view/padding/padding.type.ts
+++ b/packages/native/src/components/view/padding/padding.type.ts
@@ -40,11 +40,6 @@ export type PaddingProps = {
    */
   fullWidth?: boolean
   /**
-   * If true, the padding container will grow to fill available space.
-   * @default false
-   */
-  noGrowth?: boolean
-  /**
    * Custom style for the padding container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/padding/padding.type.ts
+++ b/packages/native/src/components/view/padding/padding.type.ts
@@ -40,6 +40,11 @@ export type PaddingProps = {
    */
   fullWidth?: boolean
   /**
+   * If true, the padding container will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+  /**
    * Custom style for the padding container.
    */
   style?: StyleProp<ViewStyle>

--- a/packages/native/src/components/view/rounded-view/rounded-view.tsx
+++ b/packages/native/src/components/view/rounded-view/rounded-view.tsx
@@ -17,6 +17,7 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
   fullWidth = false,
   backgroundColor,
   style,
+  noGrowth = false,
 }) => {
   const borderRadiusStyle = useRoundedViewStyle({
     all,
@@ -35,6 +36,7 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
       style={[
         borderRadiusStyle,
         fullWidth && styles.fullWidth,
+        noGrowth ? undefined : { flex: 1 },
         backgroundColor && { backgroundColor },
         style,
       ]}
@@ -46,9 +48,6 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
 
 const styles = StyleSheet.create({
   fullWidth: {
-    flexGrow: 1,
-    flexShrink: 1,
-    flexBasis: 'auto',
     width: '100%',
   },
 })

--- a/packages/native/src/components/view/rounded-view/rounded-view.tsx
+++ b/packages/native/src/components/view/rounded-view/rounded-view.tsx
@@ -36,7 +36,7 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
       style={[
         borderRadiusStyle,
         fullWidth && styles.fullWidth,
-        noGrowth ? undefined : { flex: 1 },
+        fullWidth && !noGrowth ? { flex: 1 } : undefined,
         backgroundColor && { backgroundColor },
         style,
       ]}

--- a/packages/native/src/components/view/rounded-view/rounded-view.tsx
+++ b/packages/native/src/components/view/rounded-view/rounded-view.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View } from 'react-native'
 import { useRoundedViewStyle } from './rounded-view.hook'
 import type { RoundedViewProps } from './rounded-view.type'
 
@@ -35,8 +35,8 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
     <View
       style={[
         borderRadiusStyle,
-        fullWidth && styles.fullWidth,
-        fullWidth && !noGrowth ? { flex: 1 } : undefined,
+        fullWidth && { width: '100%' },
+        noGrowth ? undefined : { flex: 1 },
         backgroundColor && { backgroundColor },
         style,
       ]}
@@ -45,9 +45,3 @@ export const RoundedView: React.FC<RoundedViewProps> = ({
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  fullWidth: {
-    width: '100%',
-  },
-})

--- a/packages/native/src/components/view/rounded-view/rounded-view.type.ts
+++ b/packages/native/src/components/view/rounded-view/rounded-view.type.ts
@@ -52,6 +52,11 @@ export type RoundedViewProps = {
    */
   backgroundColor?: string
   /**
+   * If true, the view will grow to fill available space.
+   * @default false
+   */
+  noGrowth?: boolean
+  /**
    * Custom style for the view
    */
   style?: ViewStyle

--- a/packages/native/src/components/view/rounded-view/rounded-view.type.ts
+++ b/packages/native/src/components/view/rounded-view/rounded-view.type.ts
@@ -52,7 +52,7 @@ export type RoundedViewProps = {
    */
   backgroundColor?: string
   /**
-   * If true, the view will grow to fill available space.
+   * If true, the view will NOT automatically grow to fill available space (e.g., via flex: 1).
    * @default false
    */
   noGrowth?: boolean


### PR DESCRIPTION
## What
- update web docs props table to include noGrowth for Column, Center, Padding, Margin, and RoundedView
- add/update changeset targeting @xaui/native with a patch bump

## Why
- align docs with native API so noGrowth behavior is discoverable in component docs

## How
- edited apps/docs/lib/data/component-props.ts
- updated .changeset/fuzzy-keys-smile.md to @xaui/native: patch
