### PR TITLE
docs: always branch before starting an implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,12 @@ pnpm --filter @xaui/native exec eslint src/components/button/button.tsx
   `utils/`, and that function is tested.
 - Mirror source paths under `src/__tests__/...`; suffix `*.test.ts`.
 
+## Branching
+
+- **Always branch before starting an implementation**, before the first line of code.
+- Never commit to `main`.
+- One branch per coherent unit of work: `feat/`, `fix/`, `refactor/`, `chore/`.
+
 ## Pull requests
 
 - Open with `gh pr create`, never as a draft unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,22 @@ The project uses GitHub Actions with the following workflow:
    - Uses Changesets action to create release PRs or publish to npm
    - Only builds `@xaui/*` scoped packages before publishing
 
+## Branching
+
+**Always create a branch before starting an implementation** — before the first line of
+code, not once the work is underway. Never commit to `main`.
+
+One branch per coherent unit of work, named by intent:
+
+```bash
+git checkout -b feat/button-v1        # new component or feature
+git checkout -b fix/style-cache-key   # bug fix
+git checkout -b refactor/alert        # rework of existing code
+git checkout -b chore/ai-setup        # tooling, config, docs
+```
+
+When a task turns out to cover two unrelated things, it is two branches and two PRs.
+
 ## Commit Message Guidelines
 
 - generate a commit message with commitizen specification


### PR DESCRIPTION
## What

Adds an explicit branching rule to `CLAUDE.md` (new `## Branching` section) and `AGENTS.md`: create the branch **before the first line of code**, never commit to `main`, one branch per coherent unit of work, named by intent (`feat/`, `fix/`, `refactor/`, `chore/`).

## Why

The rule was implicit — `xaui-flow` mentioned branching as a step, but neither instruction file stated it, so nothing caught a commit landing straight on `main`. This PR exists because that is exactly what happened while writing it: the change was committed onto `main` before being moved onto this branch.

## How

Two short sections, one per file, placed just before the commit-message guidelines so the branch → commit → PR sequence reads in order.

No changeset: documentation only, nothing under `packages/`.