### PR TITLE
docs(spec): style props are R14 — spacing and placement as props, not an object

### DIFF
--- a/.agents/skills/xaui-component/SKILL.md
+++ b/.agents/skills/xaui-component/SKILL.md
@@ -12,7 +12,7 @@ this skill, the Button is wrong and gets fixed — not duplicated.
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API vocabulary),
 §8 (Button anatomy), §9 (per-component loop).
 
-## The thirteen rules — non-negotiable
+## The fourteen rules — non-negotiable
 
 | # | Rule |
 |---|---|
@@ -21,14 +21,15 @@ Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API voca
 | R3 | Text children are auto-wrapped through `childrenToString` (recursive stringify, returns `null` if any React element is present). |
 | R4 | Layout belongs to the root (`gap`, `alignItems`, `flexDirection`). Slots have **no margin of their own**. No `startContent` / `endContent` — JSX order is screen order. |
 | R5 | Context carries **resolved** values (style IDs), never raw props. Slots re-resolve nothing. Memoized. |
-| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Exception: `color`. |
-| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`. |
+| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Two exceptions, both **outside the cache**: `color`, and the style props of R14. |
+| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`, or R14, which colours nothing. |
 | R8 | Booleans are `isX` / `hasX` (`isDisabled`, `isLoading`, `hasError`). `disabled` is never public; forward it internally to `Pressable`. |
 | R9 | Every root forwards `ref`, `style` (including `Pressable`'s function form), `testID` and a11y props. `accessibilityRole` has a default but stays overridable. **Unfixable after 1.0.** |
 | R10 | Every compound exports its context hook: `export { useButton }`. |
 | R11 | `displayName` is namespaced: `'XAUI.Button.Root'`, `'XAUI.Button.Label'`. |
 | R12 | `asChild` on every root, via `mergeProps` + `mergeRefs` from `system/slot/`. |
 | R13 | No `left` / `right` in any style. Use `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. An ESLint rule enforces it in `src/`. |
+| R14 | Spacing and placement are **props, not an object**: `p px py pt pb ps pe`, `m mx my mt mb ms me`, `gap`. The value is a **step on the spacing scale**, never a pixel — `p={4}` is `spacing(4)`. Resolved outside the cache, after the tint and **before** the slot's `style`, which still wins. |
 
 ## API vocabulary
 
@@ -63,6 +64,13 @@ union to the four emphasis levels. That's a subtype, not a different prop.
 - **`color` is the tint, in a raw value** (`'#7c3aed'`), never a token. Where it lands
   follows the variant: background for `primary`, label for `ghost`, border + label for
   `tertiary`. Resolved by `theme/derive-tint.ts`, outside the style cache.
+- **Spacing and placement are props (R14).** A closed set of shorthands whose value is a
+  **step on the spacing scale**, never a pixel — `<Button p={4} mt={2}>` is
+  `spacing(4)` / `spacing(2)`. `p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`.
+  **`ps`/`pe`, never `pl`/`pr`** — R13 applies here most of all, because a shorthand API is
+  where the mistake is easiest. They colour nothing, resolve **outside the cache** (after
+  the tint, before `style`), and `style` still wins. Adding a shorthand is a plan decision
+  — see §2 ter. *Specified, not built: P2.6.*
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.agents/skills/xaui-review/SKILL.md
+++ b/.agents/skills/xaui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xaui-review
-description: Review an XAUI change against the v1 architecture rules and against clean-code standards — the thirteen principles, API vocabulary, style-cache correctness, accessibility, readability, naming, duplication, tests and package hygiene. Use after writing or modifying any component, system primitive, theme or hybrid code, and before opening a PR.
+description: Review an XAUI change against the v1 architecture rules and against clean-code standards — the fourteen principles, API vocabulary, style-cache correctness, accessibility, readability, naming, duplication, tests and package hygiene. Use after writing or modifying any component, system primitive, theme or hybrid code, and before opening a PR.
 ---
 
 # XAUI v1 — Review
@@ -8,7 +8,7 @@ description: Review an XAUI change against the v1 architecture rules and against
 Run this after **every** component or system change, before `git commit` and before
 `gh pr create`. It asks two questions in one pass: is this code **XAUI** (sections 1–5), and
 is it **good code** (section 6). Neither passes on its own — a component that honours all
-thirteen rules and is unreadable still fails review.
+fourteen rules and is unreadable still fails review.
 
 Rules referenced here are defined in `.project-specs/XAUI-V1-PLAN.md` §1 and detailed in
 the `xaui-component`, `xaui-system` and `xaui-theme` skills.
@@ -26,7 +26,7 @@ the `xaui-component`, `xaui-system` and `xaui-theme` skills.
 Severity: **blocking** = R9, R12, cache correctness, a11y, one-provider rule, generated
 files edited by hand — these are the ones that are unfixable or expensive later.
 
-## 1. The thirteen rules
+## 1. The fourteen rules
 
 - [ ] **R1** — one `forwardRef` root + dot-notation slots. No prop styling another
       component's inside.
@@ -37,9 +37,10 @@ files edited by hand — these are the ones that are unfixable or expensive late
       slot**; no `startContent` / `endContent`.
 - [ ] **R5** — context carries resolved style IDs, memoized; no slot re-resolves the
       recipe.
-- [ ] **R6** — props take tokens only; arbitrary numbers are a type error (except `color`).
+- [ ] **R6** — props take tokens only; arbitrary numbers are a type error. Two exceptions,
+      both outside the cache: `color`, and the style props of R14.
 - [ ] **R7** — only `variant` and `color`. No `background`, no `borderColor`, no third
-      appearance prop.
+      appearance prop. R14 is not one: it places a component, it does not colour it.
 - [ ] **R8** — `isX` / `hasX`; `disabled` is not public.
 - [ ] **R9** *(blocking)* — root forwards `ref`, `style` **including `Pressable`'s function
       form**, `testID`, a11y props; `accessibilityRole` defaults but stays overridable.
@@ -51,6 +52,9 @@ files edited by hand — these are the ones that are unfixable or expensive late
       compose the caller's `onPressIn` / `onPressOut` rather than replacing them.
 - [ ] **R13** — no `left` / `right` / `paddingLeft` … anywhere in `src/`; RTL-safe
       `start` / `end` forms only.
+- [ ] **R14** — spacing and placement are props: `p px py pt pb ps pe`, `m mx my mt mb ms
+      me`, `gap`. Values are **steps on the spacing scale**, never pixels. Outside the
+      cache, after the tint, before the slot's `style`.
 
 ## 2. API vocabulary
 
@@ -60,6 +64,13 @@ files edited by hand — these are the ones that are unfixable or expensive late
 - [ ] `size` sets height / horizontal padding / gap / radius, **never width**. Fixed
       `height`, not `minHeight`. No `fullWidth` prop.
 - [ ] `color` is a raw value, never a token, and lands where the variant says.
+- [ ] **Style props (R14) are the closed set and nothing more** — no `pl` / `pr` (R13), no
+      colour, no border, no typography. A new shorthand is a plan decision, not a
+      component's.
+- [ ] Their values are **spacing steps**, resolved through `theme.spacing()`. A raw pixel in
+      one is the bug this API exists to prevent.
+- [ ] They resolve **outside the cache**, after the tint and before the slot's `style`.
+      Anything that puts them in the cache key grows the table with caller values.
 - [ ] Anything else that wanted a prop goes through `style`.
 
 ## 3. Style engine and performance

--- a/.agents/skills/xaui-system/SKILL.md
+++ b/.agents/skills/xaui-system/SKILL.md
@@ -154,3 +154,30 @@ Zero runtime dependencies in the package.
       component-shaped primitives (`PressableFeedback`, `Icon`, `Portal`) get none.
 - [ ] Reference-stability test for anything touching the cache.
 - [ ] `pnpm lint && pnpm type-check && pnpm test`.
+
+## `style-props/` — R14, specified, not built (P2.6)
+
+Spacing and placement are props rather than an object, and the resolver is shared:
+
+```tsx
+<Button p={4} mt={2}>Envoyer</Button>
+```
+
+`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. A closed set — no colour, no border,
+no typography, and **`ps`/`pe` rather than `pl`/`pr`**, because a shorthand API is exactly
+where R13 gets broken. The value is a **step on the spacing scale**: `p={4}` is
+`spacing(4)`, so changing `spacingUnit` redraws what callers wrote too.
+
+Two pieces, and the split is the point:
+
+```ts
+resolveStyleProps(props, spacing)   // utils/ — pure, mirrored test
+useStyleProps(props)                // system/style-props/ — splits shorthands from the rest
+```
+
+It resolves **outside the style cache**, in the same second pass as the tint, and lands
+after it and before the slot's `style`. Putting a style prop in the cache key is the one
+way to get this wrong: the table would then grow with caller values instead of with the
+finite combinations of tokens.
+
+Plan §2 ter has the full table and the reasoning.

--- a/.claude/skills/xaui-component/SKILL.md
+++ b/.claude/skills/xaui-component/SKILL.md
@@ -12,7 +12,7 @@ this skill, the Button is wrong and gets fixed — not duplicated.
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API vocabulary),
 §8 (Button anatomy), §9 (per-component loop).
 
-## The thirteen rules — non-negotiable
+## The fourteen rules — non-negotiable
 
 | # | Rule |
 |---|---|
@@ -21,14 +21,15 @@ Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API voca
 | R3 | Text children are auto-wrapped through `childrenToString` (recursive stringify, returns `null` if any React element is present). |
 | R4 | Layout belongs to the root (`gap`, `alignItems`, `flexDirection`). Slots have **no margin of their own**. No `startContent` / `endContent` — JSX order is screen order. |
 | R5 | Context carries **resolved** values (style IDs), never raw props. Slots re-resolve nothing. Memoized. |
-| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Exception: `color`. |
-| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`. |
+| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Two exceptions, both **outside the cache**: `color`, and the style props of R14. |
+| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`, or R14, which colours nothing. |
 | R8 | Booleans are `isX` / `hasX` (`isDisabled`, `isLoading`, `hasError`). `disabled` is never public; forward it internally to `Pressable`. |
 | R9 | Every root forwards `ref`, `style` (including `Pressable`'s function form), `testID` and a11y props. `accessibilityRole` has a default but stays overridable. **Unfixable after 1.0.** |
 | R10 | Every compound exports its context hook: `export { useButton }`. |
 | R11 | `displayName` is namespaced: `'XAUI.Button.Root'`, `'XAUI.Button.Label'`. |
 | R12 | `asChild` on every root, via `mergeProps` + `mergeRefs` from `system/slot/`. |
 | R13 | No `left` / `right` in any style. Use `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. An ESLint rule enforces it in `src/`. |
+| R14 | Spacing and placement are **props, not an object**: `p px py pt pb ps pe`, `m mx my mt mb ms me`, `gap`. The value is a **step on the spacing scale**, never a pixel — `p={4}` is `spacing(4)`. Resolved outside the cache, after the tint and **before** the slot's `style`, which still wins. |
 
 ## API vocabulary
 
@@ -63,6 +64,13 @@ union to the four emphasis levels. That's a subtype, not a different prop.
 - **`color` is the tint, in a raw value** (`'#7c3aed'`), never a token. Where it lands
   follows the variant: background for `primary`, label for `ghost`, border + label for
   `tertiary`. Resolved by `theme/derive-tint.ts`, outside the style cache.
+- **Spacing and placement are props (R14).** A closed set of shorthands whose value is a
+  **step on the spacing scale**, never a pixel — `<Button p={4} mt={2}>` is
+  `spacing(4)` / `spacing(2)`. `p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`.
+  **`ps`/`pe`, never `pl`/`pr`** — R13 applies here most of all, because a shorthand API is
+  where the mistake is easiest. They colour nothing, resolve **outside the cache** (after
+  the tint, before `style`), and `style` still wins. Adding a shorthand is a plan decision
+  — see §2 ter. *Specified, not built: P2.6.*
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.claude/skills/xaui-review/SKILL.md
+++ b/.claude/skills/xaui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xaui-review
-description: Review an XAUI change against the v1 architecture rules and against clean-code standards — the thirteen principles, API vocabulary, style-cache correctness, accessibility, readability, naming, duplication, tests and package hygiene. Use after writing or modifying any component, system primitive, theme or hybrid code, and before opening a PR.
+description: Review an XAUI change against the v1 architecture rules and against clean-code standards — the fourteen principles, API vocabulary, style-cache correctness, accessibility, readability, naming, duplication, tests and package hygiene. Use after writing or modifying any component, system primitive, theme or hybrid code, and before opening a PR.
 ---
 
 # XAUI v1 — Review
@@ -8,7 +8,7 @@ description: Review an XAUI change against the v1 architecture rules and against
 Run this after **every** component or system change, before `git commit` and before
 `gh pr create`. It asks two questions in one pass: is this code **XAUI** (sections 1–5), and
 is it **good code** (section 6). Neither passes on its own — a component that honours all
-thirteen rules and is unreadable still fails review.
+fourteen rules and is unreadable still fails review.
 
 Rules referenced here are defined in `.project-specs/XAUI-V1-PLAN.md` §1 and detailed in
 the `xaui-component`, `xaui-system` and `xaui-theme` skills.
@@ -26,7 +26,7 @@ the `xaui-component`, `xaui-system` and `xaui-theme` skills.
 Severity: **blocking** = R9, R12, cache correctness, a11y, one-provider rule, generated
 files edited by hand — these are the ones that are unfixable or expensive later.
 
-## 1. The thirteen rules
+## 1. The fourteen rules
 
 - [ ] **R1** — one `forwardRef` root + dot-notation slots. No prop styling another
       component's inside.
@@ -37,9 +37,10 @@ files edited by hand — these are the ones that are unfixable or expensive late
       slot**; no `startContent` / `endContent`.
 - [ ] **R5** — context carries resolved style IDs, memoized; no slot re-resolves the
       recipe.
-- [ ] **R6** — props take tokens only; arbitrary numbers are a type error (except `color`).
+- [ ] **R6** — props take tokens only; arbitrary numbers are a type error. Two exceptions,
+      both outside the cache: `color`, and the style props of R14.
 - [ ] **R7** — only `variant` and `color`. No `background`, no `borderColor`, no third
-      appearance prop.
+      appearance prop. R14 is not one: it places a component, it does not colour it.
 - [ ] **R8** — `isX` / `hasX`; `disabled` is not public.
 - [ ] **R9** *(blocking)* — root forwards `ref`, `style` **including `Pressable`'s function
       form**, `testID`, a11y props; `accessibilityRole` defaults but stays overridable.
@@ -51,6 +52,9 @@ files edited by hand — these are the ones that are unfixable or expensive late
       compose the caller's `onPressIn` / `onPressOut` rather than replacing them.
 - [ ] **R13** — no `left` / `right` / `paddingLeft` … anywhere in `src/`; RTL-safe
       `start` / `end` forms only.
+- [ ] **R14** — spacing and placement are props: `p px py pt pb ps pe`, `m mx my mt mb ms
+      me`, `gap`. Values are **steps on the spacing scale**, never pixels. Outside the
+      cache, after the tint, before the slot's `style`.
 
 ## 2. API vocabulary
 
@@ -60,6 +64,13 @@ files edited by hand — these are the ones that are unfixable or expensive late
 - [ ] `size` sets height / horizontal padding / gap / radius, **never width**. Fixed
       `height`, not `minHeight`. No `fullWidth` prop.
 - [ ] `color` is a raw value, never a token, and lands where the variant says.
+- [ ] **Style props (R14) are the closed set and nothing more** — no `pl` / `pr` (R13), no
+      colour, no border, no typography. A new shorthand is a plan decision, not a
+      component's.
+- [ ] Their values are **spacing steps**, resolved through `theme.spacing()`. A raw pixel in
+      one is the bug this API exists to prevent.
+- [ ] They resolve **outside the cache**, after the tint and before the slot's `style`.
+      Anything that puts them in the cache key grows the table with caller values.
 - [ ] Anything else that wanted a prop goes through `style`.
 
 ## 3. Style engine and performance

--- a/.claude/skills/xaui-system/SKILL.md
+++ b/.claude/skills/xaui-system/SKILL.md
@@ -154,3 +154,30 @@ Zero runtime dependencies in the package.
       component-shaped primitives (`PressableFeedback`, `Icon`, `Portal`) get none.
 - [ ] Reference-stability test for anything touching the cache.
 - [ ] `pnpm lint && pnpm type-check && pnpm test`.
+
+## `style-props/` — R14, specified, not built (P2.6)
+
+Spacing and placement are props rather than an object, and the resolver is shared:
+
+```tsx
+<Button p={4} mt={2}>Envoyer</Button>
+```
+
+`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. A closed set — no colour, no border,
+no typography, and **`ps`/`pe` rather than `pl`/`pr`**, because a shorthand API is exactly
+where R13 gets broken. The value is a **step on the spacing scale**: `p={4}` is
+`spacing(4)`, so changing `spacingUnit` redraws what callers wrote too.
+
+Two pieces, and the split is the point:
+
+```ts
+resolveStyleProps(props, spacing)   // utils/ — pure, mirrored test
+useStyleProps(props)                // system/style-props/ — splits shorthands from the rest
+```
+
+It resolves **outside the style cache**, in the same second pass as the tint, and lands
+after it and before the slot's `style`. Putting a style prop in the cache key is the one
+way to get this wrong: the table would then grow with caller values instead of with the
+finite combinations of tokens.
+
+Plan §2 ter has the full table and the reasoning.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -6,35 +6,36 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 Status is `done` or `todo`, plus `ci`: everything in the repository is done and the
 remaining action belongs to a workflow rather than to a commit.
 
-| Ref   | Task                                                    | Status |
-| ----- | ------------------------------------------------------- | ------ |
-| P0.1  | Split into `@xaui/native-legacy` and scaffold v1        | done   |
-| P0.2  | Single token source and generator                       | done   |
-| P0.3  | OKLab colour engine                                     | done   |
-| P0.4  | Derived colour layer                                    | done   |
-| P0.5  | Contrast guard in CI                                    | done   |
-| P0.6  | `createTheme`                                           | done   |
-| P0.7  | `XAUIProvider`                                          | done   |
-| P0.8  | Legacy `core-shim.ts`                                   | done   |
-| P0.9  | Package hygiene and optional peers                      | done   |
-| P0.10 | ESLint rule for R13                                     | done   |
-| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod    | done   |
-| P0.12 | Delete `@xaui/core` and `@xaui/icons`                   | done   |
-| P0.13 | Publish `native` and `hybrid` on the `alpha` tag        | done   |
-| P1.1  | `system/recipe/` — engine, cache, tint                  | done   |
-| P1.2  | `system/slot/` — context, `childrenToString`, merges    | done   |
-| P1.3  | `system/pressable-feedback/`                            | done   |
-| P1.4  | `system/portal/`                                        | done   |
-| P1.5  | `system/icon/`                                          | done   |
-| P1.6  | Shared hooks                                            | done   |
-| P1.7  | `pnpm pack` uniqueness check on both packages           | done   |
-| P2.1  | The reference `Button`                                  | done   |
-| P2.2  | Perf baseline — 200 buttons, re-renders and allocations | done   |
-| P2.3  | API review — blocking, nothing starts in P3 before it   | done   |
-| P2.4  | Publish `@xaui/native` on the `alpha` tag               | ci     |
-| P2.5  | Fix the ripple — it renders nothing (P2-API-REVIEW §D)  | todo   |
-| P3    | The fifteen-component core                              | todo   |
-| P4    | Docs, generated tables, `1.0.0`                         | todo   |
-| P5    | The remaining 32 components                             | todo   |
-| P6    | `@xaui/hybrid` on the v1 API                            | todo   |
-| P7    | Delete `native-legacy`                                  | todo   |
+| Ref   | Task                                                         | Status |
+| ----- | ------------------------------------------------------------ | ------ |
+| P0.1  | Split into `@xaui/native-legacy` and scaffold v1             | done   |
+| P0.2  | Single token source and generator                            | done   |
+| P0.3  | OKLab colour engine                                          | done   |
+| P0.4  | Derived colour layer                                         | done   |
+| P0.5  | Contrast guard in CI                                         | done   |
+| P0.6  | `createTheme`                                                | done   |
+| P0.7  | `XAUIProvider`                                               | done   |
+| P0.8  | Legacy `core-shim.ts`                                        | done   |
+| P0.9  | Package hygiene and optional peers                           | done   |
+| P0.10 | ESLint rule for R13                                          | done   |
+| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod         | done   |
+| P0.12 | Delete `@xaui/core` and `@xaui/icons`                        | done   |
+| P0.13 | Publish `native` and `hybrid` on the `alpha` tag             | done   |
+| P1.1  | `system/recipe/` — engine, cache, tint                       | done   |
+| P1.2  | `system/slot/` — context, `childrenToString`, merges         | done   |
+| P1.3  | `system/pressable-feedback/`                                 | done   |
+| P1.4  | `system/portal/`                                             | done   |
+| P1.5  | `system/icon/`                                               | done   |
+| P1.6  | Shared hooks                                                 | done   |
+| P1.7  | `pnpm pack` uniqueness check on both packages                | done   |
+| P2.1  | The reference `Button`                                       | done   |
+| P2.2  | Perf baseline — 200 buttons, re-renders and allocations      | done   |
+| P2.3  | API review — blocking, nothing starts in P3 before it        | done   |
+| P2.4  | Publish `@xaui/native` on the `alpha` tag                    | ci     |
+| P2.5  | Fix the ripple — it renders nothing (P2-API-REVIEW §D)       | todo   |
+| P2.6  | Style props (R14) — `system/style-props/`, then the `Button` | todo   |
+| P3    | The fifteen-component core                                   | todo   |
+| P4    | Docs, generated tables, `1.0.0`                              | todo   |
+| P5    | The remaining 32 components                                  | todo   |
+| P6    | `@xaui/hybrid` on the v1 API                                 | todo   |
+| P7    | Delete `native-legacy`                                       | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -10,7 +10,7 @@
 
 ## 1. Principes
 
-Treize règles. Elles ne se négocient pas composant par composant — c'est ce qui fait qu'une lib de 47 composants reste apprenable.
+Quatorze règles. Elles ne se négocient pas composant par composant — c'est ce qui fait qu'une lib de 47 composants reste apprenable.
 
 **R1 — Composition, pas configuration.**
 Un composant = un root `forwardRef` + des slots en dot-notation. Aucune prop ne stylise l'intérieur d'un autre composant.
@@ -37,10 +37,10 @@ On n'inspecte pas le premier enfant : on tente de **stringifier récursivement**
 Le root résout `variant × size × état` (plus la teinte `color` si fournie) une fois et publie la couleur finale. Les slots ne re-résolvent rien. Valeur memoizée. HeroUI publie les props brutes et laisse chaque slot re-résoudre — c'est gratuit chez eux grâce au cache de `tv()`, ça ne l'est pas sans moteur de classes.
 
 **R6 — Tokens dans les props, valeurs arbitraires dans `style`.**
-`size="md"` passe, `size={42}` est une erreur de type. C'est ce qui permet le cache de styles (§3) — l'ouvrir tue le gain de perf. Seule exception : `color`, qui porte une valeur brute et reste explicitement hors du cache (§3).
+`size="md"` passe, `size={42}` est une erreur de type. C'est ce qui permet le cache de styles (§3) — l'ouvrir tue le gain de perf. Deux exceptions, toutes deux **hors du cache** et résolues dans une seconde passe (§3) : `color`, qui porte une teinte brute, et les **props de style** de R14.
 
 **R7 — Deux props d'apparence, pas trois.**
-`variant` = apparence sanctionnée par le design system. `color` = une teinte brute qui remplace celle du variant. Il n'existe **aucune** autre prop de couleur — pas de `background`, pas de `borderColor` ; ces cas passent par `style`.
+`variant` = apparence sanctionnée par le design system. `color` = une teinte brute qui remplace celle du variant. Il n'existe **aucune** autre prop de couleur — pas de `background`, pas de `borderColor` ; ces cas passent par `style` ou par les props de style de R14, qui ne sont pas des props d'apparence : elles ne décident ni d'une intention ni d'une emphase, elles placent le composant.
 
 **R8 — Booléens en `isX` / `hasX`.**
 `isDisabled`, `isLoading`, `hasError`. `disabled` n'est jamais public ; il est forwardé en interne au `Pressable`.
@@ -60,6 +60,24 @@ Fusionner les props dans l'enfant au lieu de rendre son propre élément — c'e
 
 **R13 — Aucun `left` / `right` dans un style.**
 `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. RN gère le RTL tout seul avec ces propriétés et pas avec les autres. Écrire `paddingLeft` coûte zéro aujourd'hui et un audit complet le jour où quelqu'un ouvre l'app en arabe. Une règle ESLint interdit les formes directionnelles dans `src/`.
+
+**R14 — L'espacement et le placement sont des props, pas un objet.**
+Le cas courant — desserrer un bouton, le pousser d'un cran — ne doit pas demander d'ouvrir un objet `style` :
+
+```tsx
+<Button p={4} mt={2}>Envoyer</Button>          // au lieu de style={{ padding: 16, marginTop: 8 }}
+<Button px={3} gap={1} color="#7c3aed">…</Button>
+```
+
+Un **jeu fermé de raccourcis**, dont la valeur est un **pas sur l'échelle d'espacement**, jamais un pixel : `p={4}` vaut `spacing(4)`, soit 16 sur la base 4. C'est ce qui les garde dans le vocabulaire du design system au lieu d'en faire une échappatoire de plus.
+
+Trois choses les rendent compatibles avec tout le reste :
+
+- **Elles ne colorent rien.** Pas de `bg`, pas de `borderColor` — R7 tient. Une prop de style place le composant ; elle ne décide pas de son apparence.
+- **Elles sont hors du cache**, résolues dans la même seconde passe que `color` (§3). Le nombre de combinaisons de tokens reste fini ; la table ne grandit pas avec les valeurs que les gens écrivent.
+- **Elles perdent contre `style`.** L'ordre est : recette → teinte → props de style → `style` du slot. Le plus spécifique gagne, et `style` reste l'échappatoire finale.
+
+Le détail du jeu et de sa résolution est au §2 ter.
 
 ### Ce qu'on garde de l'existant
 
@@ -434,6 +452,94 @@ Conséquence sur le code existant : **45 fichiers utilisent encore l'`Animated` 
 **`@xaui/icons` → supprimé.** Les 520 SVG partent. À la place, un primitif `Icon` dans `system/` qui adapte n'importe quelle lib tierce (Ionicons, Lucide, react-native-svg) **et lit le contexte de slot pour la couleur et la taille** (§5). C'est précisément le point faible de HeroUI Native — leur doc oblige l'utilisateur à résoudre la couleur d'icône à la main via `useThemeColor`.
 
 **`@xaui/mcp` → supprimé.** Sa `src/data/` est de la doc écrite à la main, déjà dupliquée avec `apps/docs` et les README. Elle est régénérée depuis la source unique de doc (§6) et servie par le site en `llms.txt` — la route `app/docs/llms-txt` existe déjà.
+
+---
+
+## 2 ter. Les props de style
+
+R14 en détail. Le problème qu'elles règlent est banal et permanent : desserrer un contrôle,
+le pousser d'un cran, resserrer un `gap`. Aujourd'hui chacun de ces cas oblige à ouvrir un
+objet `style`, ce qui est disproportionné pour un nombre.
+
+```tsx
+<Button p={4}>Envoyer</Button>
+<Button px={3} mt={2} gap={1}>…</Button>
+<Row p={4} gap={2}>…</Row>
+```
+
+### Le jeu, fermé
+
+Espacement et placement uniquement. Pas de couleur, pas de bordure, pas de typographie —
+celles-là restent dans `variant`, `color` ou `style`.
+
+| Prop  | Style RN            | Prop | Style RN           |
+| ----- | ------------------- | ---- | ------------------ |
+| `p`   | `padding`           | `m`  | `margin`           |
+| `px`  | `paddingHorizontal` | `mx` | `marginHorizontal` |
+| `py`  | `paddingVertical`   | `my` | `marginVertical`   |
+| `pt`  | `paddingTop`        | `mt` | `marginTop`        |
+| `pb`  | `paddingBottom`     | `mb` | `marginBottom`     |
+| `ps`  | `paddingStart`      | `ms` | `marginStart`      |
+| `pe`  | `paddingEnd`        | `me` | `marginEnd`        |
+| `gap` | `gap`               |      |                    |
+
+**`ps` / `pe` et `ms` / `me`, jamais `pl` / `pr`** — R13 vaut ici comme ailleurs, et c'est
+précisément une API de raccourcis qui rendrait la faute facile.
+
+Le jeu s'arrête là **pour la 1.0**. `w`, `h`, `flex`, `alignSelf` sont des candidats
+crédibles ; ils attendent qu'un composant du noyau les demande deux fois, comme tout le
+reste (§2 bis).
+
+### La valeur est un pas, pas un pixel
+
+`p={4}` vaut `spacing(4)`, soit 16 sur la base 4. C'est ce qui garde ces props dans le
+vocabulaire du design system : changer `spacingUnit` dans le thème redessine tout, y
+compris ce que les appelants ont écrit.
+
+Les demi-pas passent — `px={3.5}` vaut 14, comme dans la recette du `Button`. Une valeur
+en pixels bruts n'a pas de raccourci : c'est `style`.
+
+### Où elles se résolvent
+
+**Hors du cache**, dans la même seconde passe que la teinte (§3). C'est la condition pour
+que R6 tienne : le cache reste indexé par un nombre fini de combinaisons de tokens, et il
+ne grandit pas avec les valeurs que les appelants écrivent.
+
+L'ordre complet, du plus général au plus spécifique :
+
+```
+base → paint → variants → compoundVariants → states → teinte → props de style → style du slot
+```
+
+`style` gagne en dernier. Une prop de style est un raccourci, pas une autorité : quand les
+deux disent quelque chose du même champ, c'est la forme explicite qui l'emporte.
+
+### Où le code vit
+
+`system/style-props/` — un résolveur partagé, pas une réimplémentation par composant. Il
+est public au même titre que le reste de `system/` : un tiers qui écrit son composant XAUI
+en a besoin pour offrir la même API.
+
+Deux fonctions, l'une pure et testée, l'autre triviale :
+
+```ts
+// utils/, pur, testé : le jeu fermé → un objet de style
+resolveStyleProps(props, spacing) // { p: 4, mt: 2 } → { padding: 16, marginTop: 8 }
+
+// system/style-props/, React : sépare les raccourcis du reste des props d'un composant
+const [styleProps, rest] = useStyleProps(props)
+```
+
+Le root applique `styleProps` entre la teinte et son `style`, et forwarde `rest`. Les slots
+les acceptent aussi — R2 dit que chaque slot porte son propre `style`, et un raccourci est
+la même chose en plus court.
+
+### Ce que ça coûte
+
+Une allocation d'objet par rendu, sur les composants dont l'appelant a écrit au moins une
+de ces props. C'est le même arbitrage que `color`, et il est mesuré au §9 bis : la ligne de
+base doit rester vraie pour un composant sans prop de style, et gagner une ligne pour un
+composant qui en porte.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Source of truth in `.agents/skills/<name>/SKILL.md`, copied — never symlinked 
 | Skill | Owns |
 | --- | --- |
 | `xaui-flow` | Start here on any non-trivial task; routes to the others |
-| `xaui-component` | Writing a component — the thirteen rules, folder shape, per-component loop |
+| `xaui-component` | Writing a component — the fourteen rules, folder shape, per-component loop |
 | `xaui-system` | Recipe engine, style cache, slots, `PressableFeedback`, `Portal`, `Icon` |
 | `xaui-theme` | Tokens, OKLab derivation, `createTheme`, provider, generation |
 | `xaui-hybrid` | The web renderer and the `em` sizing convention |
@@ -33,8 +33,10 @@ Source of truth in `.agents/skills/<name>/SKILL.md`, copied — never symlinked 
 
 - **Composition, not configuration** — a `forwardRef` root plus dot-notation slots,
   `asChild` on every root, an exported context hook per compound, namespaced `displayName`.
-- **Two appearance props** — `variant` (ten sanctioned values) and `color` (a raw tint).
-  Everything else goes through the slot's own `style`.
+- **Two appearance props** — `variant` (ten sanctioned values) and `color` (a raw tint) —
+  plus a closed set of **style props** for spacing and placement (`p`, `px`, `mt`, `gap`…)
+  whose values are steps on the spacing scale. Everything else goes through the slot's own
+  `style`, which always wins.
 - **A recipe engine with a style cache** — variants name tokens, styles resolve once at the
   root, slots receive stable `StyleSheet` references.
 - **A two-layer theme** — a hand-written source layer, ~32 tokens derived from it in OKLab.

--- a/packages/native/src/components/button/button.md
+++ b/packages/native/src/components/button/button.md
@@ -172,6 +172,24 @@ in OKLab, so a free tint behaves exactly like `accent` — same ratios, same ren
 deliberately outside the style cache: letting arbitrary values into the key would grow the
 table with the colours people invent instead of with the finite combinations of tokens.
 
+### Spacing and placement — coming as props
+
+> **Not built yet.** R14 and §2 ter of the plan specify it; it is **P2.6** in the roadmap.
+> Until it lands, spacing goes through `style`.
+
+The common case — loosen a button, push it down a notch — will not require opening a
+`style` object:
+
+```tsx
+<Button p={4} mt={2}>Envoyer</Button>
+<Button px={3} gap={1}>…</Button>
+```
+
+`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. The value is a **step on the spacing
+scale**, never a pixel: `p={4}` is `spacing(4)`, so a change to `spacingUnit` in the theme
+redraws what callers wrote too. They colour nothing, they resolve outside the style cache,
+and the slot's own `style` still wins over them.
+
 ### Everything else goes through `style`
 
 There are two appearance props, `variant` and `color`, and no third. A shadow, a border in

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -13,7 +13,8 @@ re-exported from `utils/`.
 ## What belongs
 
 - A primitive a component author needs and cannot reasonably write themselves: the style
-  engine, slot plumbing, touch feedback, the portal, the icon.
+  engine, slot plumbing, touch feedback, the portal, the icon, and — specified but **not
+  built yet**, see P2.6 — the style-prop resolver of R14.
 - Nothing component-specific. If only `Button` needs it, it lives in `components/button/`
   until a second component asks for it (§2 bis).
 - The exported surface is deliberate: an internal that `createRecipe` happens to use is
@@ -42,10 +43,12 @@ const tint = color ? buttonRecipe.tint({ theme, color, selection, states }) : un
 **Resolution order, frozen:**
 
 ```
-base → paint → variants → compoundVariants → states → slot props → slot style
+base → paint → variants → compoundVariants → states → tint → style props → slot style
 ```
 
-The last two happen at the call site, and they always win.
+The last three happen at the call site, and they always win. `tint` and the style props of
+R14 are both **outside the cache**, for the same reason: they take values a caller invents,
+and the table has to grow with the finite combinations of tokens instead.
 
 **The cache** is one `Map` per recipe, keyed by
 `${theme.id}|${theme.mode}|<axes, sorted>|<active states>`. `StyleSheet.create` runs once


### PR DESCRIPTION
Stacked on #185. Spec and skills only — **no implementation**, which is P2.6.

## What

Spacing and placement become **props, not an object**. A new rule, R14:

```tsx
<Button p={4} mt={2}>Envoyer</Button>
<Button px={3} gap={1} color="#7c3aed">…</Button>
```

`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. A closed set.

## Why

The common case — loosen a control, push it down a notch — should not require opening a
`style` object. That is disproportionate for a number, and it is the friction every
component in the library will hand its callers forty-seven times over.

**This contradicted R6 and R7 as written**, so they are amended rather than left to
disagree with the new rule. That is the whole design problem, and the answer is in three
parts:

- **The value is a step on the spacing scale, never a pixel.** `p={4}` is `spacing(4)` — 16
  on the base-4 scale. Changing `spacingUnit` in the theme redraws what callers wrote too,
  which is what keeps these props inside the design system's vocabulary instead of making
  them one more escape hatch.
- **They colour nothing.** No `bg`, no `borderColor` — R7 holds. A style prop *places* a
  component; it does not decide its appearance.
- **They resolve outside the style cache**, in the same second pass as the tint, so R6's
  reason for existing survives: the table grows with the finite combinations of tokens, not
  with the values callers invent. Resolution order becomes
  `base → paint → variants → compound → states → tint → style props → slot style`, and the
  slot's own `style` still wins.

`ps` / `pe` rather than `pl` / `pr`, because a shorthand API is precisely where R13 gets
broken.

## How

| File | Change |
| --- | --- |
| `XAUI-V1-PLAN.md` | R6 and R7 amended, **R14** added, and **§2 ter** — the closed table, the step-not-pixel rule, where it resolves, where the code lives, what it costs |
| `AGENTS.md` | The v1 API summary, and thirteen rules → fourteen |
| `xaui-component` | R14 in the rules table, and a vocabulary entry beside `variant` / `color` |
| `xaui-review` | R14 in §1, and four checks in §2 — closed set, spacing steps, outside the cache, `style` wins |
| `xaui-system` | A `style-props/` section: the two-function split and the one way to get it wrong |
| `system/README.md` | The frozen resolution order now names the tint and the style props |
| `button.md` | The section, marked *not built yet* |
| `ROADMAP.md` | **P2.6** |

The shape it will take, so the task is not a blank page:

```ts
resolveStyleProps(props, spacing) // utils/ — pure, mirrored test
useStyleProps(props) // system/style-props/ — splits shorthands from the rest
```

`w`, `h`, `flex`, `alignSelf` are credible next candidates. They wait for a core component
to ask twice, like everything else (§2 bis).

## Verification

```
pnpm turbo run lint --filter=docs --filter=@xaui/*   6 successful
pnpm type-check                                      5 successful
pnpm test                                            8 successful
pnpm perf:button                                     7 passed
```

Both skill copies are byte-identical, as AGENTS.md requires. Prettier reflowed several
unrelated files and tables on the first pass; that churn was reverted and the edits
reapplied by hand, so each skill is a 14–27 line diff rather than 142.

No changeset: nothing in a published package changed — `button.md` and the `src/` READMEs
are not in `files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
