### PR TITLE
chore(release): publish native and hybrid on the alpha dist-tag

### DIFF
--- a/.agents/skills/xaui-flow/SKILL.md
+++ b/.agents/skills/xaui-flow/SKILL.md
@@ -16,16 +16,16 @@ Plan of record: `.project-specs/XAUI-V1-PLAN.md`. Runnable references:
 The v1 phasing, in order. Each phase's **first line unblocks the rest**; within a phase the
 remaining items can be ordered freely.
 
-| Phase  | What                                                                                                                                         | Ships                                                          |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| **P0** | Package split, token source, OKLab engine, derived layer, contrast guard, `createTheme`, provider, legacy shim, peer-dep hygiene, ESLint R13 | `@xaui/native-legacy@0.2.8`                                    |
-| **P1** | `system/` — recipe + cache, slots, `PressableFeedback`, `Portal`, `Icon`, shared hooks                                                       | nothing (a UI package with no component makes no sense on npm) |
-| **P2** | The reference `Button` + a perf baseline + **the blocking API review**                                                                       | `@xaui/native@0.9.0-beta.1`                                    |
-| **P3** | The fifteen-component core, in the plan's order                                                                                              | betas                                                          |
-| **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                           |
-| **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                          |
-| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                              |
-| **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                        |
+| Phase  | What                                                                                                                                         | Ships                                                              |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **P0** | Package split, token source, OKLab engine, derived layer, contrast guard, `createTheme`, provider, legacy shim, peer-dep hygiene, ESLint R13 | `@xaui/native-legacy@0.2.8`                                        |
+| **P1** | `system/` — recipe + cache, slots, `PressableFeedback`, `Portal`, `Icon`, shared hooks                                                       | nothing on `latest` — `native` and `hybrid` sit on the `alpha` tag |
+| **P2** | The reference `Button` + a perf baseline + **the blocking API review**                                                                       | `@xaui/native@0.9.x-alpha.x`                                       |
+| **P3** | The fifteen-component core, in the plan's order                                                                                              | alphas                                                             |
+| **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                               |
+| **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                              |
+| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                                  |
+| **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                            |
 
 Two consequences worth stating out loud when a request cuts across them:
 

--- a/.agents/skills/xaui-legacy-migration/SKILL.md
+++ b/.agents/skills/xaui-legacy-migration/SKILL.md
@@ -11,7 +11,7 @@ npm name.
 | Package | Content | Version |
 |---|---|---|
 | `@xaui/native-legacy` | the 47 current components, frozen | `0.2.8` — same number as the last real release |
-| `@xaui/native` | the v1 API, from scratch | `0.9.0-beta.x` → `1.0.0` |
+| `@xaui/native` | the v1 API, from scratch | `0.9.x-alpha.x` → `1.0.0` |
 | `@xaui/hybrid` | frozen during P0–P4 | unchanged |
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §7.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "demo": "1.0.71",
+    "docs": "0.1.47",
+    "@xaui/hybrid": "0.9.0",
+    "@xaui/native": "0.9.0",
+    "@xaui/native-legacy": "0.2.11"
+  },
+  "changesets": []
+}

--- a/.changeset/publish-native-hybrid-alpha.md
+++ b/.changeset/publish-native-hybrid-alpha.md
@@ -1,0 +1,16 @@
+---
+'@xaui/native': patch
+'@xaui/hybrid': patch
+---
+
+Publish to npm again, under the `alpha` dist-tag.
+
+Both packages were `private` while the v1 rewrite started from an empty `src/`. They are
+publishable again, but the repo is now in changesets **pre mode** with the tag `alpha`, so
+`changeset publish` ships them as `alpha` and leaves `latest` where it is —
+`@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`, the last releases that actually carry
+components. Installing either package without a tag keeps returning those.
+
+`pnpm add @xaui/native@alpha` is the opt-in. At this point it exports the theme layer only
+(`createTheme`, `XAUIProvider`, the token and colour utilities) — the components land from
+P2 on, one at a time, which is exactly what the tag announces.

--- a/.claude/skills/xaui-flow/SKILL.md
+++ b/.claude/skills/xaui-flow/SKILL.md
@@ -16,16 +16,16 @@ Plan of record: `.project-specs/XAUI-V1-PLAN.md`. Runnable references:
 The v1 phasing, in order. Each phase's **first line unblocks the rest**; within a phase the
 remaining items can be ordered freely.
 
-| Phase  | What                                                                                                                                         | Ships                                                          |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| **P0** | Package split, token source, OKLab engine, derived layer, contrast guard, `createTheme`, provider, legacy shim, peer-dep hygiene, ESLint R13 | `@xaui/native-legacy@0.2.8`                                    |
-| **P1** | `system/` — recipe + cache, slots, `PressableFeedback`, `Portal`, `Icon`, shared hooks                                                       | nothing (a UI package with no component makes no sense on npm) |
-| **P2** | The reference `Button` + a perf baseline + **the blocking API review**                                                                       | `@xaui/native@0.9.0-beta.1`                                    |
-| **P3** | The fifteen-component core, in the plan's order                                                                                              | betas                                                          |
-| **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                           |
-| **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                          |
-| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                              |
-| **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                        |
+| Phase  | What                                                                                                                                         | Ships                                                              |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **P0** | Package split, token source, OKLab engine, derived layer, contrast guard, `createTheme`, provider, legacy shim, peer-dep hygiene, ESLint R13 | `@xaui/native-legacy@0.2.8`                                        |
+| **P1** | `system/` — recipe + cache, slots, `PressableFeedback`, `Portal`, `Icon`, shared hooks                                                       | nothing on `latest` — `native` and `hybrid` sit on the `alpha` tag |
+| **P2** | The reference `Button` + a perf baseline + **the blocking API review**                                                                       | `@xaui/native@0.9.x-alpha.x`                                       |
+| **P3** | The fifteen-component core, in the plan's order                                                                                              | alphas                                                             |
+| **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                               |
+| **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                              |
+| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                                  |
+| **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                            |
 
 Two consequences worth stating out loud when a request cuts across them:
 

--- a/.claude/skills/xaui-legacy-migration/SKILL.md
+++ b/.claude/skills/xaui-legacy-migration/SKILL.md
@@ -11,7 +11,7 @@ npm name.
 | Package | Content | Version |
 |---|---|---|
 | `@xaui/native-legacy` | the 47 current components, frozen | `0.2.8` — same number as the last real release |
-| `@xaui/native` | the v1 API, from scratch | `0.9.0-beta.x` → `1.0.0` |
+| `@xaui/native` | the v1 API, from scratch | `0.9.x-alpha.x` → `1.0.0` |
 | `@xaui/hybrid` | frozen during P0–P4 | unchanged |
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §7.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -17,6 +17,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P0.10 | ESLint rule for R13                                      | done   |
 | P0.11 | Publish `@xaui/native-legacy@0.2.8` and the codemod      | todo   |
 | P0.12 | Delete `@xaui/core` and `@xaui/icons`                     | done   |
+| P0.13 | Publish `native` and `hybrid` on the `alpha` tag          | done   |
 | P1    | `system/` — recipe, slots, feedback, portal, icon, hooks | todo   |
 | P2    | Reference `Button`, perf baseline, API review            | todo   |
 | P3    | The fifteen-component core                               | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -811,7 +811,7 @@ L'ancien tree ne devient **pas** un sous-chemin de `@xaui/native`. Il est republ
 |---|---|---|
 | `@xaui/native-legacy` | les 47 composants actuels, figés | `0.2.8` — le même numéro que la dernière release réelle, pour que la correspondance soit évidente |
 | `@xaui/native` | l'API v1, repart de zéro | `1.0.0` |
-| `@xaui/hybrid` | gelé pendant P0–P4 | inchangé |
+| `@xaui/hybrid` | gelé pendant P0–P4 | `0.9.x-alpha.x` — thème seulement, publié sur le tag `alpha` ; `latest` reste sur `0.0.14` |
 
 C'est plus propre que le sous-chemin sur trois points concrets :
 
@@ -903,12 +903,18 @@ startContent={<I/>} / endContent={<I/>}     → <X.Icon/> placé dans l'ordre vo
 | Package | Version | Contenu |
 |---|---|---|
 | `@xaui/native-legacy` | `0.2.8` | publié une fois, figé. Correctifs en `0.2.x` |
-| `@xaui/native` | `0.9.0-beta.x` | le noyau arrive composant par composant, API instable et annoncée comme telle |
+| `@xaui/native` | `0.9.x-alpha.x` | le noyau arrive composant par composant, API instable et annoncée comme telle |
 | `@xaui/native` | `1.0.0` | noyau de 15 composants + doc complète |
 | `@xaui/native` | `1.x` | les 32 composants restants |
 | `@xaui/native` | `2.0.0` | plus rien à voir avec legacy — `native-legacy` est déprécié bien avant |
 
-Les préversions `0.9.0-beta` remplacent les `0.4.x – 0.9.x` du modèle précédent : comme `@xaui/native` repart de zéro, publier des mineures qui ne contiennent que deux ou trois composants donnerait un package inutilisable sous un numéro qui promet le contraire. Un tag `beta` dit la vérité.
+Les préversions `0.9.x-alpha` remplacent les `0.4.x – 0.9.x` du modèle précédent : comme `@xaui/native` repart de zéro, publier des mineures qui ne contiennent que deux ou trois composants donnerait un package inutilisable sous un numéro qui promet le contraire. Un tag `alpha` dit la vérité.
+
+Concrètement, le dépôt est en **pre mode changesets** (`.changeset/pre.json`, tag `alpha`) : `changeset publish` pousse `native` et `hybrid` sous le dist-tag `alpha`, et `latest` reste sur les dernières releases qui portent réellement des composants — `@xaui/native@0.2.8` et `@xaui/hybrid@0.0.14`. Un `npm i @xaui/native` continue donc de renvoyer `0.2.8` ; l'opt-in est `@xaui/native@alpha`. Deux conséquences à garder en tête :
+
+- **Le pre mode est global au dépôt.** Un changeset sur `@xaui/native-legacy` pendant cette fenêtre le versionnerait aussi en `-alpha.x`. Legacy est figé, donc le cas est rare — mais un correctif `0.2.x` réel demande de sortir du pre mode (`changeset pre exit`) le temps de la release.
+- **La première publication d'un package jamais publié doit se faire hors pre mode.** `getReleaseTag` (`@changesets/cli`) donne le tag pre à tout package dont `publishedState !== "only-pre"`, ce qui inclut `"never"` : un premier publish sous pre mode sortirait taggé `alpha` sans tag `latest`, et `npm i <pkg>` échouerait. C'est le cas de `@xaui/native-legacy` (§7).
+- **`changeset pre exit` avant `1.0.0`**, sinon la version stable n'atteindrait jamais le tag `latest`.
 
 ---
 
@@ -1089,7 +1095,7 @@ Identique pour P2, P3 et P5. C'est **la** tâche répétée 47 fois ; l'écrire 
    → Un chiffre écrit dans le plan. C'est le seuil que les 46 autres devront tenir, et la seule preuve que le cache fait ce qu'on prétend.
 3. **Revue d'API — bloquante.**
    → Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette revue.
-4. **Publier `@xaui/native@0.9.0-beta.1`.**
+4. **Publier `@xaui/native` sur le tag `alpha`** (la ligne `0.9.x-alpha.x` est déjà ouverte, cf. §Versions).
    → La démo consomme le package publié, pas le workspace.
 
 ---

--- a/packages/hybrid/package.json
+++ b/packages/hybrid/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@xaui/hybrid",
-  "version": "0.9.0-beta.0",
-  "private": true,
+  "version": "0.9.0",
   "description": "The @xaui/native API rendered for the web and mobile webviews",
   "keywords": [
     "react",
@@ -32,6 +31,12 @@
     "dist",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rygrams/xaui.git",
+    "directory": "packages/hybrid"
+  },
+  "homepage": "https://ui.xtartapp.com/docs/introduction",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@xaui/native",
   "version": "0.9.0",
-  "private": true,
   "description": "Composition-first React Native UI components with native animations powered by Reanimated",
   "keywords": [
     "react-native",
@@ -33,6 +32,12 @@
     "dist",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rygrams/xaui.git",
+    "directory": "packages/native"
+  },
+  "homepage": "https://ui.xtartapp.com/docs/introduction",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What

- Drops `private: true` from `@xaui/native` and `@xaui/hybrid`.
- Puts the repo in **changesets pre mode with the tag `alpha`** (`.changeset/pre.json`), so
  `changeset publish` ships both under the `alpha` dist-tag.
- Normalises `@xaui/hybrid` to `0.9.0` (it sat on `0.9.0-beta.0`, never published) so both
  packages enter the alpha line from the same base. First release of each will be
  `0.9.1-alpha.0`.
- Adds `repository` + `homepage` to both manifests.
- Records the beta → alpha version-line change in the plan (§7, §Versions, the P2 task),
  `ROADMAP.md` (P0.13) and the two skills that named `0.9.0-beta.x`.
- `@xaui/native-legacy` is untouched.

## Why

Both packages went `private` when the v1 rewrite restarted from an empty `src/`. Making
them publishable again is only safe under a non-`latest` tag: `src/index.ts` is still
`export * from './theme'`, so the published tarball carries the theme layer and no
components, while npm `latest` currently points at `@xaui/native@0.2.8` (47 components) and
`@xaui/hybrid@0.0.14` (the web renderer). Publishing on `latest` would hand every
`npm i @xaui/native` a package with nothing in it.

Pre mode keeps `latest` where it is. Verified in `@changesets/cli@2.29.8`:
`getReleaseTag` (`changesets-cli.cjs.js:812`) returns `preState.tag` for any package whose
`publishedState !== "only-pre"`, and both packages have regular releases on npm, so they
resolve to `alpha`. `pnpm add @xaui/native@alpha` becomes the opt-in — which is what the
plan's §Versions asked for, with `alpha` in place of `beta`.

This deviates from the plan on one point, deliberately: §P1 says nothing ships until P2, and
`@xaui/hybrid` is frozen through P4. The deviation is confined to the tag — nothing reaches
`latest` before P2/P6 — and it is now written into the plan rather than left implicit.

## Pre mode has three consequences, all documented in plan §Versions

1. **It is repo-wide.** A changeset on `@xaui/native-legacy` during this window would
   version it `-alpha.x` too. Legacy is frozen so the case is rare, but a real `0.2.x` fix
   needs `changeset pre exit` for the release.
2. **A never-published package must not have its first publish under pre mode.**
   `getReleaseTag` hands the pre tag to any package whose `publishedState` is not
   `"only-pre"` — and `"never"` is not `"only-pre"`. A first publish would go out tagged
   `alpha` with no `latest` tag at all, and `npm i <pkg>` would fail to resolve. This is
   exactly the trap waiting for `@xaui/native-legacy`, so **exit pre mode for that
   publish**. (#161 no longer carries it, so there is no ordering constraint between the two
   PRs.)
3. **`changeset pre exit` before `1.0.0`**, or the stable version would never reach
   `latest`.

## How

`pre.json` + one patch changeset covering both packages. No source file changed.

## Test plan

- [x] `pnpm type-check` — 5/5 tasks pass
- [x] `pnpm test` — 8/8 tasks pass (build runs as a dependency)
- [x] `pnpm turbo run lint --filter="docs" --filter="@xaui/*"` — 6/6 pass, i.e. the exact
      filter the CI lint job uses. (Plain `pnpm lint` is red, but only on 6 pre-existing
      `react/no-unescaped-entities` errors in `apps/demo`, which are on `origin/main`
      verbatim and which CI excludes. Happy to fix them separately.)
- [x] `pnpm pack` on both packages — tarballs contain `dist/` + `package.json` + `LICENSE`,
      `dist/theme/index.js` present, nothing stray
- [x] `getReleaseTag` / `getUnpublishedPackages` read in `@changesets/cli@2.29.8` to confirm
      the tag each package will get

## Known, not fixed here

`exports` maps `"require"` at `./dist/index.js` (ESM) in `native`, `hybrid` and
`native-legacy`, while tsup also emits `dist/index.cjs` / `index.d.cts` that nothing
references. Metro and bundlers take the `import` condition so RN consumers are fine, but a
CJS `require()` on Node < 22.12 gets `ERR_REQUIRE_ESM`. Pre-existing on all three packages
(0.2.8 ships it today) — worth its own PR now that two of them go public.

Neither package has a `README.md`, so their npm pages would be blank. npm shows the README
of the `latest` version, which stays on 0.2.8 / 0.0.14, so nothing regresses today; P4 owns
the v1 docs.