### PR TITLE
feat(system): Portal and PortalHost (P1.4)

### DIFF
--- a/.changeset/portal.md
+++ b/.changeset/portal.md
@@ -1,0 +1,14 @@
+---
+'@xaui/native': patch
+---
+
+Add `Portal` and `PortalHost` to `@xaui/native/system`.
+
+`Portal` renders its children into the nearest `PortalHost` instead of where it sits, which
+is what `Dialog`, `Sheet`, `Drawer` and `Snackbar` will be built on — an overlay has to
+escape the clipping and stacking of whatever container held the trigger. Publishing happens
+in a layout effect, so the content lands in the same commit as the trigger's and an overlay
+never shows a frame late.
+
+Outside a host the context is `null` and `Portal` renders nothing rather than throwing: an
+app that forgot `PortalHost` should lose its overlays, not crash on its first dialog.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -21,7 +21,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P1.1  | `system/recipe/` — engine, cache, tint                   | done   |
 | P1.2  | `system/slot/` — context, `childrenToString`, merges     | done   |
 | P1.3  | `system/pressable-feedback/`                             | done   |
-| P1.4  | `system/portal/`                                         | todo   |
+| P1.4  | `system/portal/`                                         | done   |
 | P1.5  | `system/icon/`                                           | todo   |
 | P1.6  | Shared hooks                                             | todo   |
 | P1.7  | `pnpm pack` uniqueness check on both packages            | todo   |

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout() {
                 name="pressable-feedback"
                 options={{ title: 'PressableFeedback (v1)' }}
               />
+              <Stack.Screen name="portal" options={{ title: 'Portal (v1)' }} />
               <Stack.Screen name="card" options={{ title: 'Card Examples' }} />
               <Stack.Screen
                 name="carousel"

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -114,6 +114,16 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/portal')}
+            variant="solid"
+            themeColor="primary"
+          >
+            Portal v1
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/card')}
             variant="bordered"
             themeColor="primary"

--- a/apps/demo/app/portal.tsx
+++ b/apps/demo/app/portal.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { Portal, PortalHost } from '@xaui/native/system'
+import { useXAUITheme } from '@xaui/native/theme'
+
+/**
+ * The verification screen for P1.4. The point of a portal is that it escapes a clipping,
+ * stacking parent — so the trigger below sits inside one deliberately.
+ */
+export default function PortalScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <PortalHost>
+      <ScrollView
+        style={{ backgroundColor: theme.colors.background }}
+        contentContainerStyle={{ padding: 16, gap: 24, paddingBottom: 48 }}
+      >
+        <Text style={{ color: theme.colors.foreground }}>
+          The card below clips its children and sits under a sibling. An overlay
+          rendered inside it would be cut off and painted beneath; through a portal
+          it covers everything.
+        </Text>
+
+        <View
+          style={{
+            height: 120,
+            padding: 12,
+            overflow: 'hidden',
+            borderRadius: theme.radius.lg,
+            borderWidth: theme.borderWidth.default,
+            borderColor: theme.colors.border,
+            backgroundColor: theme.colors.surface,
+          }}
+        >
+          <Trigger />
+        </View>
+
+        <View
+          style={{
+            height: 80,
+            borderRadius: theme.radius.lg,
+            backgroundColor: theme.colors.accentSoft,
+            justifyContent: 'center',
+            paddingHorizontal: 12,
+          }}
+        >
+          <Text style={{ color: theme.colors.foreground }}>
+            A sibling painted after the card — the overlay must cover this too.
+          </Text>
+        </View>
+      </ScrollView>
+    </PortalHost>
+  )
+}
+
+function Trigger() {
+  const theme = useXAUITheme()
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => setIsOpen(true)}
+        style={{
+          height: theme.controlHeights.md,
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderRadius: theme.radius.md,
+          backgroundColor: theme.colors.accent,
+        }}
+      >
+        <Text style={{ color: theme.colors.accentForeground }}>
+          Open through a portal
+        </Text>
+      </Pressable>
+
+      {isOpen && (
+        <Portal>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close"
+            onPress={() => setIsOpen(false)}
+            style={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              start: 0,
+              end: 0,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.colors.backdrop,
+            }}
+          >
+            <View
+              style={{
+                padding: 24,
+                borderRadius: theme.radius.xl,
+                backgroundColor: theme.colors.overlay,
+              }}
+            >
+              <Text style={{ color: theme.colors.overlayForeground }}>
+                Rendered at the host. Tap to close.
+              </Text>
+            </View>
+          </Pressable>
+        </Portal>
+      )}
+    </>
+  )
+}

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -153,3 +153,26 @@ Each overlay also takes its own `animation` — `false` to switch that one off, 
 `duration` and an `opacity` — which wins over the blanket prop on the root, except when
 the root switched everything off. Two knobs, deliberately: past that it is a different
 animation, and that is a component's job rather than a prop's.
+
+## `portal/` in one page
+
+`Portal` renders its children into the nearest `PortalHost` instead of where it sits —
+what `Dialog`, `Sheet`, `Drawer` and `Snackbar` are built on, since an overlay has to
+escape the clipping and stacking of whatever container held the trigger.
+
+```tsx
+// once, at the root of the app, above navigation
+<XAUIProvider>
+  <PortalHost>{app}</PortalHost>
+</XAUIProvider>
+
+// anywhere below
+<Portal>
+  <Backdrop />
+</Portal>
+```
+
+Publishing happens in a layout effect, so the content lands in the same commit as the
+trigger's and an overlay never shows a frame late. Outside a host the context is `null`
+and `Portal` renders nothing rather than throwing: an app that forgot `PortalHost` should
+lose its overlays, not crash on the first `Dialog`.

--- a/packages/native/src/system/index.ts
+++ b/packages/native/src/system/index.ts
@@ -1,3 +1,4 @@
+export * from './portal'
 export * from './pressable-feedback'
 export * from './recipe'
 export * from './slot'

--- a/packages/native/src/system/portal/index.ts
+++ b/packages/native/src/system/portal/index.ts
@@ -1,0 +1,6 @@
+export { Portal } from './portal'
+export type { PortalProps } from './portal'
+export { PortalContext } from './portal-context'
+export type { PortalMethods } from './portal-context'
+export { PortalHost } from './portal-host'
+export type { PortalHostProps } from './portal-host'

--- a/packages/native/src/system/portal/portal-context.ts
+++ b/packages/native/src/system/portal/portal-context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react'
+import type { ReactNode } from 'react'
+
+export type PortalMethods = {
+  addPortal: (key: string, element: ReactNode) => void
+  removePortal: (key: string) => void
+}
+
+/**
+ * `null` outside a host, and `Portal` treats that as "render nothing" rather than
+ * throwing: an app that forgot `PortalHost` should lose its overlays, not crash on the
+ * first `Dialog`.
+ */
+export const PortalContext = createContext<PortalMethods | null>(null)

--- a/packages/native/src/system/portal/portal-host.tsx
+++ b/packages/native/src/system/portal/portal-host.tsx
@@ -1,0 +1,54 @@
+import { Fragment, useCallback, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { PortalContext } from './portal-context'
+
+export type PortalHostProps = {
+  children: ReactNode
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+})
+
+/**
+ * Where every `Portal` in the tree below renders. Mounted once, at the root of the app,
+ * above navigation — an overlay that renders inside a screen is clipped by it.
+ */
+export function PortalHost({ children }: PortalHostProps) {
+  const [portals, setPortals] = useState<ReadonlyMap<string, ReactNode>>(new Map())
+
+  // A new Map per change rather than a mutated ref with a forced re-render: the rendered
+  // list is then derived from state the way React expects, and a portal added during a
+  // commit cannot be read before the render that includes it.
+  const addPortal = useCallback((key: string, element: ReactNode) => {
+    setPortals(current => new Map(current).set(key, element))
+  }, [])
+
+  const removePortal = useCallback((key: string) => {
+    setPortals(current => {
+      if (!current.has(key)) return current
+      const next = new Map(current)
+      next.delete(key)
+      return next
+    })
+  }, [])
+
+  const methods = useMemo(
+    () => ({ addPortal, removePortal }),
+    [addPortal, removePortal]
+  )
+
+  return (
+    <PortalContext.Provider value={methods}>
+      <View style={styles.container}>
+        {children}
+        {Array.from(portals, ([key, element]) => (
+          <Fragment key={key}>{element}</Fragment>
+        ))}
+      </View>
+    </PortalContext.Provider>
+  )
+}
+
+PortalHost.displayName = 'XAUI.PortalHost'

--- a/packages/native/src/system/portal/portal.tsx
+++ b/packages/native/src/system/portal/portal.tsx
@@ -1,0 +1,32 @@
+import { useContext, useEffect, useId, useLayoutEffect } from 'react'
+import type { ReactNode } from 'react'
+import { PortalContext } from './portal-context'
+
+export type PortalProps = {
+  children: ReactNode
+}
+
+/**
+ * Renders its children into the nearest `PortalHost` instead of where it sits. What
+ * `Dialog`, `Sheet`, `Drawer` and `Snackbar` are built on: an overlay has to escape the
+ * clipping and stacking of whatever container happened to hold the trigger.
+ *
+ * Publishing in a layout effect rather than an effect is deliberate — the content lands
+ * in the same commit as the trigger's, so an overlay never shows one frame late.
+ */
+export function Portal({ children }: PortalProps) {
+  const context = useContext(PortalContext)
+  const key = useId()
+
+  useLayoutEffect(() => {
+    context?.addPortal(key, children)
+  }, [children, context, key])
+
+  useEffect(() => {
+    return () => context?.removePortal(key)
+  }, [context, key])
+
+  return null
+}
+
+Portal.displayName = 'XAUI.Portal'

--- a/packages/native/src/system/portal/portal.tsx
+++ b/packages/native/src/system/portal/portal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useId, useLayoutEffect } from 'react'
+import { useContext, useId, useLayoutEffect } from 'react'
 import type { ReactNode } from 'react'
 import { PortalContext } from './portal-context'
 
@@ -11,8 +11,11 @@ export type PortalProps = {
  * `Dialog`, `Sheet`, `Drawer` and `Snackbar` are built on: an overlay has to escape the
  * clipping and stacking of whatever container happened to hold the trigger.
  *
- * Publishing in a layout effect rather than an effect is deliberate — the content lands
- * in the same commit as the trigger's, so an overlay never shows one frame late.
+ * Both halves run in layout effects rather than effects, which is deliberate: the content
+ * lands in the same commit as the trigger's, so an overlay neither shows one frame late
+ * nor survives one frame past the unmount that closed it. The unpublish sits in its own
+ * effect so that it does not depend on `children` — a re-publish then keeps the portal's
+ * place in the host's order instead of dropping it and re-adding it at the end.
  */
 export function Portal({ children }: PortalProps) {
   const context = useContext(PortalContext)
@@ -22,7 +25,7 @@ export function Portal({ children }: PortalProps) {
     context?.addPortal(key, children)
   }, [children, context, key])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => context?.removePortal(key)
   }, [context, key])
 


### PR DESCRIPTION
> **Stacked on #175.** Base is `feat/p1-pressable-feedback` — no code dependency, but all three add to `system/index.ts` and its README. It retargets to `main` on its own as the queue drains.

## What

`packages/native/src/system/portal/` — `Portal`, `PortalHost`, `PortalContext` — plus a demo screen. Fourth item of P1.

## Why

`Dialog`, `Sheet`, `Drawer` and `Snackbar` are all built on it: an overlay has to escape the clipping and stacking of whatever container happened to hold the trigger. It is the last piece of `system/` that the fifteen-component core needs before components can start.

## A copy, not a move

Plan §P1 says *"déplacé tel quel depuis `core/portal/`"*. I copied instead. The source sits in `@xaui/native-legacy`, which is frozen **and now published** — moving it would mean cutting a release of a package whose entire point is that it does not change. P7 deletes that tree anyway, and until then the two copies are independent by design.

## Two things that did not survive the port as they were

The plan says *as-is*, so here is exactly what I changed and why:

1. **The key came from a module-level counter incremented during render.**

   ```ts
   let portalId = 0
   const keyRef = useRef(`portal-${++portalId}`)   // side effect in render
   ```

   That is impure, and StrictMode's double render burns ids. It is `useId()` now, which is what React 18 added it for.

2. **The host held its portals in a mutated ref plus a forced re-render**, then read the ref back during render (`Array.from(portals.current.entries())`). It holds state now, so the rendered list is derived the way React expects rather than read out of a box that was mutated on the side.

Everything else is the frozen implementation: the layout-effect publish (so the content lands in the same commit as the trigger's and an overlay never shows a frame late), the null-context tolerance, the `flex: 1` host container.

## Testing

**The acceptance criterion is empty.** It reads *"les tests existants passent sans modification"*, and the frozen tree has no portal tests at all — I checked before relying on it.

`Portal` and `PortalHost` are component-shaped primitives, so they get none here either, per the same rule that exempts `PressableFeedback` and `Icon`. The demo screen is the verification, and it is built around the failure case rather than the happy one: the trigger sits **inside a card that clips its children and is painted before a sibling**, so an overlay that did not escape would be visibly cut off and underneath.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 tasks
- [x] `pnpm --filter demo exec tsc --noEmit` — clean on the new screen (the demo is not in CI's filter)
- [x] `pnpm --filter @xaui/native build` — the new surface is exported
- [ ] **The demo screen, by you** — *Portal v1* in the home grid. The overlay must cover both the clipping card and the sibling below it, and tapping it must close.
