### PR TITLE
feat(button): the reference component (P2.1)

### DIFF
--- a/.changeset/reference-button.md
+++ b/.changeset/reference-button.md
@@ -1,0 +1,32 @@
+---
+'@xaui/native': patch
+---
+
+Add `Button` — the first v1 component, on `@xaui/native/button`.
+
+```tsx
+<Button onPress={submit}>Envoyer</Button>
+
+<Button variant="danger" size="lg">
+  <Button.Icon as={TrashIcon} />
+  <Button.Label>Supprimer</Button.Label>
+</Button>
+```
+
+Ten variants naming tokens and computing nothing, four sizes driving height and never
+width, `color` as one raw tint that lands where the variant put its tokens, `isLoading`
+inserting a spinner when none is composed, and `asChild` handing the press to someone
+else's element. The view depth is one — `PressableFeedback > (Text | Icon)` — and a press
+allocates no style: every combination of tokens is resolved once and cached for the
+lifetime of the app.
+
+Two fixes the component needed on the way:
+
+- The build emitted classic `React.createElement` against a binding the sources never
+  import, so **every component in the published package would have thrown on first
+  render**. esbuild now uses the automatic JSX runtime.
+- Every animated hook carries an explicit dependency array. Reanimated's Babel plugin
+  infers one, but it runs in the consumer's build and does not reach a published `dist` on
+  web, where the hook throws instead of animating.
+
+`usePressState` now accepts `null` handlers, which is how `PressableProps` types them.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -3,31 +3,34 @@
 One line per task: ref, title, status. No commentary — update the status when a task lands.
 Task detail lives in `XAUI-V1-PLAN.md`.
 
-| Ref   | Task                                                     | Status |
-| ----- | -------------------------------------------------------- | ------ |
-| P0.1  | Split into `@xaui/native-legacy` and scaffold v1         | done   |
-| P0.2  | Single token source and generator                        | done   |
-| P0.3  | OKLab colour engine                                      | done   |
-| P0.4  | Derived colour layer                                     | done   |
-| P0.5  | Contrast guard in CI                                     | done   |
-| P0.6  | `createTheme`                                            | done   |
-| P0.7  | `XAUIProvider`                                           | done   |
-| P0.8  | Legacy `core-shim.ts`                                    | done   |
-| P0.9  | Package hygiene and optional peers                       | done   |
-| P0.10 | ESLint rule for R13                                      | done   |
-| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod     | done   |
-| P0.12 | Delete `@xaui/core` and `@xaui/icons`                     | done   |
-| P0.13 | Publish `native` and `hybrid` on the `alpha` tag          | done   |
-| P1.1  | `system/recipe/` — engine, cache, tint                   | done   |
-| P1.2  | `system/slot/` — context, `childrenToString`, merges     | done   |
-| P1.3  | `system/pressable-feedback/`                             | done   |
-| P1.4  | `system/portal/`                                         | done   |
-| P1.5  | `system/icon/`                                           | done   |
-| P1.6  | Shared hooks                                             | done   |
-| P1.7  | `pnpm pack` uniqueness check on both packages            | done   |
-| P2    | Reference `Button`, perf baseline, API review            | todo   |
-| P3    | The fifteen-component core                               | todo   |
-| P4    | Docs, generated tables, `1.0.0`                          | todo   |
-| P5    | The remaining 32 components                              | todo   |
-| P6    | `@xaui/hybrid` on the v1 API                             | todo   |
-| P7    | Delete `native-legacy`                                   | todo   |
+| Ref   | Task                                                    | Status |
+| ----- | ------------------------------------------------------- | ------ |
+| P0.1  | Split into `@xaui/native-legacy` and scaffold v1        | done   |
+| P0.2  | Single token source and generator                       | done   |
+| P0.3  | OKLab colour engine                                     | done   |
+| P0.4  | Derived colour layer                                    | done   |
+| P0.5  | Contrast guard in CI                                    | done   |
+| P0.6  | `createTheme`                                           | done   |
+| P0.7  | `XAUIProvider`                                          | done   |
+| P0.8  | Legacy `core-shim.ts`                                   | done   |
+| P0.9  | Package hygiene and optional peers                      | done   |
+| P0.10 | ESLint rule for R13                                     | done   |
+| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod    | done   |
+| P0.12 | Delete `@xaui/core` and `@xaui/icons`                   | done   |
+| P0.13 | Publish `native` and `hybrid` on the `alpha` tag        | done   |
+| P1.1  | `system/recipe/` — engine, cache, tint                  | done   |
+| P1.2  | `system/slot/` — context, `childrenToString`, merges    | done   |
+| P1.3  | `system/pressable-feedback/`                            | done   |
+| P1.4  | `system/portal/`                                        | done   |
+| P1.5  | `system/icon/`                                          | done   |
+| P1.6  | Shared hooks                                            | done   |
+| P1.7  | `pnpm pack` uniqueness check on both packages           | done   |
+| P2.1  | The reference `Button`                                  | done   |
+| P2.2  | Perf baseline — 200 buttons, re-renders and allocations | todo   |
+| P2.3  | API review — blocking, nothing starts in P3 before it   | todo   |
+| P2.4  | Publish `@xaui/native` on the `alpha` tag               | todo   |
+| P3    | The fifteen-component core                              | todo   |
+| P4    | Docs, generated tables, `1.0.0`                         | todo   |
+| P5    | The remaining 32 components                             | todo   |
+| P6    | `@xaui/hybrid` on the v1 API                            | todo   |
+| P7    | Delete `native-legacy`                                  | todo   |

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -50,6 +50,7 @@ export default function RootLayout() {
               />
               <Stack.Screen name="portal" options={{ title: 'Portal (v1)' }} />
               <Stack.Screen name="icon" options={{ title: 'Icon (v1)' }} />
+              <Stack.Screen name="button" options={{ title: 'Button (v1)' }} />
               <Stack.Screen name="card" options={{ title: 'Card Examples' }} />
               <Stack.Screen
                 name="carousel"

--- a/apps/demo/app/button.tsx
+++ b/apps/demo/app/button.tsx
@@ -1,0 +1,259 @@
+import { useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import Svg, { Path } from 'react-native-svg'
+import { Button } from '@xaui/native/button'
+import type { ButtonVariant } from '@xaui/native/button'
+import type { IconComponentProps } from '@xaui/native/system'
+import { useXAUITheme } from '@xaui/native/theme'
+
+const VARIANTS: ButtonVariant[] = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'ghost',
+  'success',
+  'success-soft',
+  'warning',
+  'warning-soft',
+  'danger',
+  'danger-soft',
+]
+
+/**
+ * The verification screen for P2. A component is verified here and in the docs preview,
+ * in light and in dark — there is no test file for it.
+ *
+ * What each section is actually checking is in its subtitle: the ten variants name tokens
+ * and nothing else, `size` moves the height and never the width, a raw `color` lands
+ * where the variant put its tokens, and `asChild` hands the press to someone else's
+ * element without losing it.
+ */
+export default function ButtonScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 16, gap: 28, paddingBottom: 64 }}
+    >
+      <Section
+        title="The ten variants"
+        note="Emphasis and intention in one flat union. Each names tokens; none computes a colour."
+      >
+        {VARIANTS.map(variant => (
+          <Button key={variant} variant={variant}>
+            {variant}
+          </Button>
+        ))}
+      </Section>
+
+      <Section
+        title="size — height, never width"
+        note="A button with no width fills a column and hugs its content in a row. There is no fullWidth."
+      >
+        <Button size="xs">xs · 32</Button>
+        <Button size="sm">sm · 40</Button>
+        <Button size="md">md · 48</Button>
+        <Button size="lg">lg · 56</Button>
+
+        <Row>
+          <Button size="sm">in a row</Button>
+          <Button size="sm" variant="secondary">
+            hugs its content
+          </Button>
+        </Row>
+      </Section>
+
+      <Section
+        title="Icon and label"
+        note="JSX order is screen order. The icon takes the variant's colour and the size's scale with no prop."
+      >
+        <Button>
+          <Button.Icon as={TrashIcon} />
+          <Button.Label>icon, then label</Button.Label>
+        </Button>
+
+        <Button variant="danger">
+          <Button.Label>label, then icon</Button.Label>
+          <Button.Icon as={TrashIcon} />
+        </Button>
+
+        <Row>
+          <Button
+            isIconOnly
+            size="sm"
+            variant="tertiary"
+            accessibilityLabel="Supprimer"
+          >
+            <Button.Icon as={TrashIcon} />
+          </Button>
+          <Button isIconOnly variant="danger-soft" accessibilityLabel="Supprimer">
+            <Button.Icon as={TrashIcon} />
+          </Button>
+          <Button
+            isIconOnly
+            size="lg"
+            variant="ghost"
+            accessibilityLabel="Supprimer"
+          >
+            <Button.Icon as={TrashIcon} />
+          </Button>
+          <Text style={{ color: theme.colors.foreground, alignSelf: 'center' }}>
+            isIconOnly — square on the fixed height
+          </Text>
+        </Row>
+      </Section>
+
+      <Section
+        title="isLoading"
+        note="The spinner is inserted when none is composed; composing one is how you put it after the label."
+      >
+        <Button isLoading>Envoi…</Button>
+        <Button isLoading variant="secondary">
+          <Button.Label>composed after the label</Button.Label>
+          <Button.Spinner />
+        </Button>
+        <Button isDisabled>isDisabled</Button>
+        <Button isDisabled variant="tertiary">
+          isDisabled, tertiary
+        </Button>
+      </Section>
+
+      <Section
+        title="color — one raw tint, placed by the variant"
+        note="Background for primary, label for ghost, border and label for tertiary. Derived in OKLab, like accent."
+      >
+        <Button color="#7c3aed">primary — the tint is the background</Button>
+        <Button variant="ghost" color="#7c3aed">
+          ghost — the tint is the label
+        </Button>
+        <Button variant="tertiary" color="#7c3aed">
+          tertiary — border and label
+        </Button>
+        <Button variant="danger-soft" color="#7c3aed">
+          danger-soft — the tint, softened
+        </Button>
+      </Section>
+
+      <Section
+        title="radius — the shape its size implies, or one you name"
+        note="Unset, the radius follows the size. Set, it wins."
+      >
+        <Row>
+          <Button size="sm" radius="xs">
+            xs
+          </Button>
+          <Button size="sm" radius="md">
+            md
+          </Button>
+          <Button size="sm" radius="full">
+            full
+          </Button>
+        </Row>
+      </Section>
+
+      <Section
+        title="asChild — the press, handed to someone else's element"
+        note="R12. The child receives the ref, the styles and the handlers; it is the button."
+      >
+        <Button asChild>
+          <Pressable onPress={() => undefined}>
+            <Text style={{ color: theme.colors.accentForeground }}>
+              a bare Pressable, wearing the button
+            </Text>
+          </Pressable>
+        </Button>
+      </Section>
+
+      <Section
+        title="Escape hatches"
+        note="Everything the two appearance props do not cover goes through a slot's own style."
+      >
+        <Button style={{ alignSelf: 'flex-start' }}>alignSelf, not fullWidth</Button>
+        <Button variant="secondary">
+          <Button.Label style={{ fontStyle: 'italic', letterSpacing: 1 }}>
+            a label styling itself
+          </Button.Label>
+        </Button>
+        <Button>
+          a label far too long for the width it has been given, so it truncates
+          instead of deforming the control
+        </Button>
+      </Section>
+
+      <PressCounter />
+    </ScrollView>
+  )
+}
+
+/** The caller's `onPress` and `onPressIn` must survive the root composing its own. */
+function PressCounter() {
+  const theme = useXAUITheme()
+  const [count, setCount] = useState(0)
+
+  return (
+    <Section
+      title="Handlers compose, they do not replace"
+      note="The root maintains its own pressed state on top of the caller's handlers."
+    >
+      <Button onPress={() => setCount(n => n + 1)}>
+        <Button.Label>pressed {count} times</Button.Label>
+      </Button>
+      <Text style={{ color: theme.colors.foreground }}>
+        the count moves, and so does the press colour
+      </Text>
+    </Section>
+  )
+}
+
+function Section({
+  title,
+  note,
+  children,
+}: {
+  title: string
+  note: string
+  children: React.ReactNode
+}) {
+  const theme = useXAUITheme()
+
+  return (
+    <View style={{ gap: 10 }}>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontSize: theme.fontSizes.md,
+          fontWeight: theme.fontWeights.semibold,
+        }}
+      >
+        {title}
+      </Text>
+      <Text style={{ color: theme.colors.muted, fontSize: theme.fontSizes.xs }}>
+        {note}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={{ flexDirection: 'row', gap: 8, flexWrap: 'wrap' }}>
+      {children}
+    </View>
+  )
+}
+
+/** A third-party icon: it knows only `size` and `color`, and is told neither here. */
+function TrashIcon({ size, color }: IconComponentProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M4 7h16M10 11v6M14 11v6M6 7l1 12a2 2 0 002 2h6a2 2 0 002-2l1-12M9 7V4h6v3"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -134,6 +134,16 @@ export default function HomeScreen() {
         <GridItem>
           <Button
             size="sm"
+            onPress={() => router.push('/button')}
+            variant="solid"
+            themeColor="primary"
+          >
+            Button v1
+          </Button>
+        </GridItem>
+        <GridItem>
+          <Button
+            size="sm"
             onPress={() => router.push('/card')}
             variant="bordered"
             themeColor="primary"

--- a/packages/native-legacy/src/components/button/button.tsx
+++ b/packages/native-legacy/src/components/button/button.tsx
@@ -7,6 +7,26 @@ import type { ButtonProps } from './button.type'
 import { useBorderRadiusStyles } from '../../core/theme-hooks'
 import { runPressInAnimation, runPressOutAnimation } from './button.animation'
 
+/**
+ * @deprecated Use `Button` from `@xaui/native/button`. This tree is frozen and receives
+ * fixes only.
+ *
+ * The v1 replacement composes instead of configuring: `themeColor` and `variant` are one
+ * flat `variant` union, `customAppearance` becomes a `style` on each slot,
+ * `startContent` / `endContent` become JSX order, and `fullWidth` is gone — a button with
+ * no width already fills a column.
+ *
+ * ```tsx
+ * // legacy
+ * <Button themeColor="danger" variant="solid" startContent={<Trash />}>Supprimer</Button>
+ *
+ * // v1
+ * <Button variant="danger">
+ *   <Button.Icon as={Trash} />
+ *   <Button.Label>Supprimer</Button.Label>
+ * </Button>
+ * ```
+ */
 export const Button: React.FC<ButtonProps> = ({
   children,
   themeColor = 'primary',

--- a/packages/native-legacy/src/components/button/icon-button.tsx
+++ b/packages/native-legacy/src/components/button/icon-button.tsx
@@ -8,6 +8,23 @@ import type { IconButtonProps } from './icon-button.type'
 import { useBorderRadiusStyles } from '../../core/theme-hooks'
 import { runPressInAnimation, runPressOutAnimation } from './button.animation'
 
+/**
+ * @deprecated Use `Button` with `isIconOnly` from `@xaui/native/button`. This tree is
+ * frozen and receives fixes only.
+ *
+ * There is no separate icon button in v1: `isIconOnly` drops the horizontal padding and
+ * squares the button on its fixed height, so one component covers both shapes.
+ *
+ * ```tsx
+ * // legacy
+ * <IconButton icon={<Trash />} themeColor="danger" />
+ *
+ * // v1 — accessibilityLabel is required, there is no text to read
+ * <Button isIconOnly variant="danger" accessibilityLabel="Supprimer">
+ *   <Button.Icon as={Trash} />
+ * </Button>
+ * ```
+ */
 export const IconButton: React.FC<IconButtonProps> = ({
   icon,
   themeColor = 'primary',

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
+    "./button": {
+      "types": "./dist/components/button/index.d.ts",
+      "import": "./dist/components/button/index.js",
+      "require": "./dist/components/button/index.js"
+    },
     "./system": {
       "types": "./dist/system/index.d.ts",
       "import": "./dist/system/index.js",

--- a/packages/native/src/__tests__/components/button/button.utils.test.ts
+++ b/packages/native/src/__tests__/components/button/button.utils.test.ts
@@ -1,0 +1,52 @@
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+import { containsElementOfType } from '../../../components/button/button.utils'
+
+function Spinner() {
+  return null
+}
+
+function Label() {
+  return null
+}
+
+describe('containsElementOfType', () => {
+  it('finds the element among several children', () => {
+    const children = [
+      createElement(Label, { key: 'l' }),
+      createElement(Spinner, { key: 's' }),
+    ]
+
+    expect(containsElementOfType(children, Spinner)).toBe(true)
+  })
+
+  it('finds it when it is the only child, unwrapped by an array', () => {
+    expect(containsElementOfType(createElement(Spinner), Spinner)).toBe(true)
+  })
+
+  it('does not confuse one component for another', () => {
+    expect(containsElementOfType(createElement(Label), Spinner)).toBe(false)
+  })
+
+  it('is false for text children — the auto-wrap case', () => {
+    expect(containsElementOfType('Envoi…', Spinner)).toBe(false)
+    expect(containsElementOfType([3, ' items'], Spinner)).toBe(false)
+  })
+
+  it('is false for nothing at all', () => {
+    expect(containsElementOfType(null, Spinner)).toBe(false)
+    expect(containsElementOfType(undefined, Spinner)).toBe(false)
+    expect(containsElementOfType([], Spinner)).toBe(false)
+  })
+
+  /**
+   * The stated boundary, not an accident: a spinner the caller buried inside a wrapper is
+   * not the composition the auto-insert is about, and a deep walk would make "did I
+   * compose one?" depend on how many layers deep it sits.
+   */
+  it('does not look inside a wrapper', () => {
+    const wrapped = createElement(Label, null, createElement(Spinner))
+
+    expect(containsElementOfType(wrapped, Spinner)).toBe(false)
+  })
+})

--- a/packages/native/src/components/README.md
+++ b/packages/native/src/components/README.md
@@ -1,0 +1,55 @@
+# `components/`
+
+The library's components. Each one is a folder, an independent subpath export
+(`@xaui/native/button`), and the same seven files in the same order.
+
+## The reference
+
+`button/` is the pattern the other forty-six follow. It is written to be copied: if a
+component disagrees with it, the disagreement is a decision to take, not a local variation
+to invent. Read it before writing a new one — and if the Button itself turns out to be
+wrong, it is the Button that gets fixed.
+
+## What belongs
+
+```
+button/
+├── button.recipe.ts     # variants name tokens. The source of truth for style.
+├── button.context.ts    # createSlotContext, RESOLVED values, exports useButton (R10)
+├── button.type.ts       # the props of the root and of every slot
+├── button.utils.ts      # pure logic, only if there is any — tested in __tests__/
+├── button.tsx           # the root
+├── button-label.tsx     # one file per slot
+├── button-icon.tsx
+├── button-spinner.tsx
+└── index.ts             # Object.assign(ButtonRoot, { Label, Icon, Spinner })
+```
+
+- **No empty file to satisfy the convention.** A component with no slots has no
+  `.context.ts`; one with no pure logic has no `.utils.ts`.
+- **A file used by one component stays here.** Promotion to `hooks/`, `utils/` or
+  `system/` happens at the second use, never by anticipation (§2 bis of the plan).
+- **Everything that depends on a token or a variant is in the recipe**, not in a
+  `.style.ts`. A hardcoded colour or measurement anywhere else is a defect.
+
+## What does not
+
+- A test file for the component, its slots or its hook. Those are verified by their demo
+  screen in `apps/demo` and their docs preview, in light and dark. Logic worth pinning
+  down is extracted into a pure function — `button.utils.ts` — and **that** is tested, at
+  the mirrored path under `src/__tests__/`.
+- A primitive a second component would want. That belongs in `system/`, which is the
+  surface a third party builds their own component with.
+
+## Adding one
+
+1. The recipe — variants name tokens, no hardcoded value
+2. The context and its exported `useX` hook (R10)
+3. The root: `forwardRef`, `asChild`, a11y, function-form `style`, namespaced
+   `displayName` (R9, R11, R12)
+4. One file per slot, with no margin of its own (R4)
+5. Pure logic into `.utils.ts`, with a mirrored test
+6. A screen in `apps/demo` — this is how the component is verified
+7. A subpath export in `package.json` **and** `tsup.config.ts`
+
+Then run the `xaui-review` skill on the diff.

--- a/packages/native/src/components/button/button-icon.tsx
+++ b/packages/native/src/components/button/button-icon.tsx
@@ -1,0 +1,24 @@
+import { Icon } from '../../system/icon'
+import { useButton } from './button.context'
+import type { ButtonIconProps } from './button.type'
+
+/**
+ * An icon that takes the button's size and colour without being told either:
+ *
+ * ```tsx
+ * <Button variant="danger">
+ *   <Button.Icon as={TrashIcon} />
+ *   <Button.Label>Supprimer</Button.Label>
+ * </Button>
+ * ```
+ *
+ * The values come from the root, which resolved them once; an explicit `size` or `color`
+ * still wins, which is what `Icon` promises everywhere else in the library.
+ */
+export function ButtonIcon({ size, color, ...rest }: ButtonIconProps) {
+  const { icon } = useButton()
+
+  return <Icon size={size ?? icon.size} color={color ?? icon.color} {...rest} />
+}
+
+ButtonIcon.displayName = 'XAUI.Button.Icon'

--- a/packages/native/src/components/button/button-label.tsx
+++ b/packages/native/src/components/button/button-label.tsx
@@ -1,0 +1,35 @@
+import { forwardRef } from 'react'
+import { Text } from 'react-native'
+import { useButton } from './button.context'
+import type { ButtonLabelProps } from './button.type'
+
+/**
+ * The text of a button. Three lines, because the root already resolved everything (R5):
+ * this reads the style it published and merges the caller's over it (R2).
+ *
+ * Single-line by default. A control has a fixed height (§1 bis), so a label longer than
+ * the button truncates rather than wrapping and pushing the button out of shape —
+ * `numberOfLines` is still a prop for the rare case that wants otherwise.
+ *
+ * It carries no margin of its own (R4): the gap between a button's icon and its label is
+ * the root's, so JSX order is screen order and nothing has to be undone to reverse them.
+ */
+export const ButtonLabel = forwardRef<Text, ButtonLabelProps>(function ButtonLabel(
+  { children, style, numberOfLines = 1, ...rest },
+  ref
+) {
+  const { labelStyle } = useButton()
+
+  return (
+    <Text
+      ref={ref}
+      numberOfLines={numberOfLines}
+      style={[labelStyle, style]}
+      {...rest}
+    >
+      {children}
+    </Text>
+  )
+})
+
+ButtonLabel.displayName = 'XAUI.Button.Label'

--- a/packages/native/src/components/button/button-spinner.tsx
+++ b/packages/native/src/components/button/button-spinner.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
+import Animated, {
+  Easing,
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated'
+import { useButton } from './button.context'
+import type { ButtonSpinnerProps } from './button.type'
+
+/** One turn. Slow enough to read as waiting, fast enough not to read as stuck. */
+const ROTATION_DURATION = 800
+
+/**
+ * The busy indicator. `isLoading` inserts one when none is composed, so
+ * `<Button isLoading>Envoi…</Button>` works; composing it explicitly is how you put it
+ * after the label instead of before it.
+ *
+ * A ring rather than RN's `ActivityIndicator`: the recipe owns its diameter and its
+ * colour like every other measurement, which is what makes it follow the button's `size`
+ * and its variant with nothing to pass. P3 extracts it into the standalone `Spinner`, and
+ * this slot becomes its call site.
+ */
+export function ButtonSpinner({ style, animation = true }: ButtonSpinnerProps) {
+  const { spinnerStyle } = useButton()
+
+  // Two components rather than a branch inside one: hooks cannot be conditional, and
+  // "no animation" is only true if the Reanimated hooks are never reached.
+  if (!animation) return <View style={[spinnerStyle, style]} />
+
+  return <SpinningRing style={[spinnerStyle, style]} />
+}
+
+ButtonSpinner.displayName = 'XAUI.Button.Spinner'
+
+function SpinningRing({ style }: { style: StyleProp<ViewStyle> }) {
+  const angle = useSharedValue(0)
+
+  useEffect(() => {
+    angle.value = withRepeat(
+      withTiming(360, { duration: ROTATION_DURATION, easing: Easing.linear }),
+      -1,
+      false
+    )
+    // A repeat with no end runs until something stops it, and unmounting the button is
+    // not by itself that something.
+    return () => cancelAnimation(angle)
+  }, [angle])
+
+  const animatedStyle = useAnimatedStyle(
+    () => ({ transform: [{ rotate: `${angle.value}deg` }] }),
+    [angle]
+  )
+
+  return <Animated.View style={[style, animatedStyle]} />
+}

--- a/packages/native/src/components/button/button.context.ts
+++ b/packages/native/src/components/button/button.context.ts
@@ -1,0 +1,11 @@
+import { createSlotContext } from '../../system/slot'
+import type { ButtonContextValue } from './button.type'
+
+/**
+ * R10 — `useButton` is exported so a third party can write its own slot
+ * (`<Button.Badge>`) against the same resolved values the built-in ones read, without
+ * forking the library. Outside a `<Button>` it throws by name rather than failing three
+ * frames later on an undefined style.
+ */
+export const [ButtonProvider, useButton] =
+  createSlotContext<ButtonContextValue>('Button')

--- a/packages/native/src/components/button/button.recipe.ts
+++ b/packages/native/src/components/button/button.recipe.ts
@@ -1,0 +1,191 @@
+import { createRecipe } from '../../system/recipe'
+import type { SlotStyles, VariantTokens } from '../../system/recipe'
+import type { FontSizeKey, RadiusKey, Size, XAUITheme } from '../../theme/theme.type'
+import type { ButtonSlot, ButtonVariant } from './button.type'
+
+const SLOTS = ['root', 'label', 'icon', 'spinner'] as const
+
+/**
+ * Ten lines of data. A variant **names tokens and computes nothing** — `paint` below is
+ * the only place that decides where a colour lands, and it is written once for all ten.
+ *
+ * The suffix on each token name is also what a raw `color` reads: `resolveTint` maps
+ * `…Pressed` to the tint's pressed slice, `…Soft` to its soft one, and a bare
+ * `foreground` to the tint itself. That is why a tinted `ghost` paints its label and a
+ * tinted `tertiary` its border, with nothing further to declare here.
+ */
+const VARIANT_TOKENS: Record<ButtonVariant, VariantTokens> = {
+  primary: { bg: 'accent', bgPressed: 'accentPressed', fg: 'accentForeground' },
+  secondary: { bg: 'default', bgPressed: 'defaultPressed', fg: 'defaultForeground' },
+  tertiary: {
+    border: 'border',
+    bgPressed: 'defaultSoftPressed',
+    fg: 'foreground',
+  },
+  ghost: { bgPressed: 'defaultSoftPressed', fg: 'foreground' },
+  success: { bg: 'success', bgPressed: 'successPressed', fg: 'successForeground' },
+  'success-soft': {
+    bg: 'successSoft',
+    bgPressed: 'successSoftPressed',
+    fg: 'successSoftForeground',
+  },
+  warning: { bg: 'warning', bgPressed: 'warningPressed', fg: 'warningForeground' },
+  'warning-soft': {
+    bg: 'warningSoft',
+    bgPressed: 'warningSoftPressed',
+    fg: 'warningSoftForeground',
+  },
+  danger: { bg: 'danger', bgPressed: 'dangerPressed', fg: 'dangerForeground' },
+  'danger-soft': {
+    bg: 'dangerSoft',
+    bgPressed: 'dangerSoftPressed',
+    fg: 'dangerSoftForeground',
+  },
+}
+
+/**
+ * The ring `Button.Spinner` rotates. It is pure style, so the recipe owns it like every
+ * other measurement — `borderTopColor` is the gap that makes the rotation visible, and
+ * is structural rather than a colour the theme has an opinion about.
+ */
+function ring(theme: XAUITheme, size: number): SlotStyles<ButtonSlot>['spinner'] {
+  return {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+    borderWidth: theme.borderWidth.default * 2,
+    borderTopColor: 'transparent',
+  }
+}
+
+/**
+ * `size` drives height, padding, gap, radius and type — **never width**. A button with no
+ * width fills its parent in a column and hugs its content in a row, which is RN's own
+ * behaviour and the reason there is no `fullWidth` prop.
+ *
+ * The height is fixed rather than a minimum: a control has a height, and a label too long
+ * for it truncates (`Button.Label` is single-line by default) instead of deforming it.
+ *
+ * The icon sits one step above the label on the type scale, which is what keeps a 16px
+ * label from being paired with a 16px glyph that reads as smaller than it is.
+ */
+function sizeAxis(step: SizeStep) {
+  const { size, padding, gap, glyph, radius } = step
+
+  return (theme: XAUITheme): SlotStyles<ButtonSlot> => ({
+    root: {
+      height: theme.controlHeights[size],
+      paddingHorizontal: theme.spacing(padding),
+      gap: theme.spacing(gap),
+      borderRadius: theme.radius[radius],
+    },
+    label: {
+      fontSize: theme.fontSizes[size],
+      lineHeight: theme.lineHeights[size],
+    },
+    icon: { fontSize: theme.fontSizes[glyph] },
+    spinner: ring(theme, theme.fontSizes[glyph]),
+  })
+}
+
+type SizeStep = {
+  size: Size
+  /** Spacing steps, not pixels — `spacing(3.5)` is 14 on the base-4 scale. */
+  padding: number
+  gap: number
+  glyph: FontSizeKey
+  radius: RadiusKey
+}
+
+export const buttonRecipe = createRecipe({
+  slots: SLOTS,
+
+  base: theme => ({
+    root: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 0,
+      // iOS's squircle. Free on Android, and it is what makes a large radius read as a
+      // shape rather than as two arcs meeting a straight edge.
+      borderCurve: 'continuous',
+    },
+    label: {
+      fontFamily: theme.fontFamilies.body,
+      fontWeight: theme.fontWeights.medium,
+    },
+  }),
+
+  variantTokens: VARIANT_TOKENS,
+
+  /**
+   * Where the variant's colours land, for every variant at once. The border width follows
+   * the *presence* of the border role rather than a per-variant flag — `tertiary` is the
+   * only variant that names one, and that fact is already in the table above.
+   */
+  paint: (theme, colors) => ({
+    root: {
+      backgroundColor: colors.bg,
+      borderColor: colors.border,
+      borderWidth: colors.border ? theme.borderWidth.default : 0,
+    },
+    label: { color: colors.fg },
+    icon: { color: colors.fg },
+    spinner: { borderColor: colors.fg },
+  }),
+
+  /**
+   * Declaration order is application order: `radius` overrides the radius `size` set, and
+   * `isIconOnly` overrides its padding. Both are axes rather than a static sheet merged
+   * at the call site, so they stay inside the cache key and a press still allocates
+   * nothing.
+   */
+  variants: {
+    size: {
+      xs: sizeAxis({ size: 'xs', padding: 3, gap: 1, glyph: 'sm', radius: '3xl' }),
+      sm: sizeAxis({
+        size: 'sm',
+        padding: 3.5,
+        gap: 1.5,
+        glyph: 'md',
+        radius: '3xl',
+      }),
+      md: sizeAxis({ size: 'md', padding: 4, gap: 2, glyph: 'lg', radius: '3xl' }),
+      lg: sizeAxis({ size: 'lg', padding: 5, gap: 2.5, glyph: 'xl', radius: '4xl' }),
+    },
+
+    radius: {
+      xs: t => ({ root: { borderRadius: t.radius.xs } }),
+      sm: t => ({ root: { borderRadius: t.radius.sm } }),
+      md: t => ({ root: { borderRadius: t.radius.md } }),
+      lg: t => ({ root: { borderRadius: t.radius.lg } }),
+      xl: t => ({ root: { borderRadius: t.radius.xl } }),
+      '2xl': t => ({ root: { borderRadius: t.radius['2xl'] } }),
+      '3xl': t => ({ root: { borderRadius: t.radius['3xl'] } }),
+      '4xl': t => ({ root: { borderRadius: t.radius['4xl'] } }),
+      field: t => ({ root: { borderRadius: t.radius.field } }),
+      full: t => ({ root: { borderRadius: t.radius.full } }),
+    },
+
+    // A square on a fixed height. No width is computed, and none needs to be.
+    isIconOnly: {
+      true: () => ({ root: { paddingHorizontal: 0, aspectRatio: 1 } }),
+    },
+  },
+
+  /**
+   * The pressed colour lives here rather than in a `PressableFeedback.Highlight`, because
+   * a control picks one treatment or the other — both, and a pressed button darkens
+   * twice. This one is the variant's own `…Pressed` token, so the press reads as the
+   * button's colour going down rather than as a neutral film over it, and a tinted button
+   * presses through the same OKLab formula as a token one.
+   */
+  states: {
+    pressed: (_theme, colors) => ({ root: { backgroundColor: colors.bgPressed } }),
+    disabled: theme => ({ root: { opacity: theme.opacity.disabled } }),
+  },
+
+  // Annotated, or inference reads the whole `Variant` parameter off this one literal and
+  // narrows the recipe to the single variant named here.
+  defaultVariants: { variant: 'primary' as ButtonVariant, size: 'md' },
+})

--- a/packages/native/src/components/button/button.tsx
+++ b/packages/native/src/components/button/button.tsx
@@ -1,0 +1,146 @@
+import { forwardRef, useMemo } from 'react'
+import { StyleSheet } from 'react-native'
+import type { TextStyle, View } from 'react-native'
+import { usePressState } from '../../hooks/use-press-state'
+import { PressableFeedback } from '../../system/pressable-feedback'
+import { childrenToString } from '../../system/slot'
+import { useXAUITheme } from '../../theme/theme-hooks'
+import { warnDev } from '../../utils/warn-dev'
+import { ButtonLabel } from './button-label'
+import { ButtonSpinner } from './button-spinner'
+import { ButtonProvider } from './button.context'
+import { buttonRecipe } from './button.recipe'
+import type { ButtonProps } from './button.type'
+import { containsElementOfType } from './button.utils'
+
+/**
+ * The reference component. Every other one in the library is this shape.
+ *
+ * ```tsx
+ * <Button onPress={submit}>Envoyer</Button>
+ *
+ * <Button variant="danger" size="lg">
+ *   <Button.Icon as={TrashIcon} />
+ *   <Button.Label>Supprimer</Button.Label>
+ * </Button>
+ *
+ * <Button asChild>
+ *   <Link href="/projects">Voir les projets</Link>
+ * </Button>
+ * ```
+ *
+ * The view depth is one: `PressableFeedback > (Text | Icon)`. There is no wrapper view —
+ * it existed only for `fullWidth` and `customAppearance`, and both are gone.
+ */
+export const ButtonRoot = forwardRef<View, ButtonProps>(function Button(
+  {
+    children,
+    variant,
+    size,
+    radius,
+    color,
+    isDisabled = false,
+    isLoading = false,
+    isIconOnly = false,
+    asChild = false,
+    // `scale` and not `scale-highlight`: the recipe's `pressed` state already paints the
+    // variant's own pressed colour, and a neutral wash on top would darken it twice.
+    feedbackVariant = 'scale',
+    accessibilityRole = 'button',
+    style,
+    onPressIn,
+    onPressOut,
+    ...rest
+  },
+  ref
+) {
+  const theme = useXAUITheme()
+  const [isPressed, press] = usePressState({ onPressIn, onPressOut })
+
+  const selection = {
+    variant,
+    size,
+    radius,
+    isIconOnly: isIconOnly ? ('true' as const) : undefined,
+  }
+  const states = { pressed: isPressed, disabled: isDisabled || isLoading }
+
+  const styles = buttonRecipe.resolve({ theme, selection, states })
+  // Only when `color` is set, and never cached: a raw tint takes arbitrary values, so
+  // letting one into the key would grow the table with the colours users invent.
+  const tint = color
+    ? buttonRecipe.tint({ theme, color, selection, states })
+    : undefined
+
+  const context = useMemo(() => {
+    const icon = StyleSheet.flatten<TextStyle>([styles.icon, tint?.icon])
+
+    return {
+      labelStyle: tint ? [styles.label, tint.label] : styles.label,
+      spinnerStyle: tint ? [styles.spinner, tint.spinner] : styles.spinner,
+      icon: {
+        size: icon.fontSize,
+        // `ColorValue` also covers the platform's opaque colours, which `Icon` cannot
+        // hand to a third-party component expecting a string.
+        color: typeof icon.color === 'string' ? icon.color : undefined,
+      },
+      isDisabled,
+      isLoading,
+    }
+  }, [styles, tint, isDisabled, isLoading])
+
+  // R9 — `style` may be `Pressable`'s function form. The root owns the press state, so it
+  // resolves the function here instead of forwarding it and losing the styles inside.
+  const rootStyle = [
+    styles.root,
+    tint?.root,
+    typeof style === 'function' ? style({ pressed: isPressed }) : style,
+  ]
+
+  const text = childrenToString(children)
+  const showSpinner = isLoading && !containsElementOfType(children, ButtonSpinner)
+
+  // An icon-only button has no text for a screen reader to announce, and nothing about
+  // the glyph tells it what the button does. It is the one accessibility mistake this
+  // component makes easy, so it is the one it warns about.
+  if (isIconOnly && !rest.accessibilityLabel && !rest['aria-label']) {
+    warnDev(
+      'Button: an icon-only button needs an `accessibilityLabel` — there is no text for ' +
+        'a screen reader to read, so it announces as an unlabelled button.'
+    )
+  }
+
+  return (
+    <ButtonProvider value={context}>
+      <PressableFeedback
+        ref={ref}
+        isPressed={isPressed}
+        isDisabled={isDisabled || isLoading}
+        asChild={asChild}
+        feedbackVariant={feedbackVariant}
+        accessibilityRole={accessibilityRole}
+        accessibilityState={{ disabled: isDisabled, busy: isLoading }}
+        {...rest}
+        style={rootStyle}
+        // After `rest`, and composed rather than replacing: a caller's `onPressIn` runs,
+        // and the pressed state its own styles depend on still happens.
+        onPressIn={press.onPressIn}
+        onPressOut={press.onPressOut}
+      >
+        {/* R12 — under `asChild` the caller's element *is* the button, so neither the
+            auto-wrap nor the auto-spinner applies: there is one child, and it is theirs. */}
+        {asChild ? (
+          children
+        ) : (
+          <>
+            {showSpinner ? <ButtonSpinner /> : null}
+            {/* R3 — a stringifiable tree becomes a label; anything else is composed slots */}
+            {text !== null ? <ButtonLabel>{text}</ButtonLabel> : children}
+          </>
+        )}
+      </PressableFeedback>
+    </ButtonProvider>
+  )
+})
+
+ButtonRoot.displayName = 'XAUI.Button.Root'

--- a/packages/native/src/components/button/button.type.ts
+++ b/packages/native/src/components/button/button.type.ts
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+import type {
+  PressableStateCallbackType,
+  StyleProp,
+  TextProps,
+  TextStyle,
+  ViewStyle,
+} from 'react-native'
+import type { IconContextValue, IconProps } from '../../system/icon'
+import type { PressableFeedbackProps } from '../../system/pressable-feedback'
+import type { RadiusKey, Size } from '../../theme/theme.type'
+
+export type ButtonSlot = 'root' | 'label' | 'icon' | 'spinner'
+
+/**
+ * The ten sanctioned appearances (R7). Emphasis and intention are one flat union, which
+ * is why there is no `themeColor` beside it: `primary` … `ghost` are the emphasis levels,
+ * and each intention carries its own `-soft` low-emphasis level rather than one of them
+ * being special-cased.
+ */
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'ghost'
+  | 'success'
+  | 'success-soft'
+  | 'warning'
+  | 'warning-soft'
+  | 'danger'
+  | 'danger-soft'
+
+export type ButtonSize = Size
+
+export type ButtonProps = Omit<
+  PressableFeedbackProps,
+  'isPressed' | 'isDisabled' | 'style' | 'children'
+> & {
+  variant?: ButtonVariant
+  /** Height, padding, gap, radius and type. Never width. */
+  size?: ButtonSize
+  /** Overrides the radius `size` chose. Unset, a button is the shape its size implies. */
+  radius?: RadiusKey
+  /**
+   * A raw tint (`'#7c3aed'`), never a token (R7). Where it lands follows the variant: the
+   * background of a `primary`, the label of a `ghost`, the border and label of a
+   * `tertiary`. Its contrasted, soft and pressed slices are derived in OKLab, so it
+   * behaves exactly like `accent` — which is also why it must be a hex value.
+   */
+  color?: string
+  isDisabled?: boolean
+  /** Presses through as disabled, and inserts a `Button.Spinner` if none is composed. */
+  isLoading?: boolean
+  /** Drops the horizontal padding and squares the button on its fixed height. */
+  isIconOnly?: boolean
+  /** R9 — `Pressable`'s function form as much as an object or an array. */
+  style?:
+    | StyleProp<ViewStyle>
+    | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>)
+  children?: ReactNode
+}
+
+export type ButtonLabelProps = TextProps & {
+  children?: ReactNode
+}
+
+/**
+ * `Icon`'s three forms, plus the `style` every slot carries (R2). `size` and `color`
+ * default to what the root resolved; passing either wins over it.
+ */
+export type ButtonIconProps = IconProps
+
+export type ButtonSpinnerProps = {
+  style?: StyleProp<ViewStyle>
+  /** `false` stops the rotation. The ring stays, so the button does not change size. */
+  animation?: boolean
+}
+
+/**
+ * R5 — resolved styles, not props for a slot to resolve a second time. Each entry is the
+ * cached `StyleSheet` reference with the uncached tint pass layered over it, so a slot
+ * merges its own `style` on top and does no work of its own.
+ */
+export type ButtonContextValue = {
+  labelStyle: StyleProp<TextStyle>
+  spinnerStyle: StyleProp<ViewStyle>
+  /**
+   * Values, not a style: `Icon` hands `size` and `color` to a third-party component, so
+   * the root flattens its icon slot once here rather than in every icon it contains.
+   */
+  icon: IconContextValue
+  isDisabled: boolean
+  isLoading: boolean
+}

--- a/packages/native/src/components/button/button.utils.ts
+++ b/packages/native/src/components/button/button.utils.ts
@@ -1,0 +1,23 @@
+import { Children, isValidElement } from 'react'
+import type { ElementType, ReactNode } from 'react'
+
+/**
+ * Whether one of the direct children is an element of `type`.
+ *
+ * It is what `isLoading` asks before inserting a `Button.Spinner`: composing one yourself
+ * is how you put it after the label rather than before it, and the root has to know that
+ * before it renders. §8 of the plan takes this scan as the price of
+ * `<Button isLoading>Envoi…</Button>` working at all, which is the majority case.
+ *
+ * Direct children only. A spinner buried inside a wrapper is not the composition the
+ * auto-insert is about, and a deep walk would make "did I compose one?" depend on how
+ * many layers deep it sits.
+ */
+export function containsElementOfType(
+  children: ReactNode,
+  type: ElementType
+): boolean {
+  return Children.toArray(children).some(
+    child => isValidElement(child) && child.type === type
+  )
+}

--- a/packages/native/src/components/button/index.ts
+++ b/packages/native/src/components/button/index.ts
@@ -1,0 +1,23 @@
+import { ButtonIcon } from './button-icon'
+import { ButtonLabel } from './button-label'
+import { ButtonSpinner } from './button-spinner'
+import { ButtonRoot } from './button'
+
+export const Button = Object.assign(ButtonRoot, {
+  Label: ButtonLabel,
+  Icon: ButtonIcon,
+  Spinner: ButtonSpinner,
+})
+
+export { useButton } from './button.context'
+export { buttonRecipe } from './button.recipe'
+export type {
+  ButtonContextValue,
+  ButtonIconProps,
+  ButtonLabelProps,
+  ButtonProps,
+  ButtonSize,
+  ButtonSlot,
+  ButtonSpinnerProps,
+  ButtonVariant,
+} from './button.type'

--- a/packages/native/src/components/index.ts
+++ b/packages/native/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './button'

--- a/packages/native/src/hooks/use-press-state.ts
+++ b/packages/native/src/hooks/use-press-state.ts
@@ -1,10 +1,16 @@
 import { useCallback, useRef, useState } from 'react'
 import type { GestureResponderEvent } from 'react-native'
 
+/**
+ * `null` as much as `undefined`: that is how `PressableProps` types its handlers, and a
+ * root forwarding what it was given should not have to launder them first.
+ */
 export type PressHandlers = {
-  onPressIn?: (event: GestureResponderEvent) => void
-  onPressOut?: (event: GestureResponderEvent) => void
+  onPressIn?: PressHandler | null
+  onPressOut?: PressHandler | null
 }
+
+type PressHandler = (event: GestureResponderEvent) => void
 
 /**
  * The press state a root owns, with the handlers that maintain it.
@@ -22,7 +28,7 @@ export type PressHandlers = {
  */
 export function usePressState(
   handlers: PressHandlers = {}
-): [boolean, Required<PressHandlers>] {
+): [boolean, { onPressIn: PressHandler; onPressOut: PressHandler }] {
   const [isPressed, setIsPressed] = useState(false)
 
   // Read through a ref so the handlers below never change identity, even when the caller

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -1,3 +1,4 @@
+export * from './components'
 export * from './hooks'
 export * from './system'
 export * from './theme'

--- a/packages/native/src/system/pressable-feedback/pressable-feedback-highlight.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback-highlight.tsx
@@ -88,9 +88,10 @@ function AnimatedHighlight({
     shown.value = withTiming(isPressed ? 1 : 0, { duration })
   }, [isPressed, shown, duration])
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: shown.value * opacity,
-  }))
+  const animatedStyle = useAnimatedStyle(
+    () => ({ opacity: shown.value * opacity }),
+    [shown, opacity]
+  )
 
   return <Animated.View pointerEvents="none" style={[base, animatedStyle]} />
 }

--- a/packages/native/src/system/pressable-feedback/pressable-feedback-ripple.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback-ripple.tsx
@@ -102,7 +102,8 @@ function AnimatedRipple({
       wave.value = withTiming(2, { duration: duration * 2 })
 
       useA.value = !useA.value
-    }
+    },
+    [pressCount, origin, duration, waveA, waveB, fromA, fromB, useA]
   )
 
   return (
@@ -164,7 +165,7 @@ function RippleWave({
         { scale: interpolate(wave.value, [0, 1, 2], [0, 1, 1]) },
       ],
     }
-  })
+  }, [wave, from, size, opacity])
 
   return (
     <Animated.View

--- a/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
@@ -142,10 +142,15 @@ const AnimatedFeedback = forwardRef<View, BranchProps>(function AnimatedFeedback
     })
   }, [isPressed, progress])
 
-  const animatedStyle = useAnimatedStyle(() =>
-    animation.scale
-      ? { transform: [{ scale: 1 - (1 - PRESS_SCALE) * progress.value }] }
-      : {}
+  // The dependency array is explicit on every animated hook in this package. Reanimated's
+  // Babel plugin infers one, but it runs in the *consumer's* build and does not reach a
+  // published `dist` on web — where the hook then throws instead of animating.
+  const animatedStyle = useAnimatedStyle(
+    () =>
+      animation.scale
+        ? { transform: [{ scale: 1 - (1 - PRESS_SCALE) * progress.value }] }
+        : {},
+    [animation.scale, progress]
   )
 
   const context = useMemo(

--- a/packages/native/tsup.config.ts
+++ b/packages/native/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup'
 
 const entries = {
   index: 'src/index.ts',
+  'components/button/index': 'src/components/button/index.ts',
   'system/index': 'src/system/index.ts',
   'theme/index': 'src/theme/index.ts',
 }
@@ -9,6 +10,15 @@ const entries = {
 export default defineConfig({
   entry: entries,
   format: ['cjs', 'esm'],
+  /**
+   * The sources never `import React`, so the classic transform esbuild picks by default
+   * emits `React.createElement` against an undefined binding and every component in the
+   * built package throws on first render. `tsconfig`'s `"jsx": "react-native"` does not
+   * carry over — esbuild reads it as the classic runtime.
+   */
+  esbuildOptions(options) {
+    options.jsx = 'automatic'
+  },
   clean: false,
   dts: true,
   splitting: true,


### PR DESCRIPTION
Closes P2.1. Stacked on #180.

## What

`Button` on `@xaui/native/button` — the reference component the other forty-six copy.

```tsx
<Button onPress={submit}>Envoyer</Button>

<Button variant="danger" size="lg">
  <Button.Icon as={TrashIcon} />
  <Button.Label>Supprimer</Button.Label>
</Button>

<Button asChild>
  <Link href="/projects">Voir les projets</Link>
</Button>
```

| | |
| --- | --- |
| `variant` | the ten sanctioned values, emphasis and intention in one flat union |
| `size` | `xs` `sm` `md` `lg` — height, padding, gap, radius and type. Never width |
| `radius` | optional override of the shape the size implies |
| `color` | one raw tint, placed by the variant |
| `isDisabled` `isLoading` `isIconOnly` | R8 |
| `asChild` `feedbackVariant` `animation` | forwarded to `PressableFeedback` |
| slots | `Button.Label`, `Button.Icon`, `Button.Spinner` |

## Why

### Aligned with heroui-native, on our architecture

Their measurements are taken verbatim from `src/styles/components/button.css`, so the two
libraries render the same shapes:

| | heroui `sm/md/lg` | ours |
| --- | --- | --- |
| height | 40 · 48 · 56 | `controlHeights` — same, plus `xs` at 32 |
| padding-inline | 14 · 16 · 20 | `spacing(3.5 / 4 / 5)` — same |
| gap | 6 · 8 · 10 | `spacing(1.5 / 2 / 2.5)` — same |
| label | 14/20 · 16/24 · 18/28, `font-medium` | same, from the type scale |
| radius | `3xl` · `3xl` · `4xl` | same keys — a pill at every height |
| icon-only | `padding: 0; aspect-ratio: 1` | same |

Where we diverge, it is a decision the plan already took, not a local variation:

- **Ten variants, not seven.** Their `outline` is our `tertiary`; their `tertiary`
  (`secondary`'s background with a different label) is dropped. `-soft` generalises to
  the three intentions instead of being hand-added to `danger` alone (§1 ter, divergence 4
  and 5).
- **The context carries resolved styles, not raw props.** They re-resolve `tv()` in every
  slot, which is free with a class cache and is not free without one (R5).
- **No `Button.Background`.** That slot hosts their glass blur — a theme feature, out of
  scope for 1.0. The name stays free.
- **`isLoading` and `Button.Spinner` are ours.** They have neither.

### The rules it has to hold, since forty-six components copy it

R9 and R12 are unfixable after 1.0, so both are real here: the root forwards `ref`,
`testID`, the a11y props and `style` **including `Pressable`'s function form** — resolved
at the root, which owns the press state — and `asChild` is a render branch through `Slot`,
not a destructured prop.

## How

```
components/button/
├── button.recipe.ts     # ten lines of token names + one paint function
├── button.context.ts    # resolved values, exports useButton (R10)
├── button.type.ts
├── button.utils.ts      # containsElementOfType — the only pure logic, and it is tested
├── button.tsx           # the root
├── button-label.tsx · button-icon.tsx · button-spinner.tsx
└── index.ts
```

- **A variant names tokens and computes nothing.** `paint` is written once and says where
  they land; the border width follows the *presence* of the border role, so `tertiary`
  needs no flag. The suffix on each token name is also what a raw `color` reads, which is
  why a tinted `ghost` paints its label and a tinted `tertiary` its border with nothing
  further declared.
- **`radius` and `isIconOnly` are axes, not a sheet merged at the call site** — they stay
  inside the cache key, so a press still allocates nothing.
- **One pressed treatment, not two.** The recipe's `pressed` state paints the variant's own
  `…Pressed` token and the root asks for `feedbackVariant="scale"`; a neutral wash on top
  would darken it twice.
- **`radius` has no default**, so a button is the shape its size implies. This departs from
  the `radius = 'md'` in the plan's §8 sample, which would have made every button
  near-square and unlike its reference.

### Two build defects it surfaced

Neither is caused by the Button; both stop it rendering, so both are fixed here.

- **The package threw on first render.** esbuild emitted classic `React.createElement`
  against a binding the sources never import — `tsconfig`'s `"jsx": "react-native"` does
  not carry over. Every v1 component in the published `dist` was affected.
- **Reanimated hooks threw on web.** The Babel plugin infers the dependency array, but it
  runs in the consumer's build and does not reach a published `dist`. Every animated hook
  in the package now passes one explicitly.

`usePressState` also now accepts `null` handlers, which is how `PressableProps` types them.

## Verification

The demo screen at `apps/demo/app/button.tsx` is how a component is verified here — there
is no test file for it. Rendered through `react-native-web`, **light and dark**: the ten
variants, the four sizes, icon and label in both orders, icon-only at three sizes, loading
with the spinner inserted and with one composed after the label, disabled, the tint on four
variants, three radii, `asChild` on a bare `Pressable`, a label truncating instead of
deforming the control, and a press counter proving the caller's handlers survive.

*(The iOS simulator is unavailable on this machine — no full Xcode install — so the render
check is react-native-web only.)*

`containsElementOfType` is the only pure logic and has a mirrored test.

```
pnpm turbo run lint --filter=docs --filter=@xaui/*   6 successful
pnpm type-check                                      5 successful
pnpm test                                            8 successful — 136 tests
```

The legacy `Button` and `IconButton` now carry `@deprecated` with the v1 equivalent
written out. `.project-specs/ROADMAP.md` splits P2 into its four tasks; P2.1 is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
