### PR TITLE
feat(hooks): the shared hooks (P1.6)

### DIFF
--- a/.changeset/shared-hooks.md
+++ b/.changeset/shared-hooks.md
@@ -1,0 +1,19 @@
+---
+'@xaui/native': patch
+---
+
+Add the shared hooks: `useControllableState`, `usePressState`, `useMergedRef` and
+`usePrevious`.
+
+`useControllableState` gives a component one state that works whether the caller drives it
+or not, so there are never two code paths for the same value. Its setter keeps its identity
+across renders and reads the current value from a ref, which is what lets a handler built
+on it be passed to a memoized child. Switching between the two modes mid-life warns in
+development — it is always a bug, and invisible without it.
+
+`usePressState` is the press state a root owns, with handlers that **compose** the caller's
+rather than replacing them and keep their identity across renders. Every pressable
+component needs those three properties and gets one of them wrong on its own.
+
+`useMergedRef` memoizes `mergeRefs` on the refs it was given, so React does not detach and
+reattach every one of them — and pay for a node measurement — on each render.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -23,7 +23,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P1.3  | `system/pressable-feedback/`                             | done   |
 | P1.4  | `system/portal/`                                         | done   |
 | P1.5  | `system/icon/`                                           | done   |
-| P1.6  | Shared hooks                                             | todo   |
+| P1.6  | Shared hooks                                             | done   |
 | P1.7  | `pnpm pack` uniqueness check on both packages            | todo   |
 | P2    | Reference `Button`, perf baseline, API review            | todo   |
 | P3    | The fifteen-component core                               | todo   |

--- a/packages/native/eslint.config.js
+++ b/packages/native/eslint.config.js
@@ -29,6 +29,10 @@ export default [
         clearTimeout: 'readonly',
         setInterval: 'readonly',
         clearInterval: 'readonly',
+        // `warnDev` is the one place either is allowed: a development-only warning,
+        // guarded so it never reaches a release bundle.
+        console: 'readonly',
+        __DEV__: 'readonly',
       },
     },
   },
@@ -63,6 +67,7 @@ export default [
         beforeAll: 'readonly',
         afterAll: 'readonly',
         vi: 'readonly',
+        console: 'readonly',
       },
     },
   },

--- a/packages/native/src/__tests__/hooks/use-controllable-state.test.ts
+++ b/packages/native/src/__tests__/hooks/use-controllable-state.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useControllableState } from '../../hooks/use-controllable-state'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useControllableState — uncontrolled', () => {
+  it('starts at the default and keeps what it is told', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 'a' }))
+
+    expect(result.current[0]).toBe('a')
+
+    act(() => result.current[1]('b'))
+
+    expect(result.current[0]).toBe('b')
+  })
+
+  it('takes an updater, resolved against the current value', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 1 }))
+
+    act(() => result.current[1](n => n + 1))
+    act(() => result.current[1](n => n + 1))
+
+    expect(result.current[0]).toBe(3)
+  })
+
+  it('reports every change', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() =>
+      useControllableState({ defaultValue: 'a', onChange })
+    )
+
+    act(() => result.current[1]('b'))
+
+    expect(onChange).toHaveBeenCalledWith('b')
+  })
+})
+
+describe('useControllableState — controlled', () => {
+  it('returns the value it was given and never stores one of its own', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() =>
+      useControllableState({ value: 'a', defaultValue: 'z', onChange })
+    )
+
+    act(() => result.current[1]('b'))
+
+    // Told, not changed: the caller decides whether the value actually moves.
+    expect(result.current[0]).toBe('a')
+    expect(onChange).toHaveBeenCalledWith('b')
+  })
+
+  it('follows the caller when the value changes', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) =>
+        useControllableState({ value, defaultValue: 'z' }),
+      { initialProps: { value: 'a' } }
+    )
+
+    rerender({ value: 'b' })
+
+    expect(result.current[0]).toBe('b')
+  })
+})
+
+describe('useControllableState — the setter', () => {
+  it('keeps its identity across renders, so a memo below survives', () => {
+    const { result, rerender } = renderHook(() =>
+      useControllableState({ defaultValue: 'a', onChange: () => {} })
+    )
+    const first = result.current[1]
+
+    rerender()
+    act(() => result.current[1]('b'))
+
+    expect(result.current[1]).toBe(first)
+  })
+
+  it('says nothing when the value did not move', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() =>
+      useControllableState({ defaultValue: 'a', onChange })
+    )
+
+    act(() => result.current[1]('a'))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('useControllableState — switching modes', () => {
+  it('warns when a component goes from uncontrolled to controlled', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { rerender } = renderHook(
+      ({ value }: { value?: string }) =>
+        useControllableState({ value, defaultValue: 'a' }),
+      { initialProps: {} as { value?: string } }
+    )
+
+    rerender({ value: 'b' })
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('uncontrolled to controlled')
+    )
+  })
+
+  it('warns the other way too', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { rerender } = renderHook(
+      ({ value }: { value?: string }) =>
+        useControllableState({ value, defaultValue: 'a' }),
+      { initialProps: { value: 'b' } as { value?: string } }
+    )
+
+    rerender({})
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('controlled to uncontrolled')
+    )
+  })
+
+  it('stays quiet while the mode holds', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { rerender } = renderHook(
+      ({ value }: { value: string }) =>
+        useControllableState({ value, defaultValue: 'a' }),
+      { initialProps: { value: 'b' } }
+    )
+
+    rerender({ value: 'c' })
+    rerender({ value: 'd' })
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/native/src/__tests__/hooks/use-merged-ref.test.ts
+++ b/packages/native/src/__tests__/hooks/use-merged-ref.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { useMergedRef } from '../../hooks/use-merged-ref'
+import { usePrevious } from '../../hooks/use-previous'
+
+describe('useMergedRef', () => {
+  it('feeds every ref it was given', () => {
+    const object = createRef<string>()
+    const callback = vi.fn()
+
+    const { result } = renderHook(() => useMergedRef<string>(object, callback))
+    result.current('node')
+
+    expect(object.current).toBe('node')
+    expect(callback).toHaveBeenCalledWith('node')
+  })
+
+  it('keeps its identity while the refs hold', () => {
+    const object = createRef<string>()
+    const { result, rerender } = renderHook(() => useMergedRef<string>(object))
+    const first = result.current
+
+    rerender()
+
+    // A new callback each render would make React detach and reattach every ref, and
+    // pay for a node measurement every time.
+    expect(result.current).toBe(first)
+  })
+
+  it('makes a new one when a ref changes', () => {
+    const { result, rerender } = renderHook(
+      ({ ref }: { ref: { current: string | null } }) => useMergedRef<string>(ref),
+      { initialProps: { ref: createRef<string>() } }
+    )
+    const first = result.current
+
+    rerender({ ref: createRef<string>() })
+
+    expect(result.current).not.toBe(first)
+  })
+})
+
+describe('usePrevious', () => {
+  it('is undefined on the first render', () => {
+    const { result } = renderHook(() => usePrevious('a'))
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('lags one render behind', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => usePrevious(value),
+      { initialProps: { value: 'a' } }
+    )
+
+    rerender({ value: 'b' })
+    expect(result.current).toBe('a')
+
+    rerender({ value: 'c' })
+    expect(result.current).toBe('b')
+  })
+
+  it('tracks the previous render, not the previous distinct value', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => usePrevious(value),
+      { initialProps: { value: 'a' } }
+    )
+
+    rerender({ value: 'b' })
+    expect(result.current).toBe('a')
+
+    // Rendered with 'b' twice, so the render before this one held 'b'. Anyone wanting
+    // "the last value that differed" wants a different hook.
+    rerender({ value: 'b' })
+    expect(result.current).toBe('b')
+  })
+})

--- a/packages/native/src/__tests__/hooks/use-press-state.test.ts
+++ b/packages/native/src/__tests__/hooks/use-press-state.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { GestureResponderEvent } from 'react-native'
+import { usePressState } from '../../hooks/use-press-state'
+
+const event = {} as GestureResponderEvent
+
+describe('usePressState', () => {
+  it('follows the press', () => {
+    const { result } = renderHook(() => usePressState())
+
+    expect(result.current[0]).toBe(false)
+
+    act(() => result.current[1].onPressIn(event))
+    expect(result.current[0]).toBe(true)
+
+    act(() => result.current[1].onPressOut(event))
+    expect(result.current[0]).toBe(false)
+  })
+
+  it("composes the caller's handlers rather than replacing them", () => {
+    const onPressIn = vi.fn()
+    const onPressOut = vi.fn()
+    const { result } = renderHook(() => usePressState({ onPressIn, onPressOut }))
+
+    act(() => result.current[1].onPressIn(event))
+    act(() => result.current[1].onPressOut(event))
+
+    expect(onPressIn).toHaveBeenCalledWith(event)
+    expect(onPressOut).toHaveBeenCalledWith(event)
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('keeps the handlers identical across renders, so a memo below survives', () => {
+    const { result, rerender } = renderHook(() =>
+      // A fresh arrow on every render, which is what a call site always passes.
+      usePressState({ onPressIn: () => {} })
+    )
+    const first = result.current[1]
+
+    rerender()
+    act(() => result.current[1].onPressIn(event))
+    rerender()
+
+    expect(result.current[1]).toBe(first)
+    expect(result.current[1].onPressIn).toBe(first.onPressIn)
+  })
+
+  it('calls the latest handler, not the one from the first render', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ onPressIn }: { onPressIn: () => void }) => usePressState({ onPressIn }),
+      { initialProps: { onPressIn: first } }
+    )
+
+    rerender({ onPressIn: second })
+    act(() => result.current[1].onPressIn(event))
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/native/src/hooks/README.md
+++ b/packages/native/src/hooks/README.md
@@ -1,0 +1,34 @@
+# `hooks/`
+
+React hooks shared by **two or more components**. A hook only one component uses stays in
+that component's folder; promotion happens at the second use, never by anticipation
+(§2 bis).
+
+## The boundary
+
+`hooks/` sits between `system/` and `utils/`, and the difference is who it is for:
+
+- `system/` is what a **third party** builds their own XAUI component with. Published,
+  semver.
+- `hooks/` is what **our** components share. Reachable from `@xaui/native`, but it is not
+  the surface someone writing a component is pointed at.
+- `utils/` is pure, React-free and private.
+
+Anything here is a React hook by definition, which is exactly what keeps it out of
+`utils/`.
+
+## Current contents
+
+| File                        | Role                                                                                                 |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `use-controllable-state.ts` | One state that works controlled or not, with a dev warning when a component switches between the two |
+| `use-press-state.ts`        | The press state a root owns, plus handlers that compose the caller's and keep their identity         |
+| `use-merged-ref.ts`         | `mergeRefs` memoized for a component that renders                                                    |
+| `use-previous.ts`           | The value from the render before this one                                                            |
+
+## Testing
+
+These get tests, unlike a _component's_ hook. The rule sends `useButton` to its demo
+screen because it only means something inside its component; these are library primitives
+with behaviour of their own — `useControllableState` switching modes is a stated
+acceptance criterion of P1.6.

--- a/packages/native/src/hooks/index.ts
+++ b/packages/native/src/hooks/index.ts
@@ -1,0 +1,6 @@
+export { useControllableState } from './use-controllable-state'
+export type { ControllableStateOptions } from './use-controllable-state'
+export { useMergedRef } from './use-merged-ref'
+export { usePressState } from './use-press-state'
+export type { PressHandlers } from './use-press-state'
+export { usePrevious } from './use-previous'

--- a/packages/native/src/hooks/use-controllable-state.ts
+++ b/packages/native/src/hooks/use-controllable-state.ts
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react'
+import { warnDev } from '../utils/warn-dev'
+
+export type ControllableStateOptions<T> = {
+  /** Present means controlled: the caller owns the value and this never stores one. */
+  value?: T
+  /** The starting value when uncontrolled. */
+  defaultValue: T
+  /** Called with every new value, controlled or not. */
+  onChange?: (value: T) => void
+}
+
+/**
+ * One state that works both ways, so a component never has two code paths for "the
+ * caller drives this" and "we do".
+ *
+ * The setter is stable across renders and reads the current value from a ref, so a
+ * handler built on it can be passed to a memoized child without rebuilding it on every
+ * render — which is the whole reason components reach for this rather than a local
+ * `useState` plus an `if`.
+ */
+export function useControllableState<T>({
+  value,
+  defaultValue,
+  onChange,
+}: ControllableStateOptions<T>): [T, (next: T | ((current: T) => T)) => void] {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue)
+
+  const isControlled = value !== undefined
+  const current = isControlled ? (value as T) : uncontrolled
+
+  useControlWarning(isControlled)
+
+  // The setter must not change identity, so it cannot close over `current`.
+  const latest = useRef(current)
+  latest.current = current
+
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
+  const controlled = useRef(isControlled)
+  controlled.current = isControlled
+
+  const set = useCallback((next: T | ((currentValue: T) => T)) => {
+    const resolved =
+      typeof next === 'function' ? (next as (c: T) => T)(latest.current) : next
+
+    if (resolved === latest.current) return
+
+    // Only the uncontrolled half stores anything; a controlled component is told, and
+    // decides for itself whether the value actually moves.
+    if (!controlled.current) setUncontrolled(resolved)
+    onChangeRef.current?.(resolved)
+  }, [])
+
+  return [current, set]
+}
+
+/**
+ * Switching between the two modes mid-life is always a bug — the value silently stops
+ * being whatever the component was doing before — and it is invisible without this.
+ */
+function useControlWarning(isControlled: boolean): void {
+  const wasControlled = useRef(isControlled)
+
+  if (wasControlled.current !== isControlled) {
+    warnDev(
+      `a component switched from ${wasControlled.current ? 'controlled' : 'uncontrolled'} ` +
+        `to ${isControlled ? 'controlled' : 'uncontrolled'}. Decide for the life of the ` +
+        'component: pass `value` always, or never. Passing `undefined` for a value you ' +
+        'do control reads as "uncontrolled" here.'
+    )
+    wasControlled.current = isControlled
+  }
+}

--- a/packages/native/src/hooks/use-merged-ref.ts
+++ b/packages/native/src/hooks/use-merged-ref.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+import type { RefCallback } from 'react'
+import { mergeRefs } from '../system/slot/merge-refs'
+import type { PossibleRef } from '../system/slot/slot.type'
+
+/**
+ * `mergeRefs` for a component that renders: memoized on the refs it was given, so React
+ * does not detach and reattach every one of them on each render — which it does whenever
+ * a ref callback changes identity, and which costs a node measurement every time.
+ */
+export function useMergedRef<T>(...refs: Array<PossibleRef<T>>): RefCallback<T> {
+  return useMemo(() => mergeRefs(...refs), refs)
+}

--- a/packages/native/src/hooks/use-press-state.ts
+++ b/packages/native/src/hooks/use-press-state.ts
@@ -1,0 +1,46 @@
+import { useCallback, useRef, useState } from 'react'
+import type { GestureResponderEvent } from 'react-native'
+
+export type PressHandlers = {
+  onPressIn?: (event: GestureResponderEvent) => void
+  onPressOut?: (event: GestureResponderEvent) => void
+}
+
+/**
+ * The press state a root owns, with the handlers that maintain it.
+ *
+ * It exists because every pressable component needs the same three things and gets one
+ * of them wrong on its own: the state has to be *up here* — the recipe resolves on it
+ * (R5) — the caller's handlers must be **composed, never replaced**, and the returned
+ * handlers must keep their identity so passing them down does not defeat a memo.
+ *
+ * ```tsx
+ * const [isPressed, pressHandlers] = usePressState(props)
+ * const styles = recipe.resolve({ theme, selection, states: { pressed: isPressed } })
+ * <PressableFeedback isPressed={isPressed} {...pressHandlers} />
+ * ```
+ */
+export function usePressState(
+  handlers: PressHandlers = {}
+): [boolean, Required<PressHandlers>] {
+  const [isPressed, setIsPressed] = useState(false)
+
+  // Read through a ref so the handlers below never change identity, even when the caller
+  // passes a fresh arrow function on every render — which it always does.
+  const latest = useRef(handlers)
+  latest.current = handlers
+
+  const onPressIn = useCallback((event: GestureResponderEvent) => {
+    setIsPressed(true)
+    latest.current.onPressIn?.(event)
+  }, [])
+
+  const onPressOut = useCallback((event: GestureResponderEvent) => {
+    setIsPressed(false)
+    latest.current.onPressOut?.(event)
+  }, [])
+
+  const press = useRef({ onPressIn, onPressOut }).current
+
+  return [isPressed, press]
+}

--- a/packages/native/src/hooks/use-previous.ts
+++ b/packages/native/src/hooks/use-previous.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * The value from the render before this one, `undefined` on the first.
+ *
+ * Written in an effect rather than during render on purpose: reading it mid-render would
+ * make "previous" mean something different depending on whether React re-ran the render,
+ * which under StrictMode it does.
+ */
+export function usePrevious<T>(value: T): T | undefined {
+  const previous = useRef<T | undefined>(undefined)
+
+  useEffect(() => {
+    previous.current = value
+  }, [value])
+
+  return previous.current
+}

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -1,2 +1,3 @@
+export * from './hooks'
 export * from './system'
 export * from './theme'

--- a/packages/native/src/utils/warn-dev.ts
+++ b/packages/native/src/utils/warn-dev.ts
@@ -1,0 +1,14 @@
+declare const __DEV__: boolean
+
+/**
+ * The one sanctioned console call in the package, and the one place the `__DEV__` guard
+ * is written — a warning that survives into a release bundle is noise in someone else's
+ * app, and repeating the guard is how one eventually gets forgotten.
+ *
+ * For a mistake the code can carry on from. Anything that leaves a component in an
+ * unusable state throws instead, with a name.
+ */
+export function warnDev(message: string): void {
+  if (typeof __DEV__ !== 'undefined' && !__DEV__) return
+  console.warn(`XAUI: ${message}`)
+}


### PR DESCRIPTION
> **Stacked on #177.** Base is `feat/p1-icon`. It retargets to `main` on its own as the queue drains.

## What

`packages/native/src/hooks/` — `useControllableState`, `usePressState`, `useMergedRef`, `usePrevious` — plus `utils/warn-dev.ts` and 20 tests. Sixth item of P1; only P1.7 is left after it.

## Why

Each of these is a thing every component needs and gets wrong differently when written locally. `usePressState` is the clearest case: the state has to live in the root because the recipe resolves on it (R5), the caller's handlers must be composed rather than replaced, and the handlers must keep their identity — three properties, and a hand-rolled version keeps two of them.

## Three decisions worth reviewing

**`useControllableState`'s setter never changes identity.** It reads the current value, the `onChange` and the controlled-ness from refs rather than closing over them. That is the entire reason a component reaches for this instead of a `useState` and an `if`: a handler built on it can be passed to a memoized child and stay put. There is a test pinning the identity.

**Switching controlled ↔ uncontrolled warns.** The plan states it as the acceptance criterion, and it is the one failure here the code can carry on from, so it warns rather than throws. `warnDev` guards on `__DEV__` in one place — a warning that reaches a release bundle is noise in someone else's app.

`AGENTS.md` bans `console.log` and `console.error` in committed code; this is `console.warn`, guarded, and the plan asks for the warning by name. Flagging it rather than assuming the rule was meant to cover it.

**`hooks/` is not `system/`.** §2 bis routes a hook shared by ≥ 2 components here, and that is what I followed. But its own boundary question — *"un développeur tiers en aurait-il besoin pour écrire **son** composant XAUI ?"* — arguably says `useControllableState` belongs in `system/`, where the answer is plainly yes. The plan's layout and its decision table disagree; I took the layout, exported the folder from the root barrel so it is reachable, and left the subpath alone. Say the word if you want them promoted.

## Testing

These get tests, unlike a *component's* hook: the rule sends `useButton` to its demo screen because it only means anything inside its component, while these are library primitives with behaviour of their own. `renderHook`, 20 cases.

**Two of them were wrong before the code was.** One was an arithmetic slip (1, +1, +1 is 3). The other asserted that `usePrevious` returns the last *distinct* value; it returns the previous render's, which is the standard meaning, so the test now says that out loud instead of encoding a hook nobody wrote.

## Test plan

- [x] `pnpm turbo run lint type-check test --filter="docs" --filter="@xaui/*"` — 15/15 tasks, `@xaui/native` at 130 tests
- [x] `pnpm --filter @xaui/native build` — the new surface is exported
- [x] `pnpm --filter demo exec tsc --noEmit` — no error in anything this touches

Two things found on the way, neither fixed here:

- **The package's ESLint config declared no globals at all** beyond the timer functions, so any `console` or `__DEV__` was a `no-undef` error. Added both, scoped and commented.
- **`apps/demo` has 48 pre-existing type errors** — `menubox`, `list`, `menus`, `drawer`, `surface`, `feature-discovery` and two infra files, all legacy screens. None in anything I added. The demo is not in CI's filter, which is how it got there.
