### PR TITLE
docs(plan): the blocking P2 API review, and the six fixes it produced (P2.3)

### DIFF
--- a/.changeset/api-review-fixes.md
+++ b/.changeset/api-review-fixes.md
@@ -1,0 +1,26 @@
+---
+'@xaui/native': patch
+'@xaui/hybrid': patch
+---
+
+Fix what the blocking P2 API review found, before fifteen components copy it.
+
+**`require()` failed on every subpath.** `exports.require` pointed at the ESM build while
+the CJS build was produced and never referenced, so in a `"type": "module"` package every
+`require('@xaui/native')` threw a `SyntaxError`. Both packages now declare the full dual
+form, with types **per condition** — `.d.ts` under `import`, `.d.cts` under `require` — so
+a CommonJS consumer no longer type-checks against the ESM declarations.
+
+**Overlays painted outside rounded corners.** `Highlight` and `Ripple` are absolute fills
+with square corners, and every control in the library is rounded. The clip existed only for
+`scale-ripple`, and only on the animated branch; it now applies on both branches whenever a
+default overlay is mounted — and only then, so a root without one can still let a child
+overflow.
+
+**`accessibilityState` was replaced instead of merged** on `Button`. A caller adding
+`expanded` or `selected` silently erased `disabled` and `busy`, and a screen reader stopped
+announcing a disabled button.
+
+**`defaultVariants` narrowed a recipe's whole `Variant` type** to the single value named in
+it, making every other variant a type error at the call site. `NoInfer` in the engine
+removes the cast each of the forty-seven components would otherwise have carried.

--- a/.project-specs/P2-API-REVIEW.md
+++ b/.project-specs/P2-API-REVIEW.md
@@ -1,0 +1,192 @@
+# P2.3 — Revue d'API bloquante
+
+> _« Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant
+> cette revue. »_ — plan §9, P2.3
+
+La revue porte sur le `Button` (P2.1) **et sur tout ce qu'il a été le premier à exercer** :
+le moteur de recettes, les slots, `PressableFeedback`, `Icon`, les hooks partagés, le
+packaging. C'est le seul moment où une correction coûte un composant plutôt que quinze.
+
+**Verdict : le pattern tient.** Les treize règles sont applicables telles quelles, la boucle
+par composant du §9 se suit sans friction, et les chiffres du §9 bis confirment que le cache
+fait ce qu'on lui prête. Neuf constats en sont sortis : **six corrigés ici**, trois
+enregistrés avec leur remède et leur échéance.
+
+---
+
+## Ce qui est corrigé
+
+### 1. `require()` échouait sur les quatre sous-chemins — **bloquant**
+
+`exports.require` pointait sur le build **ESM** (`./dist/index.js`) alors que le build CJS
+(`index.cjs`) était produit et jamais référencé. Le package déclarant `"type": "module"`,
+tout `require('@xaui/native')` levait une `SyntaxError`.
+
+Portée : les trois packages publiés, sur **chaque** sous-chemin. Un consommateur Jest en
+CJS, un script Node, une résolution Metro en CJS — aucun ne pouvait charger la librairie.
+
+**Corrigé** sur `@xaui/native` et `@xaui/hybrid`, en forme duale complète : les types sont
+déclarés **par condition** (`.d.ts` sous `import`, `.d.cts` sous `require`), sans quoi un
+consommateur CJS type-check contre les déclarations ESM.
+
+```json
+"./button": {
+  "import":  { "types": "./dist/components/button/index.d.ts",  "default": "./dist/components/button/index.js" },
+  "require": { "types": "./dist/components/button/index.d.cts", "default": "./dist/components/button/index.cjs" }
+}
+```
+
+> `@xaui/native-legacy` porte le même défaut sur ses 48 entrées et **n'est pas corrigé
+> ici** : il est figé à `0.2.11` et listé dans `ignore` (`.changeset/config.json`), donc
+> le corriger demande de l'en sortir le temps d'une release. Voir « Enregistré », point A.
+
+### 2. Le package entier levait au premier rendu — **bloquant**
+
+esbuild émettait `React.createElement` en runtime JSX classique, contre un binding que les
+sources n'importent jamais. `"jsx": "react-native"` du `tsconfig` ne se transmet pas — esbuild
+le lit comme le runtime classique. **Aucun composant v1 publié n'aurait rendu.**
+
+Corrigé en P2.1 (`esbuildOptions` → `jsx: 'automatic'`). Mentionné ici parce que c'est le
+genre de défaut qu'aucune revue de code ne trouve : il n'existe que dans l'artefact publié.
+
+### 3. `asChild` sur `PressableFeedback` fusionnait dans le provider — **bloquant (R12)**
+
+Un `Slot` fusionne ses props dans son enfant unique, et cet enfant était le provider de
+contexte. La ref, le style, les handlers et `disabled` atterrissaient donc sur un provider
+qui les ignore : l'élément du composeur cessait de réagir au toucher, sans erreur.
+
+R12 est irrattrapable après la 1.0. Corrigé dans #180, avant le `Button`.
+
+### 4. Les overlays débordaient des coins arrondis
+
+`Highlight` et `Ripple` sont des remplissages absolus à coins droits. Sur un contrôle
+arrondi — c'est-à-dire **tous** — le lavis peignait hors de la surface aux quatre coins. Le
+clip n'existait que pour `scale-ripple`, et seulement sur la branche animée.
+
+**Corrigé** : `clipFor()` pose `overflow: 'hidden'` dès qu'un overlay par défaut est monté,
+sur les deux branches. Pas quand il n'y en a pas — cela couperait silencieusement un enfant
+qui déborde légitimement (un badge au coin d'un bouton), et un composant qui rend son propre
+overlay a choisi `scale` précisément pour en décider lui-même.
+
+### 5. `accessibilityState` était écrasé, pas fusionné
+
+`{...rest}` passait après `accessibilityState`, donc un appelant ajoutant `expanded` ou
+`selected` effaçait `disabled` et `busy`. Un lecteur d'écran cessait d'annoncer un bouton
+désactivé — silencieusement, et le pattern se serait répliqué sur les 46 suivants.
+
+**Corrigé** : fusion, les clés de l'appelant l'emportant sur les nôtres.
+
+### 6. `defaultVariants` narrowait le type `Variant` du recipe entier
+
+L'inférence lisait `Variant` sur le seul littéral `{ variant: 'primary' }` et réduisait la
+recette à cette valeur : toutes les autres variantes devenaient des erreurs de type au point
+d'appel. Le `Button` s'en sortait par un `as ButtonVariant` — que **les 47 composants**
+auraient recopié.
+
+**Corrigé dans le moteur** : `defaultVariants?: Selection<NoInfer<Variant>, A>`.
+L'annotation disparaît du `Button`.
+
+---
+
+## Ce qui est enregistré, avec son échéance
+
+### A. `@xaui/native-legacy` a le défaut de packaging du point 1
+
+48 entrées, même `require` cassé, déjà publié en `0.2.11`. Le corriger demande de le sortir
+d'`ignore` le temps d'une release — ce qu'AGENTS.md §Release décrit comme la procédure d'un
+correctif `0.2.x` légitime.
+
+**Échéance :** au prochain correctif legacy, pas avant. Un tree figé qu'on ne republie pas
+ne gagne rien à être corrigé dans le dépôt seul.
+
+### B. L'axe `radius` est dix lignes que 46 composants recopieront
+
+```ts
+radius: {
+  xs: t => ({ root: { borderRadius: t.radius.xs } }),
+  sm: t => ({ root: { borderRadius: t.radius.sm } }),
+  … huit autres
+}
+```
+
+Dix clés × 47 composants = 470 lignes qui ne disent rien. Un `radiusAxis('root')` dans
+`system/recipe/` les remplacerait par une.
+
+**Non fait ici, délibérément** : la règle du dépôt est _promotion au deuxième usage, jamais
+par anticipation_ (§2 bis). Le `Button` est le premier usage.
+
+**Échéance :** P3 #4, le `Card` — le deuxième composant à exposer un `radius`. Le
+constat est consigné pour que la promotion se fasse à ce moment-là plutôt que d'être
+redécouverte.
+
+### C. Le `style` de `Icon` ne s'applique qu'à la forme `source`
+
+`IconProps.style` est typé `StyleProp<ImageStyle>` et n'atteint que la branche `Image`.
+`<Button.Icon as={TrashIcon} style={{ opacity: 0.5 }} />` ne fait donc **rien**,
+silencieusement — ce qui frotte contre R2 (« chaque slot porte son propre `style` »).
+
+**Non corrigé** : les deux autres formes ne sont pas des vues que nous rendons. Une
+`<View>` d'emballage rétablirait `style` au prix d'un niveau de profondeur sur chaque icône
+de la librairie — exactement ce que le §8 a supprimé. `size` et `color` restent
+l'échappatoire, et le type le documente maintenant.
+
+**Échéance :** à revoir si un composant du noyau en a réellement besoin. Sinon, c'est une
+limite assumée du fait d'envelopper un composant tiers.
+
+---
+
+## Ce qui a été vérifié et tient
+
+| Règle                          | Verdict                                                                                                   |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| R1 · composition               | Root `forwardRef` + `Label` / `Icon` / `Spinner`. Aucune prop ne stylise l'intérieur d'un autre composant |
+| R2 · pas de `customAppearance` | Chaque slot porte son `style` — sauf la nuance C ci-dessus                                                |
+| R3 · auto-wrap                 | `childrenToString`, récursif. `<Button>{count} items</Button>` fonctionne                                 |
+| R4 · layout au root            | `gap` au root, **zéro marge** sur les trois slots. Pas de `startContent`                                  |
+| R5 · contexte résolu           | Styles résolus, memoizés. Aucun slot ne rappelle la recette                                               |
+| R6 · tokens dans les props     | `size={42}` est une erreur de type. `color` est l'exception prévue                                        |
+| R7 · deux props d'apparence    | `variant` et `color`. Rien d'autre                                                                        |
+| R8 · `isX`                     | `isDisabled`, `isLoading`, `isIconOnly`. `disabled` n'est pas public                                      |
+| R9 · le root forwarde tout     | `ref`, `testID`, a11y, et `style` **en forme fonction** — résolue au root, qui possède l'état de press    |
+| R10 · hook exporté             | `useButton`                                                                                               |
+| R11 · `displayName`            | `XAUI.Button.Root` / `.Label` / `.Icon` / `.Spinner`                                                      |
+| R12 · `asChild`                | Branche de rendu réelle, via `Slot` — après #180                                                          |
+| R13 · RTL                      | `paddingHorizontal`, aucun `left`/`right`. La règle ESLint passe                                          |
+
+**Vocabulaire.** Les dix variantes nomment des tokens et ne calculent rien ; la recette ne
+contient ni hex ni pixel — les seuls nombres sont des _pas_ sur l'échelle d'espacement et des
+valeurs structurelles (`borderWidth: 0`, `aspectRatio: 1`). `size` pilote la hauteur et
+jamais la largeur, en `height` fixe. Pas de `fullWidth`.
+
+**Perf.** §9 bis : 200 boutons coûtent 40 feuilles de style, un appui en coûte 0, et un appui
+re-rend 2 composants hôtes sur 400.
+
+**Un écart assumé au plan.** `radius` n'a **pas** de valeur par défaut, là où l'exemple du §8
+écrit `radius = 'md'`. Avec `md` (9 px sur une base de 12), chaque bouton serait presque
+carré et ne ressemblerait pas à sa référence. La taille impose la forme ; `radius` la
+remplace quand on le demande.
+
+---
+
+## Deux décisions que la revue confirme
+
+**Un seul traitement de l'état pressé.** La recette peint le token `…Pressed` de la variante
+et le root demande `feedbackVariant="scale"`. Le lavis neutre par-dessus assombrirait deux
+fois. Les 46 suivants doivent choisir de la même manière : la recette **ou** l'overlay.
+
+**Le contexte porte des styles résolus, pas des props.** C'est la divergence 1 du §1 ter, et
+elle se paie ici : l'objet `ResolvedStyles` change d'identité à l'appui, donc le memo se
+reconstruit et les slots du bouton pressé re-rendent. Mesuré : **2 composants hôtes, pas
+400**. Résoudre deux fois — une passe sans états pour les slots — supprimerait ces deux
+rendus, au prix d'un invariant fragile : « aucun état ne touche un slot », vrai pour le
+`Button` et faux au premier composant qui change la couleur de son label sous le doigt.
+**Non fait.** Le coût mesuré ne le justifie pas.
+
+---
+
+## Conclusion
+
+P3 peut démarrer. Le premier composant du noyau — `Typography` — se copie sur
+`components/button/` sans réserve, en gardant devant soi les trois points enregistrés :
+promouvoir `radiusAxis` au `Card`, ne pas s'étonner du `style` d'`Icon`, et corriger le
+packaging de legacy à sa prochaine release.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -27,7 +27,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P1.7  | `pnpm pack` uniqueness check on both packages           | done   |
 | P2.1  | The reference `Button`                                  | done   |
 | P2.2  | Perf baseline — 200 buttons, re-renders and allocations | done   |
-| P2.3  | API review — blocking, nothing starts in P3 before it   | todo   |
+| P2.3  | API review — blocking, nothing starts in P3 before it   | done   |
 | P2.4  | Publish `@xaui/native` on the `alpha` tag               | todo   |
 | P3    | The fifteen-component core                              | todo   |
 | P4    | Docs, generated tables, `1.0.0`                         | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -745,7 +745,6 @@ export const appTheme = createTheme({
 ```tsx
 // app/_layout.tsx
 import { appTheme } from './theme'
-
 ;<XAUIProvider theme={appTheme}>
   <App />
 </XAUIProvider>
@@ -1181,7 +1180,7 @@ Identique pour P2, P3 et P5. C'est **la** tâche répétée 47 fois ; l'écrire 
 2. **La mesure de référence.** Liste de 200 boutons : re-renders et allocations de style.
    → Un chiffre écrit dans le plan. C'est le seuil que les 46 autres devront tenir, et la seule preuve que le cache fait ce qu'on prétend. **Mesuré — voir §9 bis.**
 3. **Revue d'API — bloquante.**
-   → Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette revue.
+   → Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette revue. **Faite — `P2-API-REVIEW.md` : neuf constats, six corrigés, trois datés. Verdict : le pattern tient, P3 peut démarrer.**
 4. **Publier `@xaui/native` sur le tag `alpha`** (la ligne `0.9.x-alpha.x` est déjà ouverte, cf. §Versions).
    → La démo consomme le package publié, pas le workspace.
 

--- a/packages/hybrid/package.json
+++ b/packages/hybrid/package.json
@@ -13,18 +13,28 @@
   ],
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./theme": {
-      "types": "./dist/theme/index.d.ts",
-      "import": "./dist/theme/index.js",
-      "require": "./dist/theme/index.js"
+      "import": {
+        "types": "./dist/theme/index.d.ts",
+        "default": "./dist/theme/index.js"
+      },
+      "require": {
+        "types": "./dist/theme/index.d.cts",
+        "default": "./dist/theme/index.cjs"
+      }
     }
   },
   "files": [
@@ -58,5 +68,6 @@
     "react-dom": "19.1.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
-  }
+  },
+  "module": "./dist/index.js"
 }

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -14,28 +14,48 @@
   ],
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./button": {
-      "types": "./dist/components/button/index.d.ts",
-      "import": "./dist/components/button/index.js",
-      "require": "./dist/components/button/index.js"
+      "import": {
+        "types": "./dist/components/button/index.d.ts",
+        "default": "./dist/components/button/index.js"
+      },
+      "require": {
+        "types": "./dist/components/button/index.d.cts",
+        "default": "./dist/components/button/index.cjs"
+      }
     },
     "./system": {
-      "types": "./dist/system/index.d.ts",
-      "import": "./dist/system/index.js",
-      "require": "./dist/system/index.js"
+      "import": {
+        "types": "./dist/system/index.d.ts",
+        "default": "./dist/system/index.js"
+      },
+      "require": {
+        "types": "./dist/system/index.d.cts",
+        "default": "./dist/system/index.cjs"
+      }
     },
     "./theme": {
-      "types": "./dist/theme/index.d.ts",
-      "import": "./dist/theme/index.js",
-      "require": "./dist/theme/index.js"
+      "import": {
+        "types": "./dist/theme/index.d.ts",
+        "default": "./dist/theme/index.js"
+      },
+      "require": {
+        "types": "./dist/theme/index.d.cts",
+        "default": "./dist/theme/index.cjs"
+      }
     }
   },
   "files": [
@@ -89,5 +109,6 @@
     "react-native-worklets": "^0.5.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
-  }
+  },
+  "module": "./dist/index.js"
 }

--- a/packages/native/src/components/button/button.recipe.ts
+++ b/packages/native/src/components/button/button.recipe.ts
@@ -185,7 +185,5 @@ export const buttonRecipe = createRecipe({
     disabled: theme => ({ root: { opacity: theme.opacity.disabled } }),
   },
 
-  // Annotated, or inference reads the whole `Variant` parameter off this one literal and
-  // narrows the recipe to the single variant named here.
-  defaultVariants: { variant: 'primary' as ButtonVariant, size: 'md' },
+  defaultVariants: { variant: 'primary', size: 'md' },
 })

--- a/packages/native/src/components/button/button.tsx
+++ b/packages/native/src/components/button/button.tsx
@@ -47,6 +47,7 @@ export const ButtonRoot = forwardRef<View, ButtonProps>(function Button(
     // variant's own pressed colour, and a neutral wash on top would darken it twice.
     feedbackVariant = 'scale',
     accessibilityRole = 'button',
+    accessibilityState,
     style,
     onPressIn,
     onPressOut,
@@ -119,7 +120,14 @@ export const ButtonRoot = forwardRef<View, ButtonProps>(function Button(
         asChild={asChild}
         feedbackVariant={feedbackVariant}
         accessibilityRole={accessibilityRole}
-        accessibilityState={{ disabled: isDisabled, busy: isLoading }}
+        // Merged, not spread over: a caller adding `expanded` or `selected` must not
+        // silently drop the disabled and busy states a screen reader depends on. Their
+        // keys still win, because they said them.
+        accessibilityState={{
+          disabled: isDisabled,
+          busy: isLoading,
+          ...accessibilityState,
+        }}
         {...rest}
         style={rootStyle}
         // After `rest`, and composed rather than replacing: a caller's `onPressIn` runs,

--- a/packages/native/src/system/icon/icon.type.ts
+++ b/packages/native/src/system/icon/icon.type.ts
@@ -22,6 +22,13 @@ export type IconProps = {
   size?: number
   /** A raw value (R7), never a token. Overrides the slot's. */
   color?: string
+  /**
+   * The **`source` form only** — it is the one of the three where we render the view.
+   * `as` hands its props to a third-party component and the children form clones an
+   * element the caller made; neither is a view this can style, and wrapping them would
+   * add a level of depth to every icon in the library. `size` and `color` are the
+   * escape hatch there.
+   */
   style?: StyleProp<ImageStyle>
 }
 

--- a/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
@@ -109,7 +109,12 @@ const StaticFeedback = forwardRef<View, BranchProps>(function StaticFeedback(
 
   return (
     <FeedbackProvider value={context}>
-      <Root ref={ref} style={style} disabled={isDisabled} {...rest}>
+      <Root
+        ref={ref}
+        style={[clipFor(feedbackVariant, asChild), style]}
+        disabled={isDisabled}
+        {...rest}
+      >
         {body(asChild, feedbackVariant, children)}
       </Root>
     </FeedbackProvider>
@@ -172,18 +177,13 @@ const AnimatedFeedback = forwardRef<View, BranchProps>(function AnimatedFeedback
     onLayout?.(event)
   }
 
-  // A ripple painting outside its control is a defect, not a style choice, so the clip
-  // goes on before the caller's style — which can still override it.
-  const clip: StyleProp<ViewStyle> =
-    feedbackVariant === 'scale-ripple' ? { overflow: 'hidden' } : null
-
   const Root = asChild ? AnimatedSlot : AnimatedPressable
 
   return (
     <FeedbackProvider value={context}>
       <Root
         ref={ref}
-        style={[clip, style, animatedStyle]}
+        style={[clipFor(feedbackVariant, asChild), style, animatedStyle]}
         disabled={isDisabled}
         onPressIn={handlePressIn}
         onLayout={handleLayout}
@@ -222,6 +222,25 @@ function body(
       {children}
     </>
   )
+}
+
+const OVERLAY_CLIP: ViewStyle = { overflow: 'hidden' }
+
+/**
+ * An overlay is an absolute fill with square corners, and every control in this library is
+ * rounded — so without a clip both the wash and the ripple paint outside the surface at
+ * each corner. That is a defect rather than a style choice, so it goes on *before* the
+ * caller's style, which can still override it.
+ *
+ * Only when a default overlay is actually mounted. Clipping a root that has none would
+ * silently cut off a child that legitimately overflows — a badge on a button's corner —
+ * and a component that renders its own overlay picked `scale` precisely to decide this
+ * for itself.
+ */
+function clipFor(variant: FeedbackVariant, asChild: boolean): StyleProp<ViewStyle> {
+  if (asChild) return null
+  const mountsOverlay = variant === 'scale-highlight' || variant === 'scale-ripple'
+  return mountsOverlay ? OVERLAY_CLIP : null
 }
 
 function DefaultOverlay({ variant }: { variant: FeedbackVariant }): ReactNode {

--- a/packages/native/src/system/recipe/recipe.type.ts
+++ b/packages/native/src/system/recipe/recipe.type.ts
@@ -63,7 +63,13 @@ export type RecipeConfig<
   variants?: A
   compoundVariants?: ReadonlyArray<CompoundVariant<Slot, Variant, A>>
   states?: Partial<Record<StateName, StyleFn<Slot>>>
-  defaultVariants?: Selection<Variant, A>
+  /**
+   * `NoInfer`, because this is the one place a single variant name appears on its own:
+   * without it, inference reads `Variant` off `{ variant: 'primary' }` and narrows the
+   * whole recipe to that one value, so every other variant becomes a type error at the
+   * call site. `variantTokens` is the declaration; this only picks a default from it.
+   */
+  defaultVariants?: Selection<NoInfer<Variant>, A>
 }
 
 /** Stable references: the same object for the same tokens, for the app's lifetime. */


### PR DESCRIPTION
Closes P2.3 — **the blocking review**. Stacked on #182.

> *"Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette
> revue."* — plan §9

## What

`.project-specs/P2-API-REVIEW.md`, plus the fixes it produced. The review covers the
`Button` **and everything it was the first thing to exercise**: the recipe engine, the
slots, `PressableFeedback`, `Icon`, the shared hooks, the packaging.

**Verdict: the pattern holds.** Nine findings — six fixed, three recorded with a remedy and
a date. P3 can start.

## Why

Two of the findings would have shipped broken, and neither is the kind of thing a code
review finds — they only exist in the published artefact:

- **`require()` failed on every subpath of every published package.** `exports.require`
  pointed at the **ESM** build while the CJS build was produced and never referenced. In a
  `"type": "module"` package that is a `SyntaxError` on load: a Jest CJS setup, a Node
  script, a CJS Metro resolution — none could load the library.
- **The package threw on first render** (fixed in #181): esbuild emitted classic
  `React.createElement` against a binding the sources never import.

Two more are pattern defects the other 46 components would have inherited verbatim:

- **`accessibilityState` was replaced, not merged.** A caller adding `expanded` or
  `selected` silently erased `disabled` and `busy`, and a screen reader stopped announcing
  a disabled button.
- **`defaultVariants` narrowed a recipe's whole `Variant` type** to the one value named in
  it, so every other variant became a type error at the call site. The Button worked around
  it with `as ButtonVariant` — a cast all forty-seven would have copied.

## How

**Fixed here:**

| # | Finding |
| --- | --- |
| 1 | `require()` on all four subpaths — full dual form, with types **per condition** (`.d.ts` under `import`, `.d.cts` under `require`), on `@xaui/native` and `@xaui/hybrid` |
| 4 | Overlays painted outside rounded corners. The clip existed only for `scale-ripple`, and only on the animated branch; `clipFor()` now applies it on both, whenever a default overlay is mounted — and only then, so a root without one can still let a child overflow |
| 5 | `accessibilityState` merged, the caller's keys winning |
| 6 | `NoInfer` on `defaultVariants` in the engine; the cast disappears from the Button |

Findings 2 and 3 were fixed in #181 and #180 and are written up here for the record.

**Recorded, not fixed — each with its trigger:**

- **`@xaui/native-legacy` has the same packaging defect** across its 48 entries. Fixing it
  means taking it out of changesets `ignore` for a release; that is the next legacy
  `0.2.x` fix, not this PR. A frozen tree gains nothing from a fix that is never published.
- **The `radius` axis is ten near-identical lines** that 46 components would copy — 470
  lines saying nothing. A `radiusAxis()` in `system/recipe/` replaces them with one, **at
  the `Card` in P3**, because the repo's rule is promotion at the second use, never by
  anticipation (§2 bis). Recorded so it happens then rather than being rediscovered.
- **`Icon`'s `style` only reaches the `source` form.** The other two are not views we
  render, and wrapping them would add a level of depth to every icon in the library —
  exactly what §8 removed. The type now says so.

**Also confirmed, with the reason written down:** the context carries resolved styles, so
its identity changes on press and the pressed button's slots re-render. Resolving twice
would remove those two renders at the cost of a fragile invariant ("no state touches a
slot") that is true for `Button` and false for the first component that recolours its label
under the finger. Measured cost: **2 host re-renders out of 400**. Not done.

## Verification

```
pnpm turbo run lint --filter=docs --filter=@xaui/*   6 successful
pnpm type-check                                      5 successful
pnpm test                                            8 successful
pnpm perf:button                                     7 passed — unchanged
pnpm pack:check                                      ✓ @xaui/native resolves once
```

Every `.cjs` in `dist` passes `node --check` as CommonJS, and its own requires are all
`.cjs`. (`require`-ing it end-to-end in bare Node still stops at React Native's own Flow
source, which Node never parses — that is RN, not the bundle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
