### PR TITLE
chore(legacy): publish @xaui/native-legacy@0.2.11 and freeze it (P0.11)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@xaui/native-legacy", "demo", "docs"]
 }

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -15,7 +15,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P0.8  | Legacy `core-shim.ts`                                    | done   |
 | P0.9  | Package hygiene and optional peers                       | done   |
 | P0.10 | ESLint rule for R13                                      | done   |
-| P0.11 | Publish `@xaui/native-legacy@0.2.8` and the codemod      | todo   |
+| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod     | done   |
 | P0.12 | Delete `@xaui/core` and `@xaui/icons`                     | done   |
 | P0.13 | Publish `native` and `hybrid` on the `alpha` tag          | done   |
 | P1    | `system/` — recipe, slots, feedback, portal, icon, hooks | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -809,7 +809,7 @@ L'ancien tree ne devient **pas** un sous-chemin de `@xaui/native`. Il est republ
 
 | Package | Contenu | Version |
 |---|---|---|
-| `@xaui/native-legacy` | les 47 composants actuels, figés | `0.2.8` — le même numéro que la dernière release réelle, pour que la correspondance soit évidente |
+| `@xaui/native-legacy` | les 47 composants actuels, figés | `0.2.11` — le dernier numéro que le package a réellement porté avant sa publication (le `0.2.8` visé à l'origine a été dépassé par les trois patchs de P0 : core-shim, icônes inlinées) |
 | `@xaui/native` | l'API v1, repart de zéro | `1.0.0` |
 | `@xaui/hybrid` | gelé pendant P0–P4 | `0.9.x-alpha.x` — thème seulement, publié sur le tag `alpha` ; `latest` reste sur `0.0.14` |
 
@@ -902,7 +902,7 @@ startContent={<I/>} / endContent={<I/>}     → <X.Icon/> placé dans l'ordre vo
 
 | Package | Version | Contenu |
 |---|---|---|
-| `@xaui/native-legacy` | `0.2.8` | publié une fois, figé. Correctifs en `0.2.x` |
+| `@xaui/native-legacy` | `0.2.11` | publié une fois, figé — et figé pour de bon : le package est dans `ignore` (`.changeset/config.json`), donc changesets ne le versionne plus. Un correctif `0.2.x` demande de le sortir de la liste |
 | `@xaui/native` | `0.9.x-alpha.x` | le noyau arrive composant par composant, API instable et annoncée comme telle |
 | `@xaui/native` | `1.0.0` | noyau de 15 composants + doc complète |
 | `@xaui/native` | `1.x` | les 32 composants restants |
@@ -910,10 +910,10 @@ startContent={<I/>} / endContent={<I/>}     → <X.Icon/> placé dans l'ordre vo
 
 Les préversions `0.9.x-alpha` remplacent les `0.4.x – 0.9.x` du modèle précédent : comme `@xaui/native` repart de zéro, publier des mineures qui ne contiennent que deux ou trois composants donnerait un package inutilisable sous un numéro qui promet le contraire. Un tag `alpha` dit la vérité.
 
-Concrètement, le dépôt est en **pre mode changesets** (`.changeset/pre.json`, tag `alpha`) : `changeset publish` pousse `native` et `hybrid` sous le dist-tag `alpha`, et `latest` reste sur les dernières releases qui portent réellement des composants — `@xaui/native@0.2.8` et `@xaui/hybrid@0.0.14`. Un `npm i @xaui/native` continue donc de renvoyer `0.2.8` ; l'opt-in est `@xaui/native@alpha`. Deux conséquences à garder en tête :
+Concrètement, le dépôt est en **pre mode changesets** (`.changeset/pre.json`, tag `alpha`) : `changeset publish` pousse `native` et `hybrid` sous le dist-tag `alpha`, et `latest` reste sur les dernières releases qui portent réellement des composants — `@xaui/native@0.2.8` et `@xaui/hybrid@0.0.14`. Un `npm i @xaui/native` continue donc de renvoyer `0.2.8` ; l'opt-in est `@xaui/native@alpha`. Trois conséquences à garder en tête :
 
-- **Le pre mode est global au dépôt.** Un changeset sur `@xaui/native-legacy` pendant cette fenêtre le versionnerait aussi en `-alpha.x`. Legacy est figé, donc le cas est rare — mais un correctif `0.2.x` réel demande de sortir du pre mode (`changeset pre exit`) le temps de la release.
-- **La première publication d'un package jamais publié doit se faire hors pre mode.** `getReleaseTag` (`@changesets/cli`) donne le tag pre à tout package dont `publishedState !== "only-pre"`, ce qui inclut `"never"` : un premier publish sous pre mode sortirait taggé `alpha` sans tag `latest`, et `npm i <pkg>` échouerait. C'est le cas de `@xaui/native-legacy` (§7).
+- **Le pre mode est global au dépôt, et il contamine les dépendants.** Il n'y a même pas besoin d'un changeset sur `@xaui/native-legacy` : comme il déclare `@xaui/native` en peer dep, la release `0.9.1-alpha.0` l'a bumpé en `0.2.12-alpha.0` au passage. C'est pour ça que legacy est dans `ignore` (`.changeset/config.json`) — sinon chaque alpha de `native` lui collerait un numéro d'alpha alors qu'il est figé. `demo` et `docs` y sont aussi, parce que changesets exige que tout dépendant d'un package ignoré le soit également.
+- **Le tag d'un premier publish ne se négocie pas en pre mode.** `getReleaseTag` (`@changesets/cli`) donne le tag pre à tout package dont `publishedState !== "only-pre"`, ce qui inclut `"never"` : un package jamais publié sort donc taggé `alpha`, sans tag `latest` du tout. Et il n'y a pas d'échappatoire propre — `changeset publish --tag` est refusé en pre mode, et `changeset pre exit` ne suffit pas (le `preState` est passé au publish quel que soit son mode ; seul le `changeset version` suivant supprime `pre.json`, en graduant `native` et `hybrid` sur `latest` au passage). La sortie de secours est en aval : publier sous `alpha`, puis `npm dist-tag add <pkg>@<version> latest`. C'est ce qui a été fait pour `@xaui/native-legacy@0.2.11`.
 - **`changeset pre exit` avant `1.0.0`**, sinon la version stable n'atteindrait jamais le tag `latest`.
 
 ---
@@ -1043,7 +1043,7 @@ Renommer le package npm casse par définition. La phase se termine par une publi
    → `npm i @xaui/native` sur un projet nu n'émet aucun warning de peer manquante.
 10. **Règle ESLint R13.** `left`, `right`, `paddingLeft`… interdits dans `packages/native/src`.
     → La règle est active et `pnpm lint` passe.
-11. **Publier `@xaui/native-legacy@0.2.8`** + le codemod `legacy-imports`.
+11. **Publier `@xaui/native-legacy@0.2.11`** + le codemod `legacy-imports`.
     → Un projet témoin migre ses imports et compile.
 
 > **Deux tâches ont disparu de cette liste** : « `forwardRef` sur tous les roots » et « `style`/`testID`/a11y sur tous les roots ». Elles visaient les 47 composants quand legacy et v1 partageaient un tree. Legacy est maintenant figé et déprécié — les rétrofiter serait du travail mort. Pour la v1, ce ne sont pas des tâches mais les règles R9 et R12, appliquées à l'écriture de chaque composant.
@@ -1184,4 +1184,4 @@ L'ordre de P0 n'est pas indicatif : le `git mv` vient en premier, sinon tout le 
 4. `theme/create-theme.ts` puis `provider/xaui-provider.tsx`
 5. `native-legacy/core-shim.ts` — premier point de vérification réel : un `Button` legacy doit rendre sous le nouveau provider
 
-Fin de la première session. `@xaui/native-legacy@0.2.8` peut être publié ici ; `@xaui/native` attend d'avoir un composant, en P2.
+Fin de la première session. `@xaui/native-legacy@0.2.11` peut être publié ici ; `@xaui/native` attend d'avoir un composant, en P2.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,14 +165,21 @@ Three consequences, all of them load-bearing:
 - **Never `changeset pre exit`** unless the task says to. It graduates both packages onto
   `latest`, which today means handing every `npm i @xaui/native` a package with no
   components. It is required exactly once, right before `1.0.0`.
-- **Pre mode is repo-wide.** A changeset on `@xaui/native-legacy` versions it `-alpha.x`
-  too. Legacy is frozen so this is rare, but a genuine `0.2.x` fix needs pre mode exited
-  for that release.
-- **A package that has never been published must not have its first publish under pre
-  mode.** `getReleaseTag` gives the pre tag to any package whose `publishedState` is not
-  `"only-pre"`, and `"never"` is not `"only-pre"` — so it would go out tagged `alpha` with
-  no `latest` tag at all, and `npm i <pkg>` would fail to resolve. `@xaui/native-legacy` is
-  the one package this still applies to.
+- **Pre mode is repo-wide and reaches dependents.** No changeset on a package is needed for
+  it to catch an alpha number: `@xaui/native-legacy` peer-depends on `@xaui/native`, so
+  `0.9.1-alpha.0` bumped it to `0.2.12-alpha.0` on its own. That is why
+  `@xaui/native-legacy` sits in `ignore` (`.changeset/config.json`) — it is frozen at
+  `0.2.11` and must stay there. `demo` and `docs` are in that list too, because changesets
+  requires every dependent of an ignored package to be ignored as well. A genuine `0.2.x`
+  fix on legacy means taking it out of `ignore` for that release.
+- **The tag on a first publish cannot be chosen in pre mode.** `getReleaseTag` gives the
+  pre tag to any package whose `publishedState` is not `"only-pre"`, and `"never"` is not
+  `"only-pre"` — so a never-published package goes out tagged `alpha` with no `latest` tag
+  at all. There is no clean way out: `changeset publish --tag` is refused in pre mode, and
+  `changeset pre exit` does not help (publish reads `preState` whatever its mode; only the
+  next `changeset version` deletes `pre.json`, and it graduates `native` and `hybrid` onto
+  `latest` while doing so). Fix it downstream instead —
+  `npm dist-tag add <pkg>@<version> latest`.
 
 CI on PRs to `main`/`dev`: tokens check → lint → type check → test → build, plus CodeQL.
 The release workflow runs on push to `main`.

--- a/packages/native-legacy/CHANGELOG.md
+++ b/packages/native-legacy/CHANGELOG.md
@@ -1,11 +1,4 @@
-# @xaui/mobile
-
-## 0.2.12-alpha.0
-
-### Patch Changes
-
-- Updated dependencies [88c692a]
-  - @xaui/native@0.9.1-alpha.0
+# @xaui/native-legacy
 
 ## 0.2.11
 

--- a/packages/native-legacy/package.json
+++ b/packages/native-legacy/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@xaui/native-legacy",
-  "version": "0.2.12-alpha.0",
-  "private": true,
+  "version": "0.2.11",
   "description": "Frozen @xaui/native v0.2.x components, republished for migration to @xaui/native v1",
   "keywords": [
     "react-native",
@@ -14,6 +13,7 @@
     "animations",
     "xaui"
   ],
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -266,7 +266,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rygrams/xaui.git",
-    "directory": "packages/native"
+    "directory": "packages/native-legacy"
   },
   "scripts": {
     "build": "rm -rf dist && NODE_OPTIONS=--max-old-space-size=4096 tsup --config tsup.config.ts",


### PR DESCRIPTION
## What

- Drops `private: true` from `@xaui/native-legacy` and pins it back to **`0.2.11`**.
- Adds `@xaui/native-legacy`, `demo` and `docs` to `ignore` in `.changeset/config.json`.
- Adds the missing `license` field and fixes `repository.directory`.
- Cleans the CHANGELOG: drops the `0.2.12-alpha.0` entry and the `@xaui/mobile` title left
  over from an older rename.
- Records what pre mode actually does here, in plan §Versions and AGENTS.md §Release.
- ROADMAP P0.11 → `done`.

## Why

P0.11 is the last open P0 item, and the codemod from #161 rewrites imports to a package
that does not exist on npm yet — so the migration path is broken until this ships.

**Why `0.2.11` and not `0.2.8`.** The plan wanted the number of the last real pre-split
release. That is no longer reachable: three P0 patches (core-shim, then the inlined icons)
already took the package to `0.2.11` while it was private, and changesets wrote the
matching CHANGELOG entries. Then the `0.9.1-alpha.0` release bumped it again, to
`0.2.12-alpha.0` — nobody asked it to, but legacy peer-depends on `@xaui/native`, so it came
along as a dependent. An alpha suffix on a frozen 47-component tree says the opposite of the
truth, and neither number was ever published, so pinning back to `0.2.11` costs nothing.

**Why `ignore`.** That dependent bump is not a one-off — every future alpha of
`@xaui/native` would do it again, and each one would publish another `0.2.x-alpha.N` of a
package that is supposed to be frozen. `ignore` stops changesets versioning it at all, which
is exactly what §7 asks for ("publié une fois, figé"). `demo` and `docs` have to join the
list because changesets validates that every dependent of an ignored package is ignored too
— both are private apps that never publish, so losing their version churn is a small gain.
Verified that this still publishes: `publishPackages` filters on `pkg.packageJson.private`
alone and never consults `config.ignore` (`changesets-cli.cjs.js:849`).

## ⚠️ One manual step after the release runs

The package will be published **tagged `alpha`, with no `latest` tag**, and
`npm i @xaui/native-legacy` will not resolve until someone runs:

```bash
npm dist-tag add @xaui/native-legacy@0.2.11 latest
```

That is not avoidable from inside the repo, and I checked all three exits:

- `getReleaseTag` returns the pre tag for any package whose `publishedState !== "only-pre"`,
  and a never-published package reports `"never"` (`changesets-cli.cjs.js:812`, `:891`).
- `changeset publish --tag latest` is **refused** in pre mode — "Releasing under custom tag
  is not allowed in pre mode" (`:971`).
- `changeset pre exit` does **not** help: publish receives `preState` whatever its mode
  (`:970`, `:989`), and the file only disappears at the next `changeset version`, which
  would graduate `native` and `hybrid` from `0.9.1-alpha.0` to `0.9.1` **onto `latest`** —
  the exact outcome #168 existed to prevent.

So the tag gets fixed downstream, once. After that the version never moves again, so this
is a one-time step, not a recurring chore.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 pass
- [x] `npx changeset status` — config accepted, `ignore` list validates, nothing pending
- [x] `pnpm pack` — `xaui-native-legacy-0.2.11.tgz`, and the tarball carries `README.md` +
      `LICENSE` alongside `dist/` and `package.json`
- [x] `publishPackages` / `getReleaseTag` / `getUnpublishedPackages` read in
      `@changesets/cli@2.29.8` to confirm both that the package still publishes and which
      tag it lands on
- [x] No changeset, by design: `0.2.11` is absent from the registry (`npm view` → 404) and
      `changeset publish` ships any unpublished version