### PR TITLE
fix(system): asChild on PressableFeedback merged into the context provider

### DIFF
--- a/.changeset/pressable-feedback-as-child.md
+++ b/.changeset/pressable-feedback-as-child.md
@@ -1,0 +1,15 @@
+---
+'@xaui/native': patch
+---
+
+Fix `asChild` on `PressableFeedback`, which silently dropped every pressable prop.
+
+Under `asChild` the root renders a `Slot`, and a `Slot` merges its props into its single
+child. That child was the feedback context provider, so the ref, the style, the press
+handlers and `disabled` all landed on a provider that ignores them: the caller's element
+stopped reacting to touch entirely, with no error to say so. The provider now sits above
+the root, and the caller's element receives the props it was always meant to.
+
+The default overlay is no longer rendered under `asChild`. The caller's element _is_ the
+pressable there, so there is no sibling to inject it as; the context is still published, so
+`<PressableFeedback.Highlight />` among the caller's own children still works.

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -147,7 +147,12 @@ long list kills every row's worklets with one prop.
 
 `asChild` goes **through** `PressableFeedback`, not around it. A root that did
 `asChild ? Slot : PressableFeedback` would render its child with no touch feedback at all
-— so the merge happens here, and R12 and the feedback stay in the same branch.
+— so the merge happens here, and R12 and the feedback stay in the same branch. The
+feedback context is published **above** the root for the same reason: a `Slot` merges into
+its single child, so a provider nested inside would swallow the ref, the style and the
+handlers. Under `asChild` the caller's element is the pressable and there is no sibling to
+inject, so the default overlay is not rendered — a caller that wants the wash puts
+`<PressableFeedback.Highlight />` among its own children.
 
 Each overlay also takes its own `animation` — `false` to switch that one off, or a
 `duration` and an `opacity` — which wins over the blanket prop on the root, except when

--- a/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
@@ -108,12 +108,11 @@ const StaticFeedback = forwardRef<View, BranchProps>(function StaticFeedback(
   const Root = asChild ? Slot : Pressable
 
   return (
-    <Root ref={ref} style={style} disabled={isDisabled} {...rest}>
-      <FeedbackProvider value={context}>
-        <DefaultOverlay variant={feedbackVariant} />
-        {children}
-      </FeedbackProvider>
-    </Root>
+    <FeedbackProvider value={context}>
+      <Root ref={ref} style={style} disabled={isDisabled} {...rest}>
+        {body(asChild, feedbackVariant, children)}
+      </Root>
+    </FeedbackProvider>
   )
 })
 
@@ -176,21 +175,49 @@ const AnimatedFeedback = forwardRef<View, BranchProps>(function AnimatedFeedback
   const Root = asChild ? AnimatedSlot : AnimatedPressable
 
   return (
-    <Root
-      ref={ref}
-      style={[clip, style, animatedStyle]}
-      disabled={isDisabled}
-      onPressIn={handlePressIn}
-      onLayout={handleLayout}
-      {...rest}
-    >
-      <FeedbackProvider value={context}>
-        <DefaultOverlay variant={feedbackVariant} />
-        {children}
-      </FeedbackProvider>
-    </Root>
+    <FeedbackProvider value={context}>
+      <Root
+        ref={ref}
+        style={[clip, style, animatedStyle]}
+        disabled={isDisabled}
+        onPressIn={handlePressIn}
+        onLayout={handleLayout}
+        {...rest}
+      >
+        {body(asChild, feedbackVariant, children)}
+      </Root>
+    </FeedbackProvider>
   )
 })
+
+/**
+ * What goes inside the root — and the reason `FeedbackProvider` sits *above* it rather
+ * than around these children.
+ *
+ * Under `asChild` the root is a `Slot`, and a `Slot` merges its props into its single
+ * child. A provider nested inside would be that child, so every pressable prop — the
+ * ref, the style, the handlers — would land on a context provider, which ignores all of
+ * them: the caller's element would stop reacting to touch entirely, silently.
+ *
+ * The default overlay goes with it. The caller's element *is* the pressable under
+ * `asChild`, and there is nowhere to inject a sibling inside it. The context is still
+ * published, so a caller that wants the wash renders `<PressableFeedback.Highlight />`
+ * among its own children.
+ */
+function body(
+  asChild: boolean,
+  variant: FeedbackVariant,
+  children: ReactNode
+): ReactNode {
+  if (asChild) return children
+
+  return (
+    <>
+      <DefaultOverlay variant={variant} />
+      {children}
+    </>
+  )
+}
 
 function DefaultOverlay({ variant }: { variant: FeedbackVariant }): ReactNode {
   if (variant === 'scale-highlight') return <PressableFeedbackHighlight />


### PR DESCRIPTION
## What

`asChild` on `PressableFeedback` merged every pressable prop into the feedback context
provider instead of into the caller's element. The provider now sits above the root, and
the default overlay is skipped under `asChild`.

## Why

`Slot` merges its props into its single child. That child was `<FeedbackProvider>`:

```tsx
<Root ref={ref} style={style} disabled={isDisabled} {...rest}>   // Root = Slot
  <FeedbackProvider value={context}>                            // ← everything landed here
    <DefaultOverlay variant={feedbackVariant} />
    {children}
  </FeedbackProvider>
</Root>
```

A context provider ignores `ref`, `style`, `disabled` and `onPress*`, and `Slot` only
throws when its child is not a valid element — a provider is one. So `<Button asChild>`
around a navigation `Link` would have rendered, looked right, and never reacted to touch.

R12 has to hold uniformly from the first component, so this blocks the P2 `Button`.

## How

- `FeedbackProvider` moved outside `Root` in both the static and the animated branch. The
  non-`asChild` case is unchanged — the children still read the context from above.
- A `body()` helper decides what goes inside the root. Under `asChild` it returns the
  child untouched: the caller's element *is* the pressable, so there is no sibling to
  inject the overlay as. The context is still published, so a caller that wants the wash
  renders `<PressableFeedback.Highlight />` among its own children.
- `system/README.md` states both consequences.

`pnpm lint`, `pnpm type-check` and `pnpm test` pass (130 tests). No public type changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
