### PR TITLE
docs: state the alpha line for native and hybrid

### DIFF
--- a/.agents/skills/xaui-flow/SKILL.md
+++ b/.agents/skills/xaui-flow/SKILL.md
@@ -95,7 +95,7 @@ progress is recorded, and it moves in the same commit as the work.
 
 ## 7. Changeset
 
-One per touched package, **always `patch`** while we're in beta:
+One per touched package, **always `patch`** while we're on the `alpha` line:
 
 ```bash
 pnpm changeset

--- a/.agents/skills/xaui-review/SKILL.md
+++ b/.agents/skills/xaui-review/SKILL.md
@@ -169,7 +169,7 @@ pnpm lint && pnpm type-check && pnpm test
 - [ ] All three green — paste the real result, never "should pass".
 - [ ] Demo screen renders in light **and** dark.
 - [ ] Legacy equivalent carries `@deprecated` pointing at the replacement.
-- [ ] A changeset exists (`patch` — we are in beta) for every touched package.
+- [ ] A changeset exists (`patch` — we are on the `alpha` line) for every touched package.
 
 ## The one blocking review of the project
 

--- a/.claude/skills/xaui-flow/SKILL.md
+++ b/.claude/skills/xaui-flow/SKILL.md
@@ -95,7 +95,7 @@ progress is recorded, and it moves in the same commit as the work.
 
 ## 7. Changeset
 
-One per touched package, **always `patch`** while we're in beta:
+One per touched package, **always `patch`** while we're on the `alpha` line:
 
 ```bash
 pnpm changeset

--- a/.claude/skills/xaui-review/SKILL.md
+++ b/.claude/skills/xaui-review/SKILL.md
@@ -169,7 +169,7 @@ pnpm lint && pnpm type-check && pnpm test
 - [ ] All three green — paste the real result, never "should pass".
 - [ ] Demo screen renders in light **and** dark.
 - [ ] Legacy equivalent carries `@deprecated` pointing at the replacement.
-- [ ] A changeset exists (`patch` — we are in beta) for every touched package.
+- [ ] A changeset exists (`patch` — we are on the `alpha` line) for every touched package.
 
 ## The one blocking review of the project
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,8 +133,8 @@ Commits follow commitizen. **No Claude co-author line.** Commit progressively �
 per coherent unit as the work lands, not one at the end.
 
 Before the PR: create a changeset per touched package (`pnpm changeset`, always **patch**,
-we are in beta), commit the `.changeset/*.md`, run `pnpm lint && pnpm type-check && pnpm
-test`, and run the `xaui-review` skill on the diff.
+we are on the `alpha` line — see §Release), commit the `.changeset/*.md`, run `pnpm lint &&
+pnpm type-check && pnpm test`, and run the `xaui-review` skill on the diff.
 
 ```bash
 gh pr create --assignee @me --label documentation
@@ -151,6 +151,28 @@ gh pr create --assignee @me --label documentation
 Changesets, fully automated. **Never run `pnpm changeset version`, `pnpm version-packages`
 or `pnpm release` locally** — merging to `main` opens or updates a "Version Packages" PR,
 and merging that one publishes.
+
+### The `alpha` line
+
+The repo is in changesets **pre mode** with the tag `alpha` (`.changeset/pre.json`), so
+`@xaui/native` and `@xaui/hybrid` are versioned `0.9.x-alpha.x` and published on the
+`alpha` dist-tag. `latest` keeps pointing at `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`
+— the last releases that carry components — because v1's `src/` is still the theme layer
+alone. `pnpm add @xaui/native@alpha` is how you get it.
+
+Three consequences, all of them load-bearing:
+
+- **Never `changeset pre exit`** unless the task says to. It graduates both packages onto
+  `latest`, which today means handing every `npm i @xaui/native` a package with no
+  components. It is required exactly once, right before `1.0.0`.
+- **Pre mode is repo-wide.** A changeset on `@xaui/native-legacy` versions it `-alpha.x`
+  too. Legacy is frozen so this is rare, but a genuine `0.2.x` fix needs pre mode exited
+  for that release.
+- **A package that has never been published must not have its first publish under pre
+  mode.** `getReleaseTag` gives the pre tag to any package whose `publishedState` is not
+  `"only-pre"`, and `"never"` is not `"only-pre"` — so it would go out tagged `alpha` with
+  no `latest` tag at all, and `npm i <pkg>` would fail to resolve. `@xaui/native-legacy` is
+  the one package this still applies to.
 
 CI on PRs to `main`/`dev`: tokens check → lint → type check → test → build, plus CodeQL.
 The release workflow runs on push to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,5 +9,13 @@ Two pointers that save a lookup:
 - Task status: `.project-specs/ROADMAP.md`
 - The plan the work follows: `.project-specs/XAUI-V1-PLAN.md`
 
+**`@xaui/native` and `@xaui/hybrid` are on the `alpha` line.** The repo sits in changesets
+pre mode (`.changeset/pre.json`, tag `alpha`), so every version those two packages get is
+named `0.9.x-alpha.x` and every publish lands on the `alpha` dist-tag. `latest` stays where
+it is — `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`, the last releases that carry
+components — until the v1 core is real. Never run `changeset pre exit` unless asked: it
+would graduate both packages onto `latest` with a theme layer and no components. AGENTS.md
+§Release and plan §Versions have the rest.
+
 Skills live in `.agents/skills/<name>/SKILL.md`, copied into `.claude/skills/`. Start any
 non-trivial task with `xaui-flow`; run `xaui-review` on the diff before every PR.


### PR DESCRIPTION
## What

- `CLAUDE.md` states it up front: `@xaui/native` and `@xaui/hybrid` are versioned
  `0.9.x-alpha.x` and published on the `alpha` dist-tag, `latest` stays on
  `@xaui/native@0.2.8` / `@xaui/hybrid@0.0.14`, and `changeset pre exit` is not to be run
  unasked.
- `AGENTS.md` §Release gains an `alpha` line subsection with the mechanics and the three
  consequences of pre mode.
- Drops "we are in beta" from the changeset instruction in `AGENTS.md` and from the
  `xaui-flow` / `xaui-review` skills (both `.agents/` and `.claude/` copies).

## Why

#168 put the repo in changesets pre mode and the release has run — `npm view` confirms
`@xaui/native` is `{ latest: '0.2.8', alpha: '0.9.1-alpha.0' }` and `@xaui/hybrid` is
`{ latest: '0.0.14', alpha: '0.9.1-alpha.0' }`. That state was documented in the plan, which
is where a reader looks for *decisions*, but not in the files an agent actually loads before
touching the repo. The failure it prevents is concrete: `changeset pre exit` at the wrong
moment moves `latest` off a 47-component library and onto a package that currently exports
`createTheme` and `XAUIProvider` and nothing else — irreversible on npm.

The "we are in beta" phrasing became false the moment the tag changed, and it sits exactly
where someone reads how to write a changeset.

## How

Prose only. Six files, no code, no publishable package touched, so no changeset.

`AGENTS.md` and `xaui-review/SKILL.md` were already outside Prettier's style before this
branch (verified against `HEAD`), so they are left as they are rather than reformatted in a
docs PR.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 tasks
      pass
- [x] `.agents/` and `.claude/` skill copies verified byte-identical after the edit
- [x] No remaining "in beta" in `CLAUDE.md`, `AGENTS.md`, the skills or `.project-specs/`