### PR TITLE
feat(system): the slot primitives, on @xaui/native/system (P1.2)

### DIFF
--- a/.changeset/slot-system.md
+++ b/.changeset/slot-system.md
@@ -1,0 +1,20 @@
+---
+'@xaui/native': patch
+---
+
+Add the slot primitives to `@xaui/native/system`: `createSlotContext`,
+`childrenToString`, `Slot`, `mergeProps` and `mergeRefs`.
+
+`createSlotContext(name)` returns a `[Provider, useSlot]` pair, so each compound names the
+hook it exports and a slot read outside its root throws an error naming both the hook and
+the component instead of failing three frames later on `undefined`.
+
+`childrenToString` implements the text auto-wrap once for the whole library. It stringifies
+the tree recursively rather than inspecting the first child, which is what makes
+`<Button>{count} items</Button>` — children `[3, ' items']` — resolve to `'3 items'`.
+
+`Slot` is the `asChild` render branch: `const Root = asChild ? Slot : Pressable`. It merges
+through `mergeProps`, which composes event handlers rather than replacing them, stacks
+styles with the child's on top, keeps a `Pressable` state-function style callable, and
+merges refs. `asChild` has to be uniform from the first component — retrofitting it changes
+the ref signature of every core component at once.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -19,7 +19,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P0.12 | Delete `@xaui/core` and `@xaui/icons`                     | done   |
 | P0.13 | Publish `native` and `hybrid` on the `alpha` tag          | done   |
 | P1.1  | `system/recipe/` — engine, cache, tint                   | done   |
-| P1.2  | `system/slot/` — context, `childrenToString`, merges     | todo   |
+| P1.2  | `system/slot/` — context, `childrenToString`, merges     | done   |
 | P1.3  | `system/pressable-feedback/`                             | todo   |
 | P1.4  | `system/portal/`                                         | todo   |
 | P1.5  | `system/icon/`                                           | todo   |

--- a/packages/native/src/__tests__/system/slot/children-to-string.test.ts
+++ b/packages/native/src/__tests__/system/slot/children-to-string.test.ts
@@ -1,0 +1,40 @@
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+import { childrenToString } from '../../../system/slot/children-to-string'
+
+const element = createElement('span', null, 'icon')
+
+describe('childrenToString', () => {
+  it('stringifies a mixed array, which is the case R3 exists for', () => {
+    // `<Button>{count} items</Button>` hands children as `[3, ' items']`. Inspecting the
+    // first child would have called this an element and passed it through unwrapped.
+    expect(childrenToString([3, ' items'])).toBe('3 items')
+  })
+
+  it('takes a plain string or number', () => {
+    expect(childrenToString('Save')).toBe('Save')
+    expect(childrenToString(0)).toBe('0')
+  })
+
+  it('flattens nested arrays', () => {
+    expect(childrenToString(['a', ['b', ['c', 1]]])).toBe('abc1')
+  })
+
+  it('drops what React renders as nothing', () => {
+    expect(childrenToString(['Save', null, undefined, false])).toBe('Save')
+  })
+
+  it('returns null as soon as the tree holds an element', () => {
+    expect(childrenToString(element)).toBeNull()
+    expect(childrenToString(['Save', element])).toBeNull()
+    expect(childrenToString([element, 'Save'])).toBeNull()
+    expect(childrenToString(['a', ['b', element]])).toBeNull()
+  })
+
+  it('returns null for an empty result, so no root wraps an empty text node', () => {
+    expect(childrenToString(null)).toBeNull()
+    expect(childrenToString(false)).toBeNull()
+    expect(childrenToString('')).toBeNull()
+    expect(childrenToString([null, undefined])).toBeNull()
+  })
+})

--- a/packages/native/src/__tests__/system/slot/create-slot-context.test.tsx
+++ b/packages/native/src/__tests__/system/slot/create-slot-context.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react'
+import { createElement } from 'react'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { createSlotContext } from '../../../system/slot/create-slot-context'
+
+type ButtonContext = { size: string }
+
+/**
+ * The one hook this repo tests. The rule sends component hooks to their demo screen, and
+ * a factory in `system/` has no screen to be verified on — while "a hook used outside its
+ * parent raises a named error" is a stated acceptance criterion of P1.2.
+ */
+describe('createSlotContext', () => {
+  it('hands the root value to a slot inside it', () => {
+    const [Provider, useButton] = createSlotContext<ButtonContext>('Button')
+    const value = { size: 'md' }
+
+    const { result } = renderHook(() => useButton(), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(Provider, { value }, children),
+    })
+
+    expect(result.current).toBe(value)
+  })
+
+  it('names the hook and its root when a slot is used outside one', () => {
+    const [, useButton] = createSlotContext<ButtonContext>('Button')
+
+    expect(() => renderHook(() => useButton())).toThrow(
+      /useButton must be called inside <Button>/
+    )
+  })
+
+  it('says why, not just what', () => {
+    const [, useSelect] = createSlotContext<ButtonContext>('Select')
+
+    expect(() => renderHook(() => useSelect())).toThrow(/values its root resolved/)
+  })
+})

--- a/packages/native/src/__tests__/system/slot/merge-props.test.ts
+++ b/packages/native/src/__tests__/system/slot/merge-props.test.ts
@@ -1,0 +1,100 @@
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { mergeProps } from '../../../system/slot/merge-props'
+
+describe('mergeProps', () => {
+  it('lets the child win on an ordinary prop, and keeps ours where it set none', () => {
+    expect(
+      mergeProps(
+        { accessibilityRole: 'button', testID: 'ours' },
+        { testID: 'theirs' }
+      )
+    ).toEqual({ accessibilityRole: 'button', testID: 'theirs' })
+  })
+
+  it('composes event handlers instead of replacing one with the other', () => {
+    const calls: string[] = []
+    const ours = vi.fn(() => calls.push('ours'))
+    const theirs = vi.fn(() => calls.push('theirs'))
+
+    const merged = mergeProps({ onPress: ours }, { onPress: theirs })
+    ;(merged.onPress as () => void)()
+
+    expect(ours).toHaveBeenCalledOnce()
+    expect(theirs).toHaveBeenCalledOnce()
+    // Ours first: the press state that drives our styles settles before the child's
+    // navigation runs.
+    expect(calls).toEqual(['ours', 'theirs'])
+  })
+
+  it('passes the arguments through to both handlers', () => {
+    const ours = vi.fn()
+    const theirs = vi.fn()
+
+    const merged = mergeProps({ onPress: ours }, { onPress: theirs })
+    ;(merged.onPress as (event: string) => void)('event')
+
+    expect(ours).toHaveBeenCalledWith('event')
+    expect(theirs).toHaveBeenCalledWith('event')
+  })
+
+  it('keeps whichever handler exists when only one side has one', () => {
+    const ours = vi.fn()
+
+    expect(mergeProps({ onPress: ours }, {}).onPress).toBe(ours)
+    expect(mergeProps({ onPress: ours }, { onPress: undefined }).onPress).toBe(ours)
+    expect(mergeProps({}, { onPress: ours }).onPress).toBe(ours)
+  })
+
+  it('stacks styles with the child on top', () => {
+    const merged = mergeProps({ style: { padding: 4 } }, { style: { padding: 8 } })
+
+    expect(merged.style).toEqual([{ padding: 4 }, { padding: 8 }])
+  })
+
+  it('keeps a style function callable, so a Pressable state style survives', () => {
+    const ours = vi.fn(({ pressed }: { pressed: boolean }) => ({
+      opacity: pressed ? 1 : 0,
+    }))
+
+    const merged = mergeProps({ style: ours }, { style: { padding: 8 } })
+    const style = merged.style as (state: { pressed: boolean }) => unknown
+
+    expect(typeof merged.style).toBe('function')
+    expect(style({ pressed: true })).toEqual([{ opacity: 1 }, { padding: 8 }])
+    expect(ours).toHaveBeenCalledWith({ pressed: true })
+  })
+
+  it('calls both style functions when both sides are dynamic', () => {
+    const merged = mergeProps(
+      {
+        style: ({ pressed }: { pressed: boolean }) => ({ opacity: pressed ? 1 : 0 }),
+      },
+      {
+        style: ({ pressed }: { pressed: boolean }) => ({ padding: pressed ? 8 : 4 }),
+      }
+    )
+    const style = merged.style as (state: { pressed: boolean }) => unknown
+
+    expect(style({ pressed: false })).toEqual([{ opacity: 0 }, { padding: 4 }])
+  })
+
+  it('merges refs rather than dropping one — React 19 passes ref as a prop', () => {
+    const ours = createRef<string>()
+    const theirs = createRef<string>()
+
+    const merged = mergeProps({ ref: ours }, { ref: theirs })
+    ;(merged.ref as (value: string) => void)('node')
+
+    expect(ours.current).toBe('node')
+    expect(theirs.current).toBe('node')
+  })
+
+  it('leaves ours untouched', () => {
+    const ours = { testID: 'ours' }
+
+    mergeProps(ours, { testID: 'theirs' })
+
+    expect(ours).toEqual({ testID: 'ours' })
+  })
+})

--- a/packages/native/src/__tests__/system/slot/merge-refs.test.ts
+++ b/packages/native/src/__tests__/system/slot/merge-refs.test.ts
@@ -1,0 +1,36 @@
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { mergeRefs } from '../../../system/slot/merge-refs'
+
+describe('mergeRefs', () => {
+  it('feeds object refs and callback refs alike', () => {
+    const object = createRef<string>()
+    const callback = vi.fn()
+
+    mergeRefs<string>(object, callback)('node')
+
+    expect(object.current).toBe('node')
+    expect(callback).toHaveBeenCalledWith('node')
+  })
+
+  it('skips the refs that were never passed', () => {
+    const object = createRef<string>()
+
+    expect(() => mergeRefs<string>(undefined, object, null)('node')).not.toThrow()
+    expect(object.current).toBe('node')
+  })
+
+  it('forwards the null React sends on unmount', () => {
+    const object = createRef<string>()
+    const merged = mergeRefs<string>(object)
+
+    merged('node')
+    merged(null)
+
+    expect(object.current).toBeNull()
+  })
+
+  it('returns nothing, so React 19 does not read a cleanup where React 18 sees none', () => {
+    expect(mergeRefs<string>(vi.fn(() => 'not a cleanup'))('node')).toBeUndefined()
+  })
+})

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -22,9 +22,10 @@ re-exported from `utils/`.
 
 ## Current contents
 
-| Folder    | Role                                                                |
-| --------- | ------------------------------------------------------------------- |
-| `recipe/` | The style engine: variants name tokens, styles resolve once, cached |
+| Folder    | Role                                                                 |
+| --------- | -------------------------------------------------------------------- |
+| `recipe/` | The style engine: variants name tokens, styles resolve once, cached  |
+| `slot/`   | Compound plumbing: strict context, text auto-wrap, `asChild` merging |
 
 ## `recipe/` in one page
 
@@ -61,3 +62,43 @@ token names. `paint` is written once per component and says which slot takes the
 background and which takes the foreground. The tint pass reuses it, which is how `color`
 lands where the variant put its tokens with nothing further to declare: a background for
 `primary`, a label for `ghost`, a border for `tertiary`.
+
+## `slot/` in one page
+
+Four primitives, and every compound uses all four.
+
+**`createSlotContext(name)`** returns `[Provider, useSlot]`. The tuple lets each compound
+name its own hook, which R10 requires it to export:
+
+```ts
+export const [ButtonProvider, useButton] = createSlotContext<ButtonContext>('Button')
+```
+
+Reading it outside its root throws a named error pointing at the misplaced component, not
+`undefined is not an object` three frames later. The context carries values the root
+already **resolved** — style references, not tokens for the slot to resolve again (R5).
+
+**`childrenToString(children)`** implements R3 once for the whole library: the string a
+root should wrap in its default text slot, or `null` when it should render children as
+they are. It stringifies the tree recursively instead of inspecting the first child,
+which is the only way `<Button>{count} items</Button>` works — children there are the
+array `[3, ' items']`.
+
+**`Slot`** is the `asChild` render branch (R12), one line per root:
+
+```tsx
+const Root = asChild ? Slot : Pressable
+return (
+  <Root ref={ref} {...rootProps}>
+    {children}
+  </Root>
+)
+```
+
+**`mergeProps` / `mergeRefs`** are what `Slot` merges with, and are public because a root
+doing something unusual may need them directly. Event handlers compose rather than
+replace, styles stack with the child's on top, `ref`s merge, and the child wins on
+everything else.
+
+`asChild` has to be uniform from the very first component: retrofitting it changes the
+ref signature of all fifteen core components at once.

--- a/packages/native/src/system/index.ts
+++ b/packages/native/src/system/index.ts
@@ -1,1 +1,2 @@
 export * from './recipe'
+export * from './slot'

--- a/packages/native/src/system/slot/children-to-string.ts
+++ b/packages/native/src/system/slot/children-to-string.ts
@@ -1,0 +1,45 @@
+import { isValidElement } from 'react'
+import type { ReactNode } from 'react'
+
+/**
+ * R3: the string a root should wrap in its default text slot, or `null` when it should
+ * render its children as they are.
+ *
+ * The whole tree is stringified recursively rather than the first child inspected. That
+ * is what makes `<Button>{count} items</Button>` work — children there are the array
+ * `[3, ' items']`, and an `isValidElement` check on the first entry would call it an
+ * element-free tree only by accident, while a check for "is the first child a string"
+ * would miss it outright.
+ *
+ * `null` for an empty result as much as for a tree containing an element: in both cases
+ * there is nothing to wrap, and a root's fallback — render the children — is right for
+ * both. It also keeps `<Button>{false}</Button>` from mounting an empty text node.
+ */
+export function childrenToString(children: ReactNode): string | null {
+  const text = stringify(children)
+  return text === null || text === '' ? null : text
+}
+
+function stringify(node: ReactNode): string | null {
+  // What React itself renders as nothing.
+  if (node === null || node === undefined || typeof node === 'boolean') return ''
+
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+
+  // Any element — a fragment included — means the tree is not text.
+  if (isValidElement(node)) return null
+
+  if (Array.isArray(node)) {
+    let text = ''
+    for (const child of node) {
+      const part = stringify(child as ReactNode)
+      if (part === null) return null
+      text += part
+    }
+    return text
+  }
+
+  // An iterable, a portal, a promise: renderable, but not text this can flatten.
+  return null
+}

--- a/packages/native/src/system/slot/create-slot-context.ts
+++ b/packages/native/src/system/slot/create-slot-context.ts
@@ -1,0 +1,50 @@
+import { createContext, useContext } from 'react'
+import type { Provider } from 'react'
+
+type CaptureStackTrace = {
+  captureStackTrace?: (
+    target: object,
+    constructor?: (...args: never[]) => unknown
+  ) => void
+}
+
+/**
+ * A context a slot cannot read by accident. Every compound gets one, and it carries
+ * **resolved** values — style references the root already computed, not tokens for the
+ * slot to resolve again (R5).
+ *
+ * ```ts
+ * const [ButtonProvider, useButton] = createSlotContext<ButtonContext>('Button')
+ * ```
+ *
+ * The tuple is what lets each compound name its own hook, which R10 requires it to
+ * export. `name` gives both halves of the error, so there is one place to spell it.
+ */
+export function createSlotContext<T>(
+  name: string
+): readonly [Provider<T | null>, () => T] {
+  const Context = createContext<T | null>(null)
+  Context.displayName = `XAUI.${name}.Context`
+
+  function useSlotContext(): T {
+    const value = useContext(Context)
+
+    if (value === null) {
+      const error = new Error(
+        `XAUI: use${name} must be called inside <${name}>. A slot reads the values its ` +
+          'root resolved, so it can only be rendered as a child of one.'
+      )
+      // Points the trace at the offending call site instead of at this file — the
+      // reader needs to know which component was misplaced, not how the hook works.
+      ;(Error as unknown as CaptureStackTrace).captureStackTrace?.(
+        error,
+        useSlotContext
+      )
+      throw error
+    }
+
+    return value
+  }
+
+  return [Context.Provider, useSlotContext] as const
+}

--- a/packages/native/src/system/slot/index.ts
+++ b/packages/native/src/system/slot/index.ts
@@ -1,0 +1,7 @@
+export { childrenToString } from './children-to-string'
+export { createSlotContext } from './create-slot-context'
+export { mergeProps } from './merge-props'
+export { mergeRefs } from './merge-refs'
+export { Slot } from './slot'
+export type { SlotProps } from './slot'
+export type { AsChildProps, MergeableProps, PossibleRef } from './slot.type'

--- a/packages/native/src/system/slot/merge-props.ts
+++ b/packages/native/src/system/slot/merge-props.ts
@@ -1,0 +1,79 @@
+import type { PressableStateCallbackType, StyleProp } from 'react-native'
+import { mergeRefs } from './merge-refs'
+import type { MergeableProps, PossibleRef } from './slot.type'
+
+type Handler = (...args: never[]) => unknown
+type Style =
+  | StyleProp<unknown>
+  | ((state: PressableStateCallbackType) => StyleProp<unknown>)
+
+const EVENT_HANDLER = /^on[A-Z]/
+
+/**
+ * Merges a root's own props into the child it renders through `asChild` (R12). Four
+ * rules, and the child wins wherever they do not apply — it is the more specific intent:
+ *
+ * - **Event handlers compose.** Both run, ours first: the component's own behaviour (the
+ *   press state that drives its styles) happens before the child's side effect (the
+ *   navigation). Replacing one with the other is the bug this exists to prevent.
+ * - **Styles stack**, ours under the child's, so the child can override.
+ * - **`ref`s merge** through `mergeRefs`. React 19 passes `ref` as an ordinary prop, so
+ *   it arrives here rather than beside the props, and dropping it would sever the root's
+ *   handle on the node.
+ * - **Everything else: the child's value wins**, and ours fills in what it left unset.
+ */
+export function mergeProps(
+  ours: MergeableProps,
+  theirs: MergeableProps
+): MergeableProps {
+  const merged: MergeableProps = { ...ours }
+
+  for (const key of Object.keys(theirs)) {
+    const ourValue = ours[key]
+    const theirValue = theirs[key]
+
+    if (EVENT_HANDLER.test(key)) {
+      merged[key] = composeHandlers(ourValue, theirValue)
+    } else if (key === 'style') {
+      merged[key] = mergeStyles(ourValue as Style, theirValue as Style)
+    } else if (key === 'ref') {
+      merged[key] = mergeRefs(
+        ourValue as PossibleRef<unknown>,
+        theirValue as PossibleRef<unknown>
+      )
+    } else {
+      merged[key] = theirValue
+    }
+  }
+
+  return merged
+}
+
+function composeHandlers(ours: unknown, theirs: unknown): unknown {
+  if (typeof ours !== 'function') return theirs
+  if (typeof theirs !== 'function') return ours
+
+  return (...args: never[]) => {
+    ;(ours as Handler)(...args)
+    return (theirs as Handler)(...args)
+  }
+}
+
+/**
+ * `Pressable` accepts `style` as a function of its press state (R9), so a merge has to
+ * survive either side being one — flattening it to an array would silently drop the
+ * pressed and focused styles of whichever side was dynamic.
+ */
+function mergeStyles(ours: Style, theirs: Style): Style {
+  if (typeof ours === 'function' || typeof theirs === 'function') {
+    return (state: PressableStateCallbackType) => [
+      resolveStyle(ours, state),
+      resolveStyle(theirs, state),
+    ]
+  }
+  return [ours, theirs]
+}
+
+function resolveStyle(style: Style, state: PressableStateCallbackType) {
+  return typeof style === 'function' ? style(state) : style
+}

--- a/packages/native/src/system/slot/merge-refs.ts
+++ b/packages/native/src/system/slot/merge-refs.ts
@@ -1,0 +1,21 @@
+import type { MutableRefObject, RefCallback } from 'react'
+import type { PossibleRef } from './slot.type'
+
+/**
+ * One callback that feeds several refs — what lets a root keep its own handle on a node
+ * while still honouring the ref its caller passed (R9), and what `asChild` needs to
+ * forward a ref into the child it merges into (R12).
+ *
+ * It returns nothing on purpose. React 19 reads a ref callback's return value as a
+ * cleanup function while React 18 ignores it, and this package supports both; letting
+ * a merged cleanup through would behave differently on each. React calls every ref with
+ * `null` on unmount anyway, which this forwards.
+ */
+export function mergeRefs<T>(...refs: Array<PossibleRef<T>>): RefCallback<T> {
+  return value => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') ref(value)
+      else if (ref) (ref as MutableRefObject<T | null>).current = value
+    }
+  }
+}

--- a/packages/native/src/system/slot/slot.tsx
+++ b/packages/native/src/system/slot/slot.tsx
@@ -1,0 +1,47 @@
+import { cloneElement, forwardRef, isValidElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
+import { mergeProps } from './merge-props'
+import { mergeRefs } from './merge-refs'
+import type { MergeableProps, PossibleRef } from './slot.type'
+
+export type SlotProps = MergeableProps & { children?: ReactNode }
+
+/**
+ * The render branch behind `asChild` (R12). A root picks it instead of its own element:
+ *
+ * ```tsx
+ * const Root = asChild ? Slot : Pressable
+ * return <Root ref={ref} {...rootProps}>{children}</Root>
+ * ```
+ *
+ * One line per root, which is the point — forty-seven roots each hand-rolling a
+ * `cloneElement` and a ref merge would drift, and R12 has to hold uniformly from the
+ * first component or the ref signature of the whole core changes later.
+ */
+export const Slot = forwardRef<unknown, SlotProps>(function Slot(
+  { children, ...ours },
+  ref
+) {
+  if (!isValidElement(children)) {
+    throw new Error(
+      'XAUI: asChild expects exactly one React element as its child, and merges the ' +
+        "component's props into it. Text, a fragment, several children or none give it " +
+        'nothing to merge into — drop `asChild` to render the component itself.'
+    )
+  }
+
+  const child: ReactElement = children
+  const merged = mergeProps(ours, child.props as MergeableProps)
+  merged.ref = mergeRefs(ref, refOf(child))
+
+  return cloneElement(child, merged)
+})
+
+Slot.displayName = 'XAUI.Slot'
+
+/** React 19 passes `ref` as an ordinary prop; React 18 keeps it on the element. */
+function refOf(element: ReactElement): PossibleRef<unknown> {
+  const fromProps = (element.props as MergeableProps).ref
+  const fromElement = (element as { ref?: unknown }).ref
+  return (fromProps ?? fromElement) as PossibleRef<unknown>
+}

--- a/packages/native/src/system/slot/slot.type.ts
+++ b/packages/native/src/system/slot/slot.type.ts
@@ -1,0 +1,18 @@
+import type { Ref } from 'react'
+
+/** Anything React accepts as a ref, plus the absence of one. */
+export type PossibleRef<T> = Ref<T> | undefined
+
+/**
+ * The props `mergeProps` knows how to combine. Deliberately loose: it merges whatever a
+ * root hands to whatever child it was given, and neither side is knowable from here.
+ */
+export type MergeableProps = Record<string, unknown>
+
+export type AsChildProps = {
+  /**
+   * Merge this component's props into its single child instead of rendering an element
+   * of its own — a navigation `Link` as a `Button`, a bespoke trigger as a `Select`.
+   */
+  asChild?: boolean
+}


### PR DESCRIPTION
## What

`packages/native/src/system/slot/` — `createSlotContext`, `childrenToString`, `Slot`, `mergeProps`, `mergeRefs` — and 22 tests. Second item of P1, on top of the recipe engine from #172.

## Why

These are the three rules a component cannot be retrofitted with:

- **R3** — text children auto-wrapped, implemented once rather than in 47 roots.
- **R10** — every compound exports its context hook.
- **R12** — `asChild` on every root. *"Le rétrofit après coup change la signature de ref des 15 composants du noyau"* — which is why this lands before the first component, not after.

## How, and the four decisions worth reviewing

**`createSlotContext(name)` returns a tuple, not an object.** `const [ButtonProvider, useButton] = createSlotContext<ButtonContext>('Button')` — destructuring is what lets each compound name the hook it has to export (R10), and the single `name` argument spells both halves of the error message, so there is one place to get it right. Outside its root it throws `XAUI: useButton must be called inside <Button>.` plus the reason, with `Error.captureStackTrace` trimming the trace to the offending call site (guarded with `?.` — it is V8-only).

**`childrenToString` returns `null` for an empty result, not `''`.** An element in the tree and an empty tree both mean "there is nothing to wrap", and a root's fallback — render the children — is right for both. It also stops `<Button>{false}</Button>` from mounting an empty text node. A fragment counts as an element and yields `null`, per §1's wording; worth knowing because `<Button><>{count} items</></Button>` then goes unwrapped, which degrades to rendering children rather than to anything broken.

**`mergeProps` keeps a style *function* a function.** `Pressable` takes `style` as a function of its press state (R9). If either side is dynamic, the merged style stays a function that calls both — flattening it into an array would silently drop the pressed and focused styles of whichever side computed them. That is the bug this file exists to prevent, and it has two tests.

Handlers compose **ours first**, so the component's own behaviour (the press state driving its styles) settles before the child's side effect (the navigation) runs. Everything else: the child wins, ours fills in what it left unset.

**`mergeRefs` deliberately returns nothing.** React 19 reads a ref callback's return value as a cleanup function; React 18 ignores it. The package peers on both, so returning a merged cleanup would behave differently on each. React calls every ref with `null` on unmount anyway, and that is forwarded — there is a test pinning the empty return.

## One file beyond the documented layout

Plan §2 lists `create-slot-context.ts`, `children-to-string.ts`, `merge-props.ts`, `merge-refs.ts`, `slot.type.ts`. I added **`slot.tsx`** — the `Slot` component itself — because R12 describes `asChild` as "a real render branch through `Slot`", and without it every root re-implements the same `cloneElement` + ref-merge dance:

```tsx
const Root = asChild ? Slot : Pressable
return <Root ref={ref} {...rootProps}>{children}</Root>
```

One line per root instead of six, and no room for 47 divergent implementations of a rule that must be uniform. Say the word if you would rather keep the layout literal and have each root do the merge itself.

## Testing

`Slot` has **no test**: it is a component-shaped primitive, like `PressableFeedback`, `Icon` and `Portal`, and its two moving parts are pure functions covered directly — which is precisely why they are separate files.

`createSlotContext` is the one hook with a test, and a deliberate exception: P1.2 names "un hook hors parent lève une erreur nommée" as an acceptance criterion, and a factory in `system/` has no demo screen to be verified on. Three cases, `renderHook`, twenty lines.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 tasks; `@xaui/native` is now 100 tests, 22 of them new
- [x] The two stated acceptance criteria as tests: `childrenToString([3, ' items'])` is `'3 items'`, an element in the tree gives `null`, and a hook outside its parent throws naming both the hook and the component
- [x] `pnpm --filter @xaui/native build` — `dist/system/index.d.ts` grows from 4.49 KB to 8.79 KB, so the new surface is exported
