### PR TITLE
chore(release): the gate before the alpha publish (P2.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: '@xaui/native resolves once in a consumer tree'
+      # The exports half of the check reads the packed tarball, so there has to be a
+      # build in it — a subpath declared in package.json and forgotten in tsup.config.ts
+      # is exactly what it exists to catch.
+      - name: Build the published packages
+        run: pnpm build --filter=@xaui/native --filter=@xaui/hybrid
+
+      - name: '@xaui/native resolves once, and every subpath ships'
         run: pnpm pack:check
 
   lint:

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -3,6 +3,9 @@
 One line per task: ref, title, status. No commentary — update the status when a task lands.
 Task detail lives in `XAUI-V1-PLAN.md`.
 
+Status is `done` or `todo`, plus `ci`: everything in the repository is done and the
+remaining action belongs to a workflow rather than to a commit.
+
 | Ref   | Task                                                    | Status |
 | ----- | ------------------------------------------------------- | ------ |
 | P0.1  | Split into `@xaui/native-legacy` and scaffold v1        | done   |
@@ -28,7 +31,7 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 | P2.1  | The reference `Button`                                  | done   |
 | P2.2  | Perf baseline — 200 buttons, re-renders and allocations | done   |
 | P2.3  | API review — blocking, nothing starts in P3 before it   | done   |
-| P2.4  | Publish `@xaui/native` on the `alpha` tag               | todo   |
+| P2.4  | Publish `@xaui/native` on the `alpha` tag               | ci     |
 | P3    | The fifteen-component core                              | todo   |
 | P4    | Docs, generated tables, `1.0.0`                         | todo   |
 | P5    | The remaining 32 components                             | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -1182,7 +1182,7 @@ Identique pour P2, P3 et P5. C'est **la** tâche répétée 47 fois ; l'écrire 
 3. **Revue d'API — bloquante.**
    → Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette revue. **Faite — `P2-API-REVIEW.md` : neuf constats, six corrigés, trois datés. Verdict : le pattern tient, P3 peut démarrer.**
 4. **Publier `@xaui/native` sur le tag `alpha`** (la ligne `0.9.x-alpha.x` est déjà ouverte, cf. §Versions).
-   → La démo consomme le package publié, pas le workspace.
+   → La démo consomme le package publié, pas le workspace. **Le dépôt est prêt — voir §9 ter.**
 
 ---
 
@@ -1207,6 +1207,41 @@ et un appui en coûte 0**.
 
 La mesure tourne avec `animation={false}`, qui emprunte la branche statique — aucun hook
 Reanimated n'est atteint, ce que le fichier vérifie plutôt que de le supposer.
+
+---
+
+### 9 ter. P2.4 — ce que la publication demande, et ce qui reste après
+
+**La publication n'est pas une commande locale.** Merger vers `main` ouvre ou met à jour la
+PR « Version Packages » ; merger celle-là publie. `changeset version`, `version-packages` et
+`release` ne se lancent jamais à la main (§Release).
+
+Les changesets de P2 sont posés : le `Button`, le correctif `asChild`, et les correctifs de
+la revue d'API. En pre mode `alpha`, ils donnent `@xaui/native@0.9.2-alpha.0` sur le
+dist-tag `alpha`. `latest` ne bouge pas.
+
+**La barrière avant la publication.** `pnpm pack:check` répond maintenant à deux questions
+sur le tarball plutôt qu'une :
+
+1. `@xaui/native` ne se résout qu'une fois — un doublon donnerait deux contextes de thème
+   (P1.7, §10).
+2. **Chaque sous-chemin d'`exports` pointe sur un fichier que le tarball contient
+   réellement.** C'est ce qui attrape un composant déclaré dans `package.json` et oublié
+   dans `tsup.config.ts` — P3 aura quarante-six occasions de le faire — et c'est la classe
+   de défaut qui a fait pointer `require` sur un fichier ESM sur _chaque_ sous-chemin des
+   trois packages (revue d'API, point 1). Le job CI construit désormais avant de packer,
+   sans quoi la question n'a pas de sens.
+
+**Ce qui reste, une fois la version sur npm** — dans cet ordre, et pas avant :
+
+1. `apps/demo` passe de `workspace:*` à `@xaui/native@alpha`. C'est le critère d'acceptation
+   de P2.4 : la démo doit consommer ce que les gens installent, pas l'arbre de travail.
+   **Attention au risque du §10** : `@xaui/native-legacy` déclare `@xaui/native` en peer, et
+   la démo dépend des deux. Un range qui ne se résout pas sur la même version mettrait deux
+   copies dans l'arbre, donc deux contextes de thème. `pnpm pack:check` vérifie le range ;
+   c'est lui qui doit rester vert.
+2. Rien d'autre. `@xaui/native` a déjà un `latest` (`0.2.8`), donc le piège du premier
+   publish en pre mode décrit au §Release ne s'applique pas ici.
 
 ---
 

--- a/tooling/pack-check/check.ts
+++ b/tooling/pack-check/check.ts
@@ -15,15 +15,30 @@ import semver from 'semver'
  * is rewritten at pack time, and it is the published shape that consumers install.
  */
 
-const PACKAGES = ['native', 'native-legacy'] as const
+const PACKAGES = ['native', 'hybrid', 'native-legacy'] as const
 const CORE = '@xaui/native'
+
+/**
+ * Whose `exports` map is held to actually shipping what it points at.
+ *
+ * `@xaui/native-legacy` is out on purpose: its 48 entries carry the same `require` defect
+ * the P2 review found in the other two, and it is frozen at `0.2.11` and listed in
+ * changesets `ignore`, so fixing it means taking it out of `ignore` for a release. Until
+ * that release, adding it here would only turn CI red over a tree nobody republishes.
+ * See `.project-specs/P2-API-REVIEW.md`, point A.
+ */
+const EXPORTS_CHECKED: ReadonlyArray<string> = ['@xaui/native', '@xaui/hybrid']
 
 type Manifest = {
   name: string
   version: string
   dependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
+  exports?: Record<string, unknown>
 }
+
+/** A packed package: the manifest npm would publish, and the files beside it. */
+type Packed = { manifest: Manifest; files: ReadonlySet<string> }
 
 type Failure = { where: string; problem: string }
 
@@ -32,8 +47,12 @@ function main() {
   const out = mkdtempSync(join(tmpdir(), 'xaui-pack-'))
 
   try {
-    const manifests = PACKAGES.map(pkg => packed(workspace, pkg, out))
-    const failures = manifests.flatMap(manifest => check(manifest, manifests))
+    const packages = PACKAGES.map(pkg => packed(workspace, pkg, out))
+    const manifests = packages.map(entry => entry.manifest)
+    const failures = [
+      ...manifests.flatMap(manifest => check(manifest, manifests)),
+      ...packages.flatMap(checkExports),
+    ]
 
     for (const { where, problem } of failures) {
       console.error(`  ✗ ${where}\n    ${problem}`)
@@ -51,13 +70,17 @@ function main() {
       `✓ ${CORE} resolves once: declared as a peer only, no runtime dependencies, ` +
         'no workspace protocol left, and every peer range admits what we ship.'
     )
+    console.log(
+      `✓ every subpath of ${EXPORTS_CHECKED.join(' and ')} points at a file the ` +
+        'tarball actually contains.'
+    )
   } finally {
     rmSync(out, { recursive: true, force: true })
   }
 }
 
-/** Packs a workspace package and reads the manifest npm would actually publish. */
-function packed(workspace: string, pkg: string, out: string): Manifest {
+/** Packs a workspace package and reads what npm would actually publish. */
+function packed(workspace: string, pkg: string, out: string): Packed {
   const dir = join(workspace, 'packages', pkg)
 
   execFileSync('pnpm', ['pack', '--pack-destination', out], {
@@ -77,9 +100,49 @@ function packed(workspace: string, pkg: string, out: string): Manifest {
     tarball,
     'package/package.json',
   ]).toString()
+
+  // Read from the tarball rather than from `dist`: `files` decides what ships, and an
+  // entry point that exists on disk but is excluded from the package is the same
+  // broken install as one that was never built.
+  const listing = execFileSync('tar', ['-tf', tarball]).toString()
   execFileSync('rm', ['-f', tarball])
 
-  return JSON.parse(raw) as Manifest
+  const files = new Set(
+    listing
+      .split('\n')
+      .filter(Boolean)
+      .map(path => path.replace(/^package\//, './'))
+  )
+
+  return { manifest: JSON.parse(raw) as Manifest, files }
+}
+
+/**
+ * Every target in the `exports` map is a file the tarball contains.
+ *
+ * Two failures it catches, and both are silent until a consumer hits them: a new
+ * component declared in `package.json` and forgotten in `tsup.config.ts` — which P3 has
+ * 46 more chances to do — and a condition pointing at the wrong build, which is how
+ * `require` came to resolve to an ESM file on every subpath of every package.
+ */
+function checkExports({ manifest, files }: Packed): Failure[] {
+  if (!EXPORTS_CHECKED.includes(manifest.name)) return []
+
+  const where = `${manifest.name}@${manifest.version}`
+
+  return targetsOf(manifest.exports ?? {})
+    .filter(target => !files.has(target))
+    .map(target => ({
+      where,
+      problem: `exports "${target}", which is not in the tarball. Either the build does not emit it — check tsup.config.ts — or "files" excludes it.`,
+    }))
+}
+
+/** Every leaf of the conditions tree, which is where the paths are. */
+function targetsOf(node: unknown): string[] {
+  if (typeof node === 'string') return node.startsWith('./') ? [node] : []
+  if (node === null || typeof node !== 'object') return []
+  return Object.values(node).flatMap(targetsOf)
 }
 
 function check(manifest: Manifest, all: Manifest[]): Failure[] {


### PR DESCRIPTION
Closes P2.4 as far as a commit can. Stacked on #183.

## What

The gate that has to hold before `@xaui/native` goes out on the `alpha` tag, and a written
account of what merging actually does — plan **§9 ter**.

`pnpm pack:check` now answers two questions about the packed tarball instead of one:

1. `@xaui/native` resolves once in a consumer tree (P1.7, unchanged).
2. **Every subpath of `exports` points at a file the tarball actually contains.**

## Why

The publish is not a local command — merging to `main` opens the "Version Packages" PR, and
merging that one publishes. So the deliverable here is not the release; it is making the
release correct.

The second check exists because of two things that already happened:

- A component can be declared in `package.json` and forgotten in `tsup.config.ts`. **P3 has
  forty-six more chances to do that**, and the failure is silent until a consumer writes
  `import { Chip } from '@xaui/native/chip'`.
- It is the class of defect that had `require` resolving to an **ESM** file on every subpath
  of all three packages (#183, finding 1). A check that only reads the manifest cannot see
  it; one that reads the tarball can.

Proven rather than assumed — a `./chip` subpath added to `package.json` and left out of
`tsup.config.ts`:

```
✗ @xaui/native@0.9.1-alpha.1
  exports "./dist/components/chip/index.js", which is not in the tarball. Either the
  build does not emit it — check tsup.config.ts — or "files" excludes it.
4 problem(s).
```

## How

- `packed()` now reads the tarball's **file listing** as well as its manifest. From the
  tarball rather than from `dist`, because `files` decides what ships: an entry point that
  exists on disk but is excluded from the package is the same broken install as one that
  was never built.
- `checkExports()` walks the conditions tree and reports every leaf that is not in the
  listing.
- The CI `pack` job **builds before packing**. Without a build the exports question has no
  meaning — the tarball would contain no `dist` at all.
- `@xaui/native-legacy` is excluded, and the comment says why: it carries the same `require`
  defect across its 48 entries, is frozen at `0.2.11` and sits in changesets `ignore`, so
  holding it to this would only turn CI red over a tree nobody republishes. It goes back in
  at its next release (#183, recorded finding A).

## What is left, and why it is not in this PR

**The publish itself.** The P2 changesets are in place across #180, #181 and #183; in
`alpha` pre mode they produce `@xaui/native@0.9.2-alpha.0` on the `alpha` dist-tag, with
`latest` untouched. `changeset version` / `version-packages` / `release` are never run by
hand.

**The demo switching to the published package** — P2.4's stated acceptance criterion —
can only happen once that version exists on npm. §9 ter records it as the next step, with
the §10 risk to watch: `@xaui/native-legacy` peers on `@xaui/native` and the demo depends on
both, so a range that does not resolve to the same version puts two copies in the tree and
therefore two theme contexts. `pack:check` is what keeps that honest.

`.project-specs/ROADMAP.md` marks P2.4 `ci` rather than `done`, with a legend: everything in
the repository is done and the remaining action belongs to a workflow.

## Verification

```
pnpm pack:check    ✓ resolves once   ✓ every subpath ships
pnpm type-check    5 successful
pnpm test          8 successful
```

No changeset: nothing in a published package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
