### PR TITLE
feat(system): the Icon primitive (P1.5)

### DIFF
--- a/.changeset/icon.md
+++ b/.changeset/icon.md
@@ -1,0 +1,17 @@
+---
+'@xaui/native': patch
+---
+
+Add `Icon` to `@xaui/native/system`.
+
+An icon is a third-party component, so a slot context never reaches it and every call site
+ends up computing the colour by hand. `Icon` closes that: three forms — a component through
+`as` (`size` and `color` injected, covering Lucide, Ionicons and vector-icons), a raw
+`react-native-svg` element as children, or an image through `source` — all resolving the
+same way. An explicit prop, else what the surrounding slot published through `IconContext`,
+else the theme.
+
+For a raw SVG the resolved values win over the element's own `width`, `height` and `color`:
+one arriving from a design tool carries a baked-in size, and inheriting the slot's instead
+is the point of wrapping it. `react-native-svg` stays an optional peer — nothing here
+imports it, the raw-SVG form only clones an element the caller already made.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -22,7 +22,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P1.2  | `system/slot/` — context, `childrenToString`, merges     | done   |
 | P1.3  | `system/pressable-feedback/`                             | done   |
 | P1.4  | `system/portal/`                                         | done   |
-| P1.5  | `system/icon/`                                           | todo   |
+| P1.5  | `system/icon/`                                           | done   |
 | P1.6  | Shared hooks                                             | todo   |
 | P1.7  | `pnpm pack` uniqueness check on both packages            | todo   |
 | P2    | Reference `Button`, perf baseline, API review            | todo   |

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -49,6 +49,7 @@ export default function RootLayout() {
                 options={{ title: 'PressableFeedback (v1)' }}
               />
               <Stack.Screen name="portal" options={{ title: 'Portal (v1)' }} />
+              <Stack.Screen name="icon" options={{ title: 'Icon (v1)' }} />
               <Stack.Screen name="card" options={{ title: 'Card Examples' }} />
               <Stack.Screen
                 name="carousel"

--- a/apps/demo/app/icon.tsx
+++ b/apps/demo/app/icon.tsx
@@ -1,0 +1,139 @@
+import { ScrollView, Text, View } from 'react-native'
+import Svg, { Path } from 'react-native-svg'
+import { Icon, IconContext } from '@xaui/native/system'
+import type { IconComponentProps } from '@xaui/native/system'
+import { useXAUITheme } from '@xaui/native/theme'
+
+/**
+ * The verification screen for P1.5. The criterion is the last row of each slot: a
+ * component icon and a raw SVG must take the surrounding colour **with no explicit
+ * prop**, which is the whole reason this primitive exists.
+ */
+export default function IconScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 16, gap: 24, paddingBottom: 48 }}
+    >
+      <Section title="Inherited — one provider, two very different icons">
+        <Slot color={theme.colors.danger} size={28} label="danger, 28">
+          <Icon as={TrashIcon} />
+          <Icon>
+            <RawCheck />
+          </Icon>
+        </Slot>
+
+        <Slot color={theme.colors.success} size={20} label="success, 20">
+          <Icon as={TrashIcon} />
+          <Icon>
+            <RawCheck />
+          </Icon>
+        </Slot>
+      </Section>
+
+      <Section title="Overridden — an explicit prop wins over the slot">
+        <Slot color={theme.colors.danger} size={28} label="slot says danger/28">
+          <Icon as={TrashIcon} />
+          <Icon as={TrashIcon} color={theme.colors.accent} />
+          <Icon as={TrashIcon} size={16} />
+        </Slot>
+      </Section>
+
+      <Section title="Standalone — no provider, so the theme decides">
+        <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+          <Icon as={TrashIcon} />
+          <Icon>
+            <RawCheck />
+          </Icon>
+          <Text style={{ color: theme.colors.foreground }}>
+            foreground, at the md font size
+          </Text>
+        </View>
+      </Section>
+    </ScrollView>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  const theme = useXAUITheme()
+
+  return (
+    <View style={{ gap: 8 }}>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontSize: theme.fontSizes.sm,
+          fontWeight: theme.fontWeights.semibold,
+        }}
+      >
+        {title}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+/** Stands in for a component root publishing what its icon slot resolved. */
+function Slot({
+  color,
+  size,
+  label,
+  children,
+}: {
+  color: string
+  size: number
+  label: string
+  children: React.ReactNode
+}) {
+  const theme = useXAUITheme()
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        padding: 12,
+        borderRadius: theme.radius.md,
+        borderWidth: theme.borderWidth.default,
+        borderColor: theme.colors.border,
+      }}
+    >
+      <IconContext.Provider value={{ color, size }}>{children}</IconContext.Provider>
+      <Text style={{ color: theme.colors.foreground }}>{label}</Text>
+    </View>
+  )
+}
+
+/** A third-party icon: it knows nothing about XAUI, only `size` and `color`. */
+function TrashIcon({ size, color }: IconComponentProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M4 7h16M10 11v6M14 11v6M6 7l1 12a2 2 0 002 2h6a2 2 0 002-2l1-12M9 7V4h6v3"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}
+
+/**
+ * A raw SVG with its own size and colour baked in, the way one arrives from a design
+ * tool. Both must be overridden by what the slot published.
+ */
+function RawCheck() {
+  return (
+    <Svg width={99} height={99} viewBox="0 0 24 24" fill="none" color="magenta">
+      <Path
+        d="M4 12l5 5L20 6"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -124,6 +124,16 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/icon')}
+            variant="solid"
+            themeColor="primary"
+          >
+            Icon v1
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/card')}
             variant="bordered"
             themeColor="primary"

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -176,3 +176,29 @@ Publishing happens in a layout effect, so the content lands in the same commit a
 trigger's and an overlay never shows a frame late. Outside a host the context is `null`
 and `Portal` renders nothing rather than throwing: an app that forgot `PortalHost` should
 lose its overlays, not crash on the first `Dialog`.
+
+## `icon/` in one page
+
+An icon is a third-party component, so a slot context never reaches it and every call site
+ends up computing the colour by hand. `Icon` closes that:
+
+```tsx
+<Button variant="danger">
+  <Button.Icon as={TrashIcon} /> {/* colour and size inherited — nothing to pass */}
+  <Button.Label>Supprimer</Button.Label>
+</Button>
+```
+
+Three forms — a component through `as` (`size` and `color` injected, which covers Lucide,
+Ionicons and vector-icons), a raw `react-native-svg` element as children, or an image
+through `source`. All three resolve the same way: an explicit prop, else what the
+surrounding slot published through `IconContext`, else the theme.
+
+For a raw SVG the resolved values **win over the element's own** `width`, `height` and
+`color`. One arriving from a design tool carries a baked-in size, and inheriting the
+slot's instead is the entire point of wrapping it.
+
+`IconContext` is a plain defaulted context rather than a `createSlotContext`: that one
+throws outside its parent, and an `Icon` has to work standalone as much as inside a
+`Button`. `react-native-svg` stays an **optional** peer — nothing here imports it, the
+raw-SVG form only clones an element the caller already made.

--- a/packages/native/src/system/icon/icon-context.ts
+++ b/packages/native/src/system/icon/icon-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+import type { IconContextValue } from './icon.type'
+
+/**
+ * Not a `createSlotContext`: that one throws outside its parent, and an `Icon` has to
+ * work on its own as much as inside a `Button`. An empty context is the honest default —
+ * nothing inherited, so the theme decides.
+ */
+export const IconContext = createContext<IconContextValue>({})
+
+IconContext.displayName = 'XAUI.Icon.Context'
+
+export function useIconContext(): IconContextValue {
+  return useContext(IconContext)
+}

--- a/packages/native/src/system/icon/icon.tsx
+++ b/packages/native/src/system/icon/icon.tsx
@@ -1,0 +1,70 @@
+import { cloneElement, isValidElement } from 'react'
+import type { ReactElement } from 'react'
+import { Image } from 'react-native'
+import { useXAUITheme } from '../../theme/theme-hooks'
+import { useIconContext } from './icon-context'
+import type { IconProps } from './icon.type'
+
+/**
+ * The gap nobody else closes: an icon is a third-party component, so a slot context does
+ * not reach it and every call site ends up computing the colour by hand.
+ *
+ * ```tsx
+ * <Button variant="danger">
+ *   <Button.Icon as={TrashIcon} />   {/* colour and size inherited, nothing to pass *\/}
+ *   <Button.Label>Supprimer</Button.Label>
+ * </Button>
+ * ```
+ *
+ * Three accepted forms — a component through `as`, a raw SVG as children, or an image
+ * through `source` — and the resolution is the same for all three: an explicit prop, else
+ * what the surrounding slot published, else the theme.
+ */
+export function Icon({
+  as: Component,
+  children,
+  source,
+  size,
+  color,
+  style,
+}: IconProps) {
+  const inherited = useIconContext()
+  const theme = useXAUITheme()
+
+  const resolvedSize = size ?? inherited.size ?? theme.fontSizes.md
+  const resolvedColor = color ?? inherited.color ?? theme.colors.foreground
+
+  if (Component) {
+    return <Component size={resolvedSize} color={resolvedColor} />
+  }
+
+  if (isValidElement(children)) {
+    // The resolved values win over the element's own `width`, `height` and `color`. An
+    // SVG pasted from a design tool carries a baked-in size, and inheriting the slot's
+    // instead is the entire point of putting it in an `Icon`.
+    return cloneElement(children as ReactElement<Record<string, unknown>>, {
+      width: resolvedSize,
+      height: resolvedSize,
+      color: resolvedColor,
+    })
+  }
+
+  if (source) {
+    return (
+      <Image
+        source={source}
+        style={[
+          { width: resolvedSize, height: resolvedSize, tintColor: resolvedColor },
+          style,
+        ]}
+      />
+    )
+  }
+
+  throw new Error(
+    'XAUI: Icon needs one of `as` (an icon component), a raw SVG element as its child, ' +
+      'or `source` (an image). It renders nothing on its own.'
+  )
+}
+
+Icon.displayName = 'XAUI.Icon'

--- a/packages/native/src/system/icon/icon.type.ts
+++ b/packages/native/src/system/icon/icon.type.ts
@@ -1,0 +1,32 @@
+import type { ComponentType, ReactNode } from 'react'
+import type { ImageSourcePropType, ImageStyle, StyleProp } from 'react-native'
+
+/**
+ * The props Lucide, Ionicons and `react-native-vector-icons` all accept — the shape
+ * `as` is handed. It is a convention rather than an interface anyone published, which is
+ * exactly why `Icon` exists: without it every call site computes the two values by hand.
+ */
+export type IconComponentProps = {
+  size?: number
+  color?: string
+}
+
+export type IconProps = {
+  /** An icon component. `size` and `color` are injected into it. */
+  as?: ComponentType<IconComponentProps>
+  /** A raw `react-native-svg` element, cloned with the resolved size and colour. */
+  children?: ReactNode
+  /** An image, tinted with the resolved colour. */
+  source?: ImageSourcePropType
+  /** Overrides what the surrounding slot asked for. */
+  size?: number
+  /** A raw value (R7), never a token. Overrides the slot's. */
+  color?: string
+  style?: StyleProp<ImageStyle>
+}
+
+/** What a component root publishes so the icons inside it need no props at all. */
+export type IconContextValue = {
+  size?: number
+  color?: string
+}

--- a/packages/native/src/system/icon/index.ts
+++ b/packages/native/src/system/icon/index.ts
@@ -1,0 +1,3 @@
+export { Icon } from './icon'
+export { IconContext, useIconContext } from './icon-context'
+export type { IconComponentProps, IconContextValue, IconProps } from './icon.type'

--- a/packages/native/src/system/index.ts
+++ b/packages/native/src/system/index.ts
@@ -1,3 +1,4 @@
+export * from './icon'
 export * from './portal'
 export * from './pressable-feedback'
 export * from './recipe'


### PR DESCRIPTION
> **Stacked on #176.** Base is `feat/p1-portal`. It retargets to `main` on its own as the queue drains.

## What

`packages/native/src/system/icon/` — `Icon`, `IconContext`, `useIconContext` — plus a demo screen. Fifth item of P1.

## Why

Plan §5 states the problem exactly: *"une icône est un composant tiers, le contexte de slot ne l'atteint pas, donc l'utilisateur doit calculer la couleur à la main."* HeroUI never closed it. `Button.Icon` should just work:

```tsx
<Button variant="danger">
  <Button.Icon as={TrashIcon} />   {/* colour and size inherited, nothing to pass */}
  <Button.Label>Supprimer</Button.Label>
</Button>
```

## How

Three forms, one resolution rule. `as={Component}` injects `size` and `color` — the shape Lucide, Ionicons and vector-icons all accept, and a convention rather than an interface anyone published, which is precisely why this primitive has to exist. A raw `react-native-svg` element as children is cloned. `source` renders a tinted image.

All three resolve the same way: **an explicit prop, else what the surrounding slot published through `IconContext`, else the theme.**

## Two decisions worth reviewing

**For a raw SVG, the resolved values win over the element's own `width`, `height` and `color`.** This is the one place where "the child is more specific" — the rule `mergeProps` follows — is deliberately reversed. An SVG arriving from a design tool carries a baked-in size and often a hard-coded colour; inheriting the slot's instead is the entire point of wrapping it in an `Icon`. The demo's raw check is deliberately `width={99}` and `color="magenta"` so that a regression here is impossible to miss.

**`IconContext` is a plain defaulted context, not a `createSlotContext`.** That one throws outside its parent, and an `Icon` has to work standalone as much as inside a `Button`. An empty context is the honest default: nothing inherited, so the theme decides.

## One inconsistency in the plan, flagged rather than followed

Plan §5's override example reads `<Button.Icon as={TrashIcon} color="warning" size="sm" />` — a **token** for `color` and a size token. That contradicts §1 bis, where `color` is always a raw value and never a token (R7). I followed §1 bis: `color` takes a raw value and `size` a number. Worth correcting in the plan, or telling me if §5 was the intent and §1 bis is the one that should bend.

## Testing

No tests — a component-shaped primitive, like `Portal` and `PressableFeedback`, and the resolution rule it contains is a two-line `??` chain rather than logic worth extracting.

The demo screen carries the acceptance criterion (*"une icône Lucide et un SVG brut prennent tous deux la couleur du variant parent sans prop explicite"*): both forms sit side by side under one provider, twice, with different colours and sizes.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 tasks
- [x] `pnpm --filter demo exec tsc --noEmit` — clean on the new screen (the demo is not in CI's filter)
- [x] `pnpm --filter @xaui/native build` — the new surface is exported
- [ ] **The demo screen, by you** — *Icon v1* in the home grid. The two icons on each row must match their label's colour and size; the raw check must be neither 99px nor magenta.

---

**P1 after this**: only P1.6 (shared hooks) and P1.7 (the `pnpm pack` uniqueness check) are left. The review queue is now four deep — #174 → #175 → #176 → #177 — so it is probably worth draining it before I add more.
