### PR TITLE
feat(tabs): replace React key with explicit tabKey prop

### DIFF
--- a/.changeset/tired-feet-notice.md
+++ b/.changeset/tired-feet-notice.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+feat(tabs): replace React key with explicit tabKey prop on Tab component

--- a/apps/demo/app/tabs.tsx
+++ b/apps/demo/app/tabs.tsx
@@ -15,15 +15,15 @@ const themeColors = [
 
 function renderAccountTabs() {
   return [
-    <Tab key="profile" title="Profile" />,
-    <Tab key="security" title="Security" />,
-    <Tab key="billing" title="Billing" />,
+    <Tab key="profile" tabKey="profile" title="Profile" />,
+    <Tab key="security" tabKey="security" title="Security" />,
+    <Tab key="billing" tabKey="billing" title="Billing" />,
   ]
 }
 
 function renderAccountTabsWithContent(colors: ReturnType<typeof useXUIColors>) {
   return [
-    <Tab key="profile" title="Profile">
+    <Tab key="profile" tabKey="profile" title="Profile">
       <View
         style={[
           styles.contentBox,
@@ -41,7 +41,7 @@ function renderAccountTabsWithContent(colors: ReturnType<typeof useXUIColors>) {
         </Text>
       </View>
     </Tab>,
-    <Tab key="security" title="Security">
+    <Tab key="security" tabKey="security" title="Security">
       <View
         style={[
           styles.contentBox,
@@ -59,7 +59,7 @@ function renderAccountTabsWithContent(colors: ReturnType<typeof useXUIColors>) {
         </Text>
       </View>
     </Tab>,
-    <Tab key="billing" title="Billing">
+    <Tab key="billing" tabKey="billing" title="Billing">
       <View
         style={[
           styles.contentBox,
@@ -214,9 +214,9 @@ export default function TabsScreen() {
             </Text>
           )}
         >
-          <Tab key="all" title="All" />
-          <Tab key="active" title="Active" />
-          <Tab key="done" title="Done" />
+          <Tab key="all" tabKey="all" title="All" />
+          <Tab key="active" tabKey="active" title="Active" />
+          <Tab key="done" tabKey="done" title="Done" />
         </Tabs>
       </View>
 

--- a/apps/docs/lib/data/component-props.ts
+++ b/apps/docs/lib/data/component-props.ts
@@ -9242,13 +9242,13 @@ import { Typography } from '@xaui/native/typography'
 export function BasicExample() {
   return (
     <Tabs>
-      <Tab title="Home">
+      <Tab tabKey="home" title="Home">
         <Typography>Home content</Typography>
       </Tab>
-      <Tab title="Profile">
+      <Tab tabKey="profile" title="Profile">
         <Typography>Profile content</Typography>
       </Tab>
-      <Tab title="Settings">
+      <Tab tabKey="settings" title="Settings">
         <Typography>Settings content</Typography>
       </Tab>
     </Tabs>
@@ -9266,20 +9266,20 @@ export function VariantsExample() {
   return (
     <Column gap={24}>
       <Tabs variant="solid">
-        <Tab title="One"><Typography>One</Typography></Tab>
-        <Tab title="Two"><Typography>Two</Typography></Tab>
+        <Tab tabKey="one" title="One"><Typography>One</Typography></Tab>
+        <Tab tabKey="two" title="Two"><Typography>Two</Typography></Tab>
       </Tabs>
       <Tabs variant="bordered">
-        <Tab title="One"><Typography>One</Typography></Tab>
-        <Tab title="Two"><Typography>Two</Typography></Tab>
+        <Tab tabKey="one" title="One"><Typography>One</Typography></Tab>
+        <Tab tabKey="two" title="Two"><Typography>Two</Typography></Tab>
       </Tabs>
       <Tabs variant="light">
-        <Tab title="One"><Typography>One</Typography></Tab>
-        <Tab title="Two"><Typography>Two</Typography></Tab>
+        <Tab tabKey="one" title="One"><Typography>One</Typography></Tab>
+        <Tab tabKey="two" title="Two"><Typography>Two</Typography></Tab>
       </Tabs>
       <Tabs variant="underlined">
-        <Tab title="One"><Typography>One</Typography></Tab>
-        <Tab title="Two"><Typography>Two</Typography></Tab>
+        <Tab tabKey="one" title="One"><Typography>One</Typography></Tab>
+        <Tab tabKey="two" title="Two"><Typography>Two</Typography></Tab>
       </Tabs>
     </Column>
   )
@@ -9297,13 +9297,13 @@ export function ControlledExample() {
 
   return (
     <Tabs selectedKey={selected} onSelectionChange={setSelected}>
-      <Tab title="Inbox">
+      <Tab tabKey="inbox" title="Inbox">
         <Typography>Inbox items</Typography>
       </Tab>
-      <Tab title="Sent">
+      <Tab tabKey="sent" title="Sent">
         <Typography>Sent items</Typography>
       </Tab>
-      <Tab title="Drafts">
+      <Tab tabKey="drafts" title="Drafts">
         <Typography>Draft items</Typography>
       </Tab>
     </Tabs>
@@ -9319,10 +9319,10 @@ import { Typography } from '@xaui/native/typography'
 export function DisabledTabsExample() {
   return (
     <Tabs disabledKeys={['premium']}>
-      <Tab title="Free">
+      <Tab tabKey="free" title="Free">
         <Typography>Free content</Typography>
       </Tab>
-      <Tab title="Premium">
+      <Tab tabKey="premium" title="Premium">
         <Typography>Premium content</Typography>
       </Tab>
     </Tabs>
@@ -9338,9 +9338,9 @@ import { Typography } from '@xaui/native/typography'
 export function FullWidthExample() {
   return (
     <Tabs fullWidth>
-      <Tab title="Overview"><Typography>Overview</Typography></Tab>
-      <Tab title="Details"><Typography>Details</Typography></Tab>
-      <Tab title="Reviews"><Typography>Reviews</Typography></Tab>
+      <Tab tabKey="overview" title="Overview"><Typography>Overview</Typography></Tab>
+      <Tab tabKey="details" title="Details"><Typography>Details</Typography></Tab>
+      <Tab tabKey="reviews" title="Reviews"><Typography>Reviews</Typography></Tab>
     </Tabs>
   )
 }`,
@@ -9350,6 +9350,12 @@ export function FullWidthExample() {
       {
         name: 'Tab',
         props: [
+          {
+            name: 'tabKey',
+            type: 'string',
+            defaultValue: '-',
+            description: 'Unique identifier for this tab (used for selection and disabled state)',
+          },
           {
             name: 'title',
             type: 'ReactNode',

--- a/packages/native/src/__tests__/components/tabs/tabs.test.tsx
+++ b/packages/native/src/__tests__/components/tabs/tabs.test.tsx
@@ -14,8 +14,8 @@ describe('Tabs Types', () => {
       selectedKey: 'account',
       onSelectionChange: () => {},
       children: [
-        <Tab key="account" title="Account" />,
-        <Tab key="billing" title="Billing" />,
+        <Tab tabKey="account" title="Account" />,
+        <Tab tabKey="billing" title="Billing" />,
       ],
     }
 
@@ -25,7 +25,7 @@ describe('Tabs Types', () => {
 
   it('requires children', () => {
     const props: TabsProps = {
-      children: [<Tab key="overview" title="Overview" />],
+      children: [<Tab tabKey="overview" title="Overview" />],
     }
 
     expect(props.children).toBeDefined()
@@ -33,7 +33,7 @@ describe('Tabs Types', () => {
 
   it('accepts render function as content', () => {
     const props: TabsProps = {
-      children: [<Tab key="security" title="Security" />],
+      children: [<Tab tabKey="security" title="Security" />],
       content: ({ selectedKey }) => React.createElement('div', null, selectedKey),
     }
 
@@ -45,7 +45,7 @@ describe('Tabs Types', () => {
 
     variants.forEach(variant => {
       const props: TabsProps = {
-        children: [<Tab key="general" title="General" />],
+        children: [<Tab tabKey="general" title="General" />],
         variant,
       }
 
@@ -55,7 +55,7 @@ describe('Tabs Types', () => {
 
   it('accepts theme color, size and radius', () => {
     const props: TabsProps = {
-      children: [<Tab key="general" title="General" />],
+      children: [<Tab tabKey="general" title="General" />],
       color: 'secondary',
       size: 'lg',
       radius: 'md',
@@ -84,11 +84,13 @@ describe('Tabs Types', () => {
 
   it('accepts tab props with tab content', () => {
     const tabProps: TabProps = {
+      tabKey: 'overview',
       title: 'Overview',
       isDisabled: false,
       children: React.createElement('div'),
     }
 
+    expect(tabProps.tabKey).toBe('overview')
     expect(tabProps.title).toBe('Overview')
     expect(tabProps.children).toBeDefined()
   })

--- a/packages/native/src/components/tabs/tabs.tsx
+++ b/packages/native/src/components/tabs/tabs.tsx
@@ -49,13 +49,14 @@ function toTabItems(children: TabsProps['children']): TabsItem[] {
       return []
     }
 
-    if (child.key == null) {
+    const tabKey = child.props.tabKey
+    if (!tabKey) {
       return []
     }
 
     return [
       {
-        key: String(child.key),
+        key: tabKey,
         title: child.props.title,
         startContent: child.props.startContent,
         endContent: child.props.endContent,

--- a/packages/native/src/components/tabs/tabs.type.ts
+++ b/packages/native/src/components/tabs/tabs.type.ts
@@ -34,6 +34,10 @@ export type TabsItem = {
 
 export type TabProps = {
   /**
+   * Unique identifier for the tab. Used for selection, disabled state, and content rendering.
+   */
+  tabKey: string
+  /**
    * Label content for the tab trigger.
    */
   title: ReactNode


### PR DESCRIPTION
## What

Introduces a new `tabKey` prop on the `Tab` component to explicitly identify each tab, replacing the previous reliance on React's internal `key` prop for tab selection and disabled state logic.

## Why

React's native `key` prop is a reconciliation hint — not a stable, user-accessible identifier. When `React.Children.toArray` is used internally, keys are prefixed (e.g. `".$profile"`), making them unreliable to match against user-provided strings like `selectedKey="profile"` or `disabledKeys={['billing']}`. Using `tabKey` gives a clean, explicit, and predictable identifier.

## How

- Added `tabKey: string` (required) to `TabProps` in `tabs.type.ts`
- Updated `toTabItems()` in `tabs.tsx` to read `child.props.tabKey` instead of `child.key`
- Updated tests to use `tabKey` instead of `key` on `Tab` elements
- Updated demo (`apps/demo/app/tabs.tsx`) to pass `tabKey` alongside React `key`
- Updated docs (`apps/docs/lib/data/component-props.ts`): added `tabKey` to Tab subcomponent props table and updated all code examples

## Migration

Before:
```tsx
<Tab key="profile" title="Profile" />
```

After:
```tsx
<Tab key="profile" tabKey="profile" title="Profile" />
```

> `key` is still needed for React reconciliation — `tabKey` is the semantic identifier used by `Tabs` for selection and disabled state.

## Changeset

- `@xaui/native` — patch