### PR TITLE
docs(spec): R14 is style as props — full RN names, full RN values

### DIFF
--- a/.agents/skills/xaui-component/SKILL.md
+++ b/.agents/skills/xaui-component/SKILL.md
@@ -21,15 +21,15 @@ Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API voca
 | R3 | Text children are auto-wrapped through `childrenToString` (recursive stringify, returns `null` if any React element is present). |
 | R4 | Layout belongs to the root (`gap`, `alignItems`, `flexDirection`). Slots have **no margin of their own**. No `startContent` / `endContent` — JSX order is screen order. |
 | R5 | Context carries **resolved** values (style IDs), never raw props. Slots re-resolve nothing. Memoized. |
-| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Two exceptions, both **outside the cache**: `color`, and the style props of R14. |
-| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`, or R14, which colours nothing. |
+| R6 | Tokens in the **vocabulary** props: `size="md"` yes, `size={42}` is a type error. Raw values have their own path, outside the cache: `color` and the style props of R14. |
+| R7 | Two appearance props in the **vocabulary**: `variant` and `color`. R14's `backgroundColor` / `borderColor` are not vocabulary — they are raw overrides, the same category as `style`. Seeing one where a `variant` would do still means the design system is being bypassed. |
 | R8 | Booleans are `isX` / `hasX` (`isDisabled`, `isLoading`, `hasError`). `disabled` is never public; forward it internally to `Pressable`. |
 | R9 | Every root forwards `ref`, `style` (including `Pressable`'s function form), `testID` and a11y props. `accessibilityRole` has a default but stays overridable. **Unfixable after 1.0.** |
 | R10 | Every compound exports its context hook: `export { useButton }`. |
 | R11 | `displayName` is namespaced: `'XAUI.Button.Root'`, `'XAUI.Button.Label'`. |
 | R12 | `asChild` on every root, via `mergeProps` + `mergeRefs` from `system/slot/`. |
 | R13 | No `left` / `right` in any style. Use `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. An ESLint rule enforces it in `src/`. |
-| R14 | Spacing and placement are **props, not an object**: `p px py pt pb ps pe`, `m mx my mt mb ms me`, `gap`. The value is a **step on the spacing scale**, never a pixel — `p={4}` is `spacing(4)`. Resolved outside the cache, after the tint and **before** the slot's `style`, which still wins. |
+| R14 | A component's style is editable **in props**: `padding={16}`, `width="100%"`, `backgroundColor="#111"`. **Full RN names and RN values** — no abbreviations, no hidden scale (`padding={t.spacing(4)}` when you want the scale). The set is the node's style type (`ViewStyle`, `TextStyle` on a text slot) **minus the directional keys R13 bans**, which are not exposed at all. Scoped to the node the prop is written on, never a descendant. Outside the cache, after the tint, **before** `style`, which still wins. |
 
 ## API vocabulary
 
@@ -64,13 +64,27 @@ union to the four emphasis levels. That's a subtype, not a different prop.
 - **`color` is the tint, in a raw value** (`'#7c3aed'`), never a token. Where it lands
   follows the variant: background for `primary`, label for `ghost`, border + label for
   `tertiary`. Resolved by `theme/derive-tint.ts`, outside the style cache.
-- **Spacing and placement are props (R14).** A closed set of shorthands whose value is a
-  **step on the spacing scale**, never a pixel — `<Button p={4} mt={2}>` is
-  `spacing(4)` / `spacing(2)`. `p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`.
-  **`ps`/`pe`, never `pl`/`pr`** — R13 applies here most of all, because a shorthand API is
-  where the mistake is easiest. They colour nothing, resolve **outside the cache** (after
-  the tint, before `style`), and `style` still wins. Adding a shorthand is a plan decision
-  — see §2 ter. *Specified, not built: P2.6.*
+- **A component's style is editable in props (R14).** Full RN names, full RN values:
+
+  ```tsx
+  <Button padding={16} width="100%" backgroundColor="#111">Envoyer</Button>
+  <Button.Label fontSize={18} letterSpacing={1}>Envoyer</Button.Label>
+  ```
+
+  No abbreviations — `padding`, not `p`. And therefore no hidden scale: `padding={16}` is
+  16 points, exactly as `style` would be. A prop carrying the RN key's name and silently
+  multiplying its value is the most expensive trap the API could set. Reach for the scale
+  explicitly: `padding={t.spacing(4)}`.
+
+  The set is not a list but a type — the node's style type minus the directional keys R13
+  bans, which are **not exposed at all**, because a prop API is exactly where someone
+  writes `paddingLeft` without thinking.
+
+  They are scoped to the node the prop is written on, never a descendant (R1) — that is
+  what separates them from `customAppearance`. They resolve **outside the cache** (after
+  the tint, before `style`), and `style` still wins, for `transform` and anything typed
+  loosely. `color` keeps its R7 meaning on a root and is `TextStyle.color` on a text slot;
+  those coincide rather than conflict. *Specified, not built: P2.6.*
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.agents/skills/xaui-review/SKILL.md
+++ b/.agents/skills/xaui-review/SKILL.md
@@ -37,10 +37,10 @@ files edited by hand — these are the ones that are unfixable or expensive late
       slot**; no `startContent` / `endContent`.
 - [ ] **R5** — context carries resolved style IDs, memoized; no slot re-resolves the
       recipe.
-- [ ] **R6** — props take tokens only; arbitrary numbers are a type error. Two exceptions,
-      both outside the cache: `color`, and the style props of R14.
-- [ ] **R7** — only `variant` and `color`. No `background`, no `borderColor`, no third
-      appearance prop. R14 is not one: it places a component, it does not colour it.
+- [ ] **R6** — the **vocabulary** props take tokens only; `size={42}` is a type error. Raw
+      values go the other path: `color` and R14, both outside the cache.
+- [ ] **R7** — only `variant` and `color` in the vocabulary. R14's style props are raw
+      overrides, the same category as `style` — flag one used where a `variant` would do.
 - [ ] **R8** — `isX` / `hasX`; `disabled` is not public.
 - [ ] **R9** *(blocking)* — root forwards `ref`, `style` **including `Pressable`'s function
       form**, `testID`, a11y props; `accessibilityRole` defaults but stays overridable.
@@ -52,9 +52,12 @@ files edited by hand — these are the ones that are unfixable or expensive late
       compose the caller's `onPressIn` / `onPressOut` rather than replacing them.
 - [ ] **R13** — no `left` / `right` / `paddingLeft` … anywhere in `src/`; RTL-safe
       `start` / `end` forms only.
-- [ ] **R14** — spacing and placement are props: `p px py pt pb ps pe`, `m mx my mt mb ms
-      me`, `gap`. Values are **steps on the spacing scale**, never pixels. Outside the
-      cache, after the tint, before the slot's `style`.
+- [ ] **R14** — style props carry **full RN names and RN values**: `padding={16}` is 16
+      points. An abbreviation (`p`, `bg`) or a hidden scale is the defect.
+- [ ] The set comes from the node's **style type**, not a hand-written list, and the
+      directional keys R13 bans are **not exposed** — no `paddingLeft` prop can be written.
+- [ ] A style prop styles **its own node**, never a descendant (R1).
+- [ ] A component's own prop wins over a style prop of the same name, and the type says so.
 
 ## 2. API vocabulary
 
@@ -64,13 +67,6 @@ files edited by hand — these are the ones that are unfixable or expensive late
 - [ ] `size` sets height / horizontal padding / gap / radius, **never width**. Fixed
       `height`, not `minHeight`. No `fullWidth` prop.
 - [ ] `color` is a raw value, never a token, and lands where the variant says.
-- [ ] **Style props (R14) are the closed set and nothing more** — no `pl` / `pr` (R13), no
-      colour, no border, no typography. A new shorthand is a plan decision, not a
-      component's.
-- [ ] Their values are **spacing steps**, resolved through `theme.spacing()`. A raw pixel in
-      one is the bug this API exists to prevent.
-- [ ] They resolve **outside the cache**, after the tint and before the slot's `style`.
-      Anything that puts them in the cache key grows the table with caller values.
 - [ ] Anything else that wanted a prop goes through `style`.
 
 ## 3. Style engine and performance

--- a/.agents/skills/xaui-system/SKILL.md
+++ b/.agents/skills/xaui-system/SKILL.md
@@ -160,19 +160,30 @@ Zero runtime dependencies in the package.
 Spacing and placement are props rather than an object, and the resolver is shared:
 
 ```tsx
-<Button p={4} mt={2}>Envoyer</Button>
+<Button padding={16} width="100%">Envoyer</Button>
+<Button.Label fontSize={18}>Envoyer</Button.Label>
 ```
 
-`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. A closed set — no colour, no border,
-no typography, and **`ps`/`pe` rather than `pl`/`pr`**, because a shorthand API is exactly
-where R13 gets broken. The value is a **step on the spacing scale**: `p={4}` is
-`spacing(4)`, so changing `spacingUnit` redraws what callers wrote too.
+The set is the node's style type — `ViewStyle`, `TextStyle` on a text slot — **minus the
+directional keys R13 bans**, which are not exposed at all:
+
+```ts
+type StyleProps = Omit<ViewStyle, DirectionalStyleKey>
+```
+
+Full RN names and **full RN values**: `padding={16}` is 16 points, exactly as `style` would
+be. No abbreviations, and above all no hidden scale — a prop carrying the RN key's name and
+multiplying its value would be the most expensive trap in the API, the kind you only catch
+by measuring on screen. The scale stays explicit: `padding={t.spacing(4)}`.
+
+A style prop styles **its own node**, never a descendant (R1), which is what separates it
+from `customAppearance`.
 
 Two pieces, and the split is the point:
 
 ```ts
-resolveStyleProps(props, spacing)   // utils/ — pure, mirrored test
-useStyleProps(props)                // system/style-props/ — splits shorthands from the rest
+splitStyleProps(props) // utils/ — pure, mirrored test; splits, transforms nothing
+useStyleProps(props) // system/style-props/ — the same, memoized on the values
 ```
 
 It resolves **outside the style cache**, in the same second pass as the tint, and lands

--- a/.claude/skills/xaui-component/SKILL.md
+++ b/.claude/skills/xaui-component/SKILL.md
@@ -21,15 +21,15 @@ Source of truth: `.project-specs/XAUI-V1-PLAN.md` §1 (rules), §1 bis (API voca
 | R3 | Text children are auto-wrapped through `childrenToString` (recursive stringify, returns `null` if any React element is present). |
 | R4 | Layout belongs to the root (`gap`, `alignItems`, `flexDirection`). Slots have **no margin of their own**. No `startContent` / `endContent` — JSX order is screen order. |
 | R5 | Context carries **resolved** values (style IDs), never raw props. Slots re-resolve nothing. Memoized. |
-| R6 | Tokens in props, arbitrary values in `style`. `size="md"` yes, `size={42}` is a type error. Two exceptions, both **outside the cache**: `color`, and the style props of R14. |
-| R7 | Two appearance props only: `variant` and `color`. No `background`, no `borderColor` — those go through `style`, or R14, which colours nothing. |
+| R6 | Tokens in the **vocabulary** props: `size="md"` yes, `size={42}` is a type error. Raw values have their own path, outside the cache: `color` and the style props of R14. |
+| R7 | Two appearance props in the **vocabulary**: `variant` and `color`. R14's `backgroundColor` / `borderColor` are not vocabulary — they are raw overrides, the same category as `style`. Seeing one where a `variant` would do still means the design system is being bypassed. |
 | R8 | Booleans are `isX` / `hasX` (`isDisabled`, `isLoading`, `hasError`). `disabled` is never public; forward it internally to `Pressable`. |
 | R9 | Every root forwards `ref`, `style` (including `Pressable`'s function form), `testID` and a11y props. `accessibilityRole` has a default but stays overridable. **Unfixable after 1.0.** |
 | R10 | Every compound exports its context hook: `export { useButton }`. |
 | R11 | `displayName` is namespaced: `'XAUI.Button.Root'`, `'XAUI.Button.Label'`. |
 | R12 | `asChild` on every root, via `mergeProps` + `mergeRefs` from `system/slot/`. |
 | R13 | No `left` / `right` in any style. Use `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. An ESLint rule enforces it in `src/`. |
-| R14 | Spacing and placement are **props, not an object**: `p px py pt pb ps pe`, `m mx my mt mb ms me`, `gap`. The value is a **step on the spacing scale**, never a pixel — `p={4}` is `spacing(4)`. Resolved outside the cache, after the tint and **before** the slot's `style`, which still wins. |
+| R14 | A component's style is editable **in props**: `padding={16}`, `width="100%"`, `backgroundColor="#111"`. **Full RN names and RN values** — no abbreviations, no hidden scale (`padding={t.spacing(4)}` when you want the scale). The set is the node's style type (`ViewStyle`, `TextStyle` on a text slot) **minus the directional keys R13 bans**, which are not exposed at all. Scoped to the node the prop is written on, never a descendant. Outside the cache, after the tint, **before** `style`, which still wins. |
 
 ## API vocabulary
 
@@ -64,13 +64,27 @@ union to the four emphasis levels. That's a subtype, not a different prop.
 - **`color` is the tint, in a raw value** (`'#7c3aed'`), never a token. Where it lands
   follows the variant: background for `primary`, label for `ghost`, border + label for
   `tertiary`. Resolved by `theme/derive-tint.ts`, outside the style cache.
-- **Spacing and placement are props (R14).** A closed set of shorthands whose value is a
-  **step on the spacing scale**, never a pixel — `<Button p={4} mt={2}>` is
-  `spacing(4)` / `spacing(2)`. `p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`.
-  **`ps`/`pe`, never `pl`/`pr`** — R13 applies here most of all, because a shorthand API is
-  where the mistake is easiest. They colour nothing, resolve **outside the cache** (after
-  the tint, before `style`), and `style` still wins. Adding a shorthand is a plan decision
-  — see §2 ter. *Specified, not built: P2.6.*
+- **A component's style is editable in props (R14).** Full RN names, full RN values:
+
+  ```tsx
+  <Button padding={16} width="100%" backgroundColor="#111">Envoyer</Button>
+  <Button.Label fontSize={18} letterSpacing={1}>Envoyer</Button.Label>
+  ```
+
+  No abbreviations — `padding`, not `p`. And therefore no hidden scale: `padding={16}` is
+  16 points, exactly as `style` would be. A prop carrying the RN key's name and silently
+  multiplying its value is the most expensive trap the API could set. Reach for the scale
+  explicitly: `padding={t.spacing(4)}`.
+
+  The set is not a list but a type — the node's style type minus the directional keys R13
+  bans, which are **not exposed at all**, because a prop API is exactly where someone
+  writes `paddingLeft` without thinking.
+
+  They are scoped to the node the prop is written on, never a descendant (R1) — that is
+  what separates them from `customAppearance`. They resolve **outside the cache** (after
+  the tint, before `style`), and `style` still wins, for `transform` and anything typed
+  loosely. `color` keeps its R7 meaning on a root and is `TextStyle.color` on a text slot;
+  those coincide rather than conflict. *Specified, not built: P2.6.*
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.claude/skills/xaui-review/SKILL.md
+++ b/.claude/skills/xaui-review/SKILL.md
@@ -37,10 +37,10 @@ files edited by hand — these are the ones that are unfixable or expensive late
       slot**; no `startContent` / `endContent`.
 - [ ] **R5** — context carries resolved style IDs, memoized; no slot re-resolves the
       recipe.
-- [ ] **R6** — props take tokens only; arbitrary numbers are a type error. Two exceptions,
-      both outside the cache: `color`, and the style props of R14.
-- [ ] **R7** — only `variant` and `color`. No `background`, no `borderColor`, no third
-      appearance prop. R14 is not one: it places a component, it does not colour it.
+- [ ] **R6** — the **vocabulary** props take tokens only; `size={42}` is a type error. Raw
+      values go the other path: `color` and R14, both outside the cache.
+- [ ] **R7** — only `variant` and `color` in the vocabulary. R14's style props are raw
+      overrides, the same category as `style` — flag one used where a `variant` would do.
 - [ ] **R8** — `isX` / `hasX`; `disabled` is not public.
 - [ ] **R9** *(blocking)* — root forwards `ref`, `style` **including `Pressable`'s function
       form**, `testID`, a11y props; `accessibilityRole` defaults but stays overridable.
@@ -52,9 +52,12 @@ files edited by hand — these are the ones that are unfixable or expensive late
       compose the caller's `onPressIn` / `onPressOut` rather than replacing them.
 - [ ] **R13** — no `left` / `right` / `paddingLeft` … anywhere in `src/`; RTL-safe
       `start` / `end` forms only.
-- [ ] **R14** — spacing and placement are props: `p px py pt pb ps pe`, `m mx my mt mb ms
-      me`, `gap`. Values are **steps on the spacing scale**, never pixels. Outside the
-      cache, after the tint, before the slot's `style`.
+- [ ] **R14** — style props carry **full RN names and RN values**: `padding={16}` is 16
+      points. An abbreviation (`p`, `bg`) or a hidden scale is the defect.
+- [ ] The set comes from the node's **style type**, not a hand-written list, and the
+      directional keys R13 bans are **not exposed** — no `paddingLeft` prop can be written.
+- [ ] A style prop styles **its own node**, never a descendant (R1).
+- [ ] A component's own prop wins over a style prop of the same name, and the type says so.
 
 ## 2. API vocabulary
 
@@ -64,13 +67,6 @@ files edited by hand — these are the ones that are unfixable or expensive late
 - [ ] `size` sets height / horizontal padding / gap / radius, **never width**. Fixed
       `height`, not `minHeight`. No `fullWidth` prop.
 - [ ] `color` is a raw value, never a token, and lands where the variant says.
-- [ ] **Style props (R14) are the closed set and nothing more** — no `pl` / `pr` (R13), no
-      colour, no border, no typography. A new shorthand is a plan decision, not a
-      component's.
-- [ ] Their values are **spacing steps**, resolved through `theme.spacing()`. A raw pixel in
-      one is the bug this API exists to prevent.
-- [ ] They resolve **outside the cache**, after the tint and before the slot's `style`.
-      Anything that puts them in the cache key grows the table with caller values.
 - [ ] Anything else that wanted a prop goes through `style`.
 
 ## 3. Style engine and performance

--- a/.claude/skills/xaui-system/SKILL.md
+++ b/.claude/skills/xaui-system/SKILL.md
@@ -160,19 +160,30 @@ Zero runtime dependencies in the package.
 Spacing and placement are props rather than an object, and the resolver is shared:
 
 ```tsx
-<Button p={4} mt={2}>Envoyer</Button>
+<Button padding={16} width="100%">Envoyer</Button>
+<Button.Label fontSize={18}>Envoyer</Button.Label>
 ```
 
-`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. A closed set — no colour, no border,
-no typography, and **`ps`/`pe` rather than `pl`/`pr`**, because a shorthand API is exactly
-where R13 gets broken. The value is a **step on the spacing scale**: `p={4}` is
-`spacing(4)`, so changing `spacingUnit` redraws what callers wrote too.
+The set is the node's style type — `ViewStyle`, `TextStyle` on a text slot — **minus the
+directional keys R13 bans**, which are not exposed at all:
+
+```ts
+type StyleProps = Omit<ViewStyle, DirectionalStyleKey>
+```
+
+Full RN names and **full RN values**: `padding={16}` is 16 points, exactly as `style` would
+be. No abbreviations, and above all no hidden scale — a prop carrying the RN key's name and
+multiplying its value would be the most expensive trap in the API, the kind you only catch
+by measuring on screen. The scale stays explicit: `padding={t.spacing(4)}`.
+
+A style prop styles **its own node**, never a descendant (R1), which is what separates it
+from `customAppearance`.
 
 Two pieces, and the split is the point:
 
 ```ts
-resolveStyleProps(props, spacing)   // utils/ — pure, mirrored test
-useStyleProps(props)                // system/style-props/ — splits shorthands from the rest
+splitStyleProps(props) // utils/ — pure, mirrored test; splits, transforms nothing
+useStyleProps(props) // system/style-props/ — the same, memoized on the values
 ```
 
 It resolves **outside the style cache**, in the same second pass as the tint, and lands

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -6,36 +6,36 @@ Task detail lives in `XAUI-V1-PLAN.md`.
 Status is `done` or `todo`, plus `ci`: everything in the repository is done and the
 remaining action belongs to a workflow rather than to a commit.
 
-| Ref   | Task                                                         | Status |
-| ----- | ------------------------------------------------------------ | ------ |
-| P0.1  | Split into `@xaui/native-legacy` and scaffold v1             | done   |
-| P0.2  | Single token source and generator                            | done   |
-| P0.3  | OKLab colour engine                                          | done   |
-| P0.4  | Derived colour layer                                         | done   |
-| P0.5  | Contrast guard in CI                                         | done   |
-| P0.6  | `createTheme`                                                | done   |
-| P0.7  | `XAUIProvider`                                               | done   |
-| P0.8  | Legacy `core-shim.ts`                                        | done   |
-| P0.9  | Package hygiene and optional peers                           | done   |
-| P0.10 | ESLint rule for R13                                          | done   |
-| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod         | done   |
-| P0.12 | Delete `@xaui/core` and `@xaui/icons`                        | done   |
-| P0.13 | Publish `native` and `hybrid` on the `alpha` tag             | done   |
-| P1.1  | `system/recipe/` — engine, cache, tint                       | done   |
-| P1.2  | `system/slot/` — context, `childrenToString`, merges         | done   |
-| P1.3  | `system/pressable-feedback/`                                 | done   |
-| P1.4  | `system/portal/`                                             | done   |
-| P1.5  | `system/icon/`                                               | done   |
-| P1.6  | Shared hooks                                                 | done   |
-| P1.7  | `pnpm pack` uniqueness check on both packages                | done   |
-| P2.1  | The reference `Button`                                       | done   |
-| P2.2  | Perf baseline — 200 buttons, re-renders and allocations      | done   |
-| P2.3  | API review — blocking, nothing starts in P3 before it        | done   |
-| P2.4  | Publish `@xaui/native` on the `alpha` tag                    | ci     |
-| P2.5  | Fix the ripple — it renders nothing (P2-API-REVIEW §D)       | todo   |
-| P2.6  | Style props (R14) — `system/style-props/`, then the `Button` | todo   |
-| P3    | The fifteen-component core                                   | todo   |
-| P4    | Docs, generated tables, `1.0.0`                              | todo   |
-| P5    | The remaining 32 components                                  | todo   |
-| P6    | `@xaui/hybrid` on the v1 API                                 | todo   |
-| P7    | Delete `native-legacy`                                       | todo   |
+| Ref   | Task                                                            | Status |
+| ----- | --------------------------------------------------------------- | ------ |
+| P0.1  | Split into `@xaui/native-legacy` and scaffold v1                | done   |
+| P0.2  | Single token source and generator                               | done   |
+| P0.3  | OKLab colour engine                                             | done   |
+| P0.4  | Derived colour layer                                            | done   |
+| P0.5  | Contrast guard in CI                                            | done   |
+| P0.6  | `createTheme`                                                   | done   |
+| P0.7  | `XAUIProvider`                                                  | done   |
+| P0.8  | Legacy `core-shim.ts`                                           | done   |
+| P0.9  | Package hygiene and optional peers                              | done   |
+| P0.10 | ESLint rule for R13                                             | done   |
+| P0.11 | Publish `@xaui/native-legacy@0.2.11` and the codemod            | done   |
+| P0.12 | Delete `@xaui/core` and `@xaui/icons`                           | done   |
+| P0.13 | Publish `native` and `hybrid` on the `alpha` tag                | done   |
+| P1.1  | `system/recipe/` — engine, cache, tint                          | done   |
+| P1.2  | `system/slot/` — context, `childrenToString`, merges            | done   |
+| P1.3  | `system/pressable-feedback/`                                    | done   |
+| P1.4  | `system/portal/`                                                | done   |
+| P1.5  | `system/icon/`                                                  | done   |
+| P1.6  | Shared hooks                                                    | done   |
+| P1.7  | `pnpm pack` uniqueness check on both packages                   | done   |
+| P2.1  | The reference `Button`                                          | done   |
+| P2.2  | Perf baseline — 200 buttons, re-renders and allocations         | done   |
+| P2.3  | API review — blocking, nothing starts in P3 before it           | done   |
+| P2.4  | Publish `@xaui/native` on the `alpha` tag                       | ci     |
+| P2.5  | Fix the ripple — it renders nothing (P2-API-REVIEW §D)          | todo   |
+| P2.6  | Style as props (R14) — `system/style-props/`, then the `Button` | todo   |
+| P3    | The fifteen-component core                                      | todo   |
+| P4    | Docs, generated tables, `1.0.0`                                 | todo   |
+| P5    | The remaining 32 components                                     | todo   |
+| P6    | `@xaui/hybrid` on the v1 API                                    | todo   |
+| P7    | Delete `native-legacy`                                          | todo   |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -37,10 +37,10 @@ On n'inspecte pas le premier enfant : on tente de **stringifier récursivement**
 Le root résout `variant × size × état` (plus la teinte `color` si fournie) une fois et publie la couleur finale. Les slots ne re-résolvent rien. Valeur memoizée. HeroUI publie les props brutes et laisse chaque slot re-résoudre — c'est gratuit chez eux grâce au cache de `tv()`, ça ne l'est pas sans moteur de classes.
 
 **R6 — Tokens dans les props, valeurs arbitraires dans `style`.**
-`size="md"` passe, `size={42}` est une erreur de type. C'est ce qui permet le cache de styles (§3) — l'ouvrir tue le gain de perf. Deux exceptions, toutes deux **hors du cache** et résolues dans une seconde passe (§3) : `color`, qui porte une teinte brute, et les **props de style** de R14.
+`size="md"` passe, `size={42}` est une erreur de type. C'est ce qui permet le cache de styles (§3) — l'ouvrir tue le gain de perf. La règle porte sur le **vocabulaire** : `variant`, `size`, `radius`. Les valeurs brutes ont leur propre chemin, **hors du cache** et résolu dans une seconde passe (§3) : `color` et les **props de style** de R14.
 
 **R7 — Deux props d'apparence, pas trois.**
-`variant` = apparence sanctionnée par le design system. `color` = une teinte brute qui remplace celle du variant. Il n'existe **aucune** autre prop de couleur — pas de `background`, pas de `borderColor` ; ces cas passent par `style` ou par les props de style de R14, qui ne sont pas des props d'apparence : elles ne décident ni d'une intention ni d'une emphase, elles placent le composant.
+`variant` = apparence sanctionnée par le design system. `color` = une teinte brute qui remplace celle du variant. Ce sont les deux seules props du **vocabulaire** : rien d'autre ne décrit une intention ou une emphase. Les props de style de R14 — `backgroundColor`, `borderColor` — ne sont pas de ce vocabulaire, ce sont des surcharges brutes, la même catégorie que `style`. Une revue qui voit `backgroundColor` là où `variant` suffisait signale la même chose qu'avant ; ce qui change, c'est que le contournement est court et lisible au lieu d'être un objet.
 
 **R8 — Booléens en `isX` / `hasX`.**
 `isDisabled`, `isLoading`, `hasError`. `disabled` n'est jamais public ; il est forwardé en interne au `Pressable`.
@@ -61,21 +61,23 @@ Fusionner les props dans l'enfant au lieu de rendre son propre élément — c'e
 **R13 — Aucun `left` / `right` dans un style.**
 `paddingStart` / `paddingEnd`, `marginStart` / `marginEnd`, `start` / `end`. RN gère le RTL tout seul avec ces propriétés et pas avec les autres. Écrire `paddingLeft` coûte zéro aujourd'hui et un audit complet le jour où quelqu'un ouvre l'app en arabe. Une règle ESLint interdit les formes directionnelles dans `src/`.
 
-**R14 — L'espacement et le placement sont des props, pas un objet.**
-Le cas courant — desserrer un bouton, le pousser d'un cran — ne doit pas demander d'ouvrir un objet `style` :
+**R14 — Le style d'un composant se modifie en props.**
+Desserrer un contrôle, lui donner une largeur, changer un fond ne doit pas demander d'ouvrir un objet :
 
 ```tsx
-<Button p={4} mt={2}>Envoyer</Button>          // au lieu de style={{ padding: 16, marginTop: 8 }}
-<Button px={3} gap={1} color="#7c3aed">…</Button>
+<Button padding={16} marginTop={8}>Envoyer</Button>
+<Button width="100%" backgroundColor="#111">…</Button>
 ```
 
-Un **jeu fermé de raccourcis**, dont la valeur est un **pas sur l'échelle d'espacement**, jamais un pixel : `p={4}` vaut `spacing(4)`, soit 16 sur la base 4. C'est ce qui les garde dans le vocabulaire du design system au lieu d'en faire une échappatoire de plus.
+**Le nom est celui de la propriété RN, en entier** — `padding`, pas `p` ; `backgroundColor`, pas `bg`. Et donc **la valeur est celle de RN aussi** : `padding={16}` vaut 16 points. Une prop qui porte le nom exact de la clé et en multiplierait la valeur par une échelle serait le piège le plus coûteux de l'API. L'échelle reste explicite : `padding={t.spacing(4)}`.
 
-Trois choses les rendent compatibles avec tout le reste :
+Le jeu n'est pas une liste mais un type : **les clés de style du nœud du composant** — `ViewStyle`, `TextStyle` sur un slot texte — **moins les formes directionnelles que R13 interdit**, qui ne sont pas exposées du tout.
 
-- **Elles ne colorent rien.** Pas de `bg`, pas de `borderColor` — R7 tient. Une prop de style place le composant ; elle ne décide pas de son apparence.
-- **Elles sont hors du cache**, résolues dans la même seconde passe que `color` (§3). Le nombre de combinaisons de tokens reste fini ; la table ne grandit pas avec les valeurs que les gens écrivent.
-- **Elles perdent contre `style`.** L'ordre est : recette → teinte → props de style → `style` du slot. Le plus spécifique gagne, et `style` reste l'échappatoire finale.
+Trois choses les gardent compatibles avec le reste :
+
+- **La portée s'arrête au nœud sur lequel la prop est écrite.** Jamais un descendant : R1 tient, et c'est ce qui les sépare de `customAppearance`.
+- **Elles sont hors du cache**, résolues dans la même seconde passe que `color` (§3). Le nombre de combinaisons de tokens reste fini.
+- **Elles perdent contre `style`**, qui reste l'échappatoire finale pour ce qui n'a pas de prop lisible — `transform`, une ombre par plateforme, un objet calculé.
 
 Le détail du jeu et de sa résolution est au §2 ter.
 
@@ -150,7 +152,7 @@ Conséquence, en React Native : `alignItems` vaut `stretch` par défaut, donc **
 **Trois décisions pour XAUI :**
 
 1. **Aucune largeur dans le recipe.** Le comportement par défaut est celui de RN, pas une invention de la lib.
-2. **`fullWidth` est supprimé.** Dans le code actuel il ajoute `width: '100%'` — quasiment sans effet en `Column` (le bouton y est _déjà_ pleine largeur) et utile seulement en `Row`. Une prop dont le nom décrit le comportement par défaut est un piège. Pour resserrer un bouton, on compose : `<Row><Button/></Row>`, ou `style={{ alignSelf: 'flex-start' }}`.
+2. **`fullWidth` est supprimé.** Dans le code actuel il ajoute `width: '100%'` — quasiment sans effet en `Column` (le bouton y est _déjà_ pleine largeur) et utile seulement en `Row`. Une prop dont le nom décrit le comportement par défaut est un piège. Pour resserrer un bouton, on compose : `<Row><Button/></Row>`, ou `style={{ alignSelf: 'flex-start' }}`. Et le cas où la largeur _est_ voulue s'écrit maintenant `width="100%"` (R14), explicitement, plutôt que par une prop qui prétend décrire un comportement.
 3. **`height` fixe, pas `minHeight`.** Le code actuel utilise `minHeight`, ce qui laisse un bouton grandir si son label passe à la ligne. Un contrôle a une hauteur, pas une hauteur minimale ; un label trop long doit être tronqué, pas déformer le bouton.
 
 Corollaire : `isIconOnly` n'a pas besoin de calcul de largeur — `padding: 0` + `aspectRatio: 1` sur une hauteur fixe donne un carré.
@@ -458,46 +460,98 @@ Conséquence sur le code existant : **45 fichiers utilisent encore l'`Animated` 
 ## 2 ter. Les props de style
 
 R14 en détail. Le problème qu'elles règlent est banal et permanent : desserrer un contrôle,
-le pousser d'un cran, resserrer un `gap`. Aujourd'hui chacun de ces cas oblige à ouvrir un
-objet `style`, ce qui est disproportionné pour un nombre.
+lui donner une largeur, changer un fond. Chacun de ces cas oblige aujourd'hui à ouvrir un
+objet `style`, ce qui est disproportionné pour une valeur.
 
 ```tsx
-<Button p={4}>Envoyer</Button>
-<Button px={3} mt={2} gap={1}>…</Button>
-<Row p={4} gap={2}>…</Row>
+<Button padding={16} marginTop={8}>Envoyer</Button>
+<Button width="100%" borderRadius={12}>…</Button>
+<Card backgroundColor="#111" borderColor="#333">…</Card>
 ```
 
-### Le jeu, fermé
+### Le nom est celui de la propriété RN, en entier
 
-Espacement et placement uniquement. Pas de couleur, pas de bordure, pas de typographie —
-celles-là restent dans `variant`, `color` ou `style`.
+Pas d'abréviations. `padding`, pas `p` ; `marginTop`, pas `mt` ; `backgroundColor`, pas
+`bg`. Ce sont des props, elles se lisent au point d'appel, et une API de raccourcis oblige
+à apprendre une table de correspondance pour rien.
 
-| Prop  | Style RN            | Prop | Style RN           |
-| ----- | ------------------- | ---- | ------------------ |
-| `p`   | `padding`           | `m`  | `margin`           |
-| `px`  | `paddingHorizontal` | `mx` | `marginHorizontal` |
-| `py`  | `paddingVertical`   | `my` | `marginVertical`   |
-| `pt`  | `paddingTop`        | `mt` | `marginTop`        |
-| `pb`  | `paddingBottom`     | `mb` | `marginBottom`     |
-| `ps`  | `paddingStart`      | `ms` | `marginStart`      |
-| `pe`  | `paddingEnd`        | `me` | `marginEnd`        |
-| `gap` | `gap`               |      |                    |
+**La contrepartie est que la valeur doit être celle de RN aussi.** `padding={16}` vaut 16
+points, comme `style={{ padding: 16 }}`. Une prop qui porte le nom exact de la clé RN et en
+multiplie silencieusement la valeur par une échelle serait le piège le plus coûteux de
+toute l'API — celui qu'on ne voit qu'en mesurant à l'écran.
 
-**`ps` / `pe` et `ms` / `me`, jamais `pl` / `pr`** — R13 vaut ici comme ailleurs, et c'est
-précisément une API de raccourcis qui rendrait la faute facile.
+L'échelle reste accessible, explicitement :
 
-Le jeu s'arrête là **pour la 1.0**. `w`, `h`, `flex`, `alignSelf` sont des candidats
-crédibles ; ils attendent qu'un composant du noyau les demande deux fois, comme tout le
-reste (§2 bis).
+```tsx
+const t = useXAUITheme()
+<Button padding={t.spacing(4)} borderRadius={t.radius.lg}>…</Button>
+```
 
-### La valeur est un pas, pas un pixel
+C'est un mot de plus et zéro ambiguïté. Le design system continue de vivre dans `variant`,
+`size` et les tokens ; les props de style sont l'échappatoire courte, pas le vocabulaire.
 
-`p={4}` vaut `spacing(4)`, soit 16 sur la base 4. C'est ce qui garde ces props dans le
-vocabulaire du design system : changer `spacingUnit` dans le thème redessine tout, y
-compris ce que les appelants ont écrit.
+### Le jeu est le type de style, moins ce que R13 interdit
 
-Les demi-pas passent — `px={3.5}` vaut 14, comme dans la recette du `Button`. Une valeur
-en pixels bruts n'a pas de raccourci : c'est `style`.
+Il n'y a pas de liste à maintenir. Un composant expose **les clés de style de son propre
+nœud** :
+
+- un root ou un slot vue : `ViewStyle`
+- un slot texte : `TextStyle` (donc `color`, `fontSize`, `fontWeight`, `letterSpacing`…)
+- un slot image : `ImageStyle`
+
+**Moins les formes directionnelles que R13 interdit** — `left`, `right`, `paddingLeft`,
+`paddingRight`, `marginLeft`, `marginRight`, `borderLeftWidth`, `borderRightColor`,
+`borderTopLeftRadius`… Elles ne sont pas exposées du tout : `paddingStart` / `paddingEnd`,
+`start` / `end`, `borderStartWidth`. Une API de props est exactement l'endroit où quelqu'un
+écrirait `paddingLeft` sans y penser, donc le type le rend impossible plutôt que de compter
+sur une revue.
+
+```ts
+type StyleProps = Omit<ViewStyle, DirectionalStyleKey>
+```
+
+### La portée s'arrête au nœud du composant
+
+Une prop de style stylise **la boîte du composant sur lequel elle est écrite**, jamais
+celle d'un descendant — R1 tient exactement comme avant. Chaque slot porte les siennes,
+comme il porte déjà son `style` (R2) :
+
+```tsx
+<Button padding={20}>
+  <Button.Label fontSize={18} letterSpacing={1}>
+    Envoyer
+  </Button.Label>
+</Button>
+```
+
+C'est ce qui les distingue de l'ancien `customAppearance`, qui atteignait l'intérieur d'un
+composant depuis l'extérieur : ici l'endroit où on écrit la prop est l'endroit où elle
+s'applique.
+
+### `color` garde son sens, et ce n'est pas une exception
+
+Sur un **root**, `color` est la teinte de R7 : une valeur brute que le variant place — fond
+pour `primary`, label pour `ghost`, bordure pour `tertiary` (§1 bis).
+
+Sur un **slot texte**, `color` est le `color` de `TextStyle`. Les deux coïncident au lieu de
+se contredire : §1 bis dit déjà que dans un composant texte il n'y a qu'une chose à teinter.
+
+Le fond brut d'un root n'est donc pas `color` mais `backgroundColor`, qui dit ce qu'il fait.
+
+### Ce que R7 devient
+
+R7 ne disparaît pas, elle se précise. Il y a deux **vocabulaires**, et un seul est le
+design system :
+
+|                            | Rôle                                                           | Exemple                      |
+| -------------------------- | -------------------------------------------------------------- | ---------------------------- |
+| `variant`, `color`, `size` | Le vocabulaire sanctionné. Ce qu'on écrit d'habitude           | `variant="danger" size="lg"` |
+| Props de style             | Des surcharges brutes, la même catégorie que `style`           | `backgroundColor="#111"`     |
+| `style`                    | Le reste : transformations, ombres, tout ce qui est typé large | `style={{ transform: […] }}` |
+
+Une revue qui voit `backgroundColor="#7c3aed"` là où `variant="primary"` suffisait signale
+la même chose qu'avant : le design system est contourné. Ce qui change, c'est que le
+contournement est court à écrire et lisible, au lieu d'être un objet.
 
 ### Où elles se résolvent
 
@@ -511,8 +565,24 @@ L'ordre complet, du plus général au plus spécifique :
 base → paint → variants → compoundVariants → states → teinte → props de style → style du slot
 ```
 
-`style` gagne en dernier. Une prop de style est un raccourci, pas une autorité : quand les
-deux disent quelque chose du même champ, c'est la forme explicite qui l'emporte.
+`style` gagne en dernier, et reste l'échappatoire finale pour ce qui n'a pas de prop
+lisible : `transform`, une ombre plateforme par plateforme, un objet calculé.
+
+### Les props du composant l'emportent
+
+`size` est une prop du `Button`, pas `width`. Quand un nom de prop de composant existe déjà,
+c'est lui qui gagne, et le type l'exprime : la prop de style du même nom n'est pas exposée.
+La liste par composant vit dans son `.type.ts`, donc un conflit est une erreur de
+compilation et non une surprise à l'écran.
+
+Deux cas valent d'être notés :
+
+- **`height` bat la hauteur que `size` a choisie**, puisque les props de style se résolvent
+  après la recette. C'est une échappatoire, pas le chemin normal : un contrôle dont on
+  redresse la hauteur à la main est en général un contrôle dont la taille manque à
+  l'échelle.
+- **`width="100%"` remplace l'ancien `fullWidth`** (§1 bis), dit explicitement plutôt que
+  par une prop dont le nom décrit le comportement par défaut.
 
 ### Où le code vit
 
@@ -523,23 +593,27 @@ en a besoin pour offrir la même API.
 Deux fonctions, l'une pure et testée, l'autre triviale :
 
 ```ts
-// utils/, pur, testé : le jeu fermé → un objet de style
-resolveStyleProps(props, spacing) // { p: 4, mt: 2 } → { padding: 16, marginTop: 8 }
+// utils/, pur, testé : sépare les clés de style du reste, sans rien transformer
+splitStyleProps(props) // { padding: 16, onPress } → [{ padding: 16 }, { onPress }]
 
-// system/style-props/, React : sépare les raccourcis du reste des props d'un composant
+// system/style-props/, React : la même chose, memoizée sur les valeurs
 const [styleProps, rest] = useStyleProps(props)
 ```
 
-Le root applique `styleProps` entre la teinte et son `style`, et forwarde `rest`. Les slots
-les acceptent aussi — R2 dit que chaque slot porte son propre `style`, et un raccourci est
-la même chose en plus court.
+Le root applique `styleProps` entre la teinte et son `style`, et forwarde `rest`.
 
 ### Ce que ça coûte
 
-Une allocation d'objet par rendu, sur les composants dont l'appelant a écrit au moins une
-de ces props. C'est le même arbitrage que `color`, et il est mesuré au §9 bis : la ligne de
-base doit rester vraie pour un composant sans prop de style, et gagner une ligne pour un
-composant qui en porte.
+Deux choses, et aucune n'est gratuite :
+
+- **Une allocation d'objet par rendu**, sur les composants dont l'appelant a écrit au moins
+  une prop de style. Même arbitrage que `color`, et §9 bis doit gagner une ligne : la ligne
+  de base reste vraie pour un composant sans prop de style, et une seconde la mesure avec.
+- **Une surface de props large.** C'est le prix du choix, et il est assumé : le type dérive
+  de `ViewStyle` au lieu d'être écrit à la main, donc il ne dérive pas dans le temps ; mais
+  l'autocomplétion d'un composant montre désormais des dizaines d'entrées, et la
+  documentation générée (§6) doit séparer les props du composant des props de style plutôt
+  que de les lister ensemble.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,11 @@ Source of truth in `.agents/skills/<name>/SKILL.md`, copied — never symlinked 
 - **Composition, not configuration** — a `forwardRef` root plus dot-notation slots,
   `asChild` on every root, an exported context hook per compound, namespaced `displayName`.
 - **Two appearance props** — `variant` (ten sanctioned values) and `color` (a raw tint) —
-  plus a closed set of **style props** for spacing and placement (`p`, `px`, `mt`, `gap`…)
-  whose values are steps on the spacing scale. Everything else goes through the slot's own
-  `style`, which always wins.
+  as the design-system **vocabulary**, plus **style props** for raw overrides:
+  `padding={16}`, `width="100%"`, `backgroundColor="#111"`. Full RN names and RN values, no
+  abbreviations and no hidden scale; the set is the node's style type minus the directional
+  keys R13 bans. Scoped to the node the prop is written on. `style` is still the last word,
+  for `transform` and anything typed loosely.
 - **A recipe engine with a style cache** — variants name tokens, styles resolve once at the
   root, slots receive stable `StyleSheet` references.
 - **A two-layer theme** — a hand-written source layer, ~32 tokens derived from it in OKLab.

--- a/packages/native/src/components/button/button.md
+++ b/packages/native/src/components/button/button.md
@@ -116,7 +116,8 @@ yours.
 
 `size` drives **height, padding, gap, radius and type — never width**. A button with no
 width fills its parent in a column and hugs its content in a row, which is React Native's
-own behaviour. There is no `fullWidth` prop; to tighten one, compose:
+own behaviour. There is no `fullWidth` prop — once R14 lands the deliberate case is
+`width="100%"`, said explicitly. To tighten one, compose:
 
 ```tsx
 <Row>
@@ -172,23 +173,49 @@ in OKLab, so a free tint behaves exactly like `accent` — same ratios, same ren
 deliberately outside the style cache: letting arbitrary values into the key would grow the
 table with the colours people invent instead of with the finite combinations of tokens.
 
-### Spacing and placement — coming as props
+### Style as props — coming
 
 > **Not built yet.** R14 and §2 ter of the plan specify it; it is **P2.6** in the roadmap.
-> Until it lands, spacing goes through `style`.
+> Until it lands, everything below goes through `style`.
 
-The common case — loosen a button, push it down a notch — will not require opening a
-`style` object:
+Loosening a button, giving it a width, changing a fill will not require opening an object:
 
 ```tsx
-<Button p={4} mt={2}>Envoyer</Button>
-<Button px={3} gap={1}>…</Button>
+<Button padding={16} marginTop={8}>Envoyer</Button>
+<Button width="100%" backgroundColor="#111">…</Button>
+
+<Button>
+  <Button.Label fontSize={18} letterSpacing={1}>Envoyer</Button.Label>
+</Button>
 ```
 
-`p px py pt pb ps pe` · `m mx my mt mb ms me` · `gap`. The value is a **step on the spacing
-scale**, never a pixel: `p={4}` is `spacing(4)`, so a change to `spacingUnit` in the theme
-redraws what callers wrote too. They colour nothing, they resolve outside the style cache,
-and the slot's own `style` still wins over them.
+**Full React Native names, and therefore full React Native values.** `padding` rather than
+`p`; `padding={16}` is 16 points, exactly as `style` would be. A prop carrying the RN key's
+name while silently multiplying its value by a scale would be the most expensive trap in
+the API. The scale stays one word away:
+
+```tsx
+const t = useXAUITheme()
+<Button padding={t.spacing(4)} borderRadius={t.radius.lg}>…</Button>
+```
+
+The set is not a list but a type — the node's style keys (`ViewStyle` on the root,
+`TextStyle` on `Button.Label`) **minus the directional forms R13 bans**, which are not
+exposed at all: `paddingStart`, never `paddingLeft`.
+
+Each one styles **the node it is written on**, never a descendant — which is what separates
+this from the legacy `customAppearance`. `width="100%"` is what replaces `fullWidth`, said
+explicitly, and `height` beats the height `size` chose, because style props resolve after
+the recipe. That is an escape hatch, not the normal path: a control whose height you
+straighten by hand is usually one whose size is missing from the scale.
+
+`color` keeps its meaning here — the tint the variant places (above) on the root, and
+`TextStyle`'s `color` on `Button.Label`. Those coincide rather than conflict: in a text
+component there is only one thing to tint. A raw fill on the root is `backgroundColor`,
+which says what it does.
+
+They resolve outside the style cache, and the slot's own `style` still wins — it stays the
+last word for `transform`, a per-platform shadow, or a computed object.
 
 ### Everything else goes through `style`
 

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -14,7 +14,7 @@ re-exported from `utils/`.
 
 - A primitive a component author needs and cannot reasonably write themselves: the style
   engine, slot plumbing, touch feedback, the portal, the icon, and — specified but **not
-  built yet**, see P2.6 — the style-prop resolver of R14.
+  built yet**, see P2.6 — the style-prop splitter of R14.
 - Nothing component-specific. If only `Button` needs it, it lives in `components/button/`
   until a second component asks for it (§2 bis).
 - The exported surface is deliberate: an internal that `createRecipe` happens to use is


### PR DESCRIPTION
Stacked on #186, which it supersedes in substance — merge both, or squash them.
Specification only; the implementation is **P2.6**.

## What

R14 is no longer a shorthand API. A component's style is editable in props, with the
**React Native key spelled out** and the **React Native value**:

```tsx
<Button padding={16} marginTop={8}>Envoyer</Button>
<Button width="100%" backgroundColor="#111">…</Button>

<Button>
  <Button.Label fontSize={18} letterSpacing={1}>Envoyer</Button.Label>
</Button>
```

The set is not a list somebody maintains — it is the node's style type:

```ts
type StyleProps = Omit<ViewStyle, DirectionalStyleKey>
```

## Why the naming decides the semantics

This is the load-bearing change, and it reverses what #186 said.

#186 had `p={4}` resolve to `spacing(4)` = 16, and argued a number should *always* be a
scale step so the API carries one convention. That argument holds **only while the prop has
a different name from the style key**. The moment it is called `padding`, a caller reads
`padding={16}` as sixteen points, because that is what `style={{ padding: 16 }}` means
three lines away. A prop that carries the RN key's name and silently multiplies its value
is wrong *only on screen* — the worst place to be wrong.

So: full names, full values. The scale stays one word away and explicit:

```tsx
<Button padding={t.spacing(4)} borderRadius={t.radius.lg}>…</Button>
```

The design system keeps living in `variant`, `size` and the tokens. Style props are the
short escape hatch, not the vocabulary.

## What R7 had to absorb

Colours are in scope now, and R7 said there were two appearance props and no more. It does
not disappear; it separates **vocabulary** from **overrides**:

| | Role |
| --- | --- |
| `variant`, `color`, `size` | The sanctioned vocabulary. What you normally write |
| Style props | Raw overrides — same category as `style` |
| `style` | The rest: `transform`, per-platform shadows, computed objects |

A review that sees `backgroundColor="#7c3aed"` where `variant="primary"` would do flags
exactly what it flagged before. What changed is that the bypass is now short and readable
instead of an object.

`color` needs no exception: on a root it is still R7's tint, placed by the variant; on a
text slot it is `TextStyle.color`. §1 bis already argues there is only one thing to tint in
a text component, so the two coincide rather than collide. A raw fill on a root is
`backgroundColor`, which says what it does.

## The other three decisions

- **R13 is enforced by omission.** The directional keys are not exposed at all — there is
  no `paddingLeft` prop to write. A prop API is exactly where someone writes it without
  thinking, so the type forbids it rather than a review catching it.
- **Scope is the node the prop sits on**, never a descendant. That keeps R1 and is what
  separates this from the legacy `customAppearance`, which reached inside from outside.
- **Order is unchanged**: recipe → tint → style props → `style`. Outside the cache, so R6's
  reason for existing survives; `style` still wins.

Two consequences worth naming rather than discovering: `height` beats the height `size`
chose (an escape hatch, not the path), and `width="100%"` is what replaces `fullWidth`,
said explicitly.

## Cost, stated in the plan

- One object allocation per render on components whose caller used a style prop. §9 bis
  gains a second line when P2.6 lands.
- A wide prop surface. The type derives from `ViewStyle` so it cannot drift, but
  autocomplete now shows dozens of entries and the generated prop tables (§6) have to
  separate component props from style props instead of listing them together.

## How

`XAUI-V1-PLAN.md` §2 ter rewritten, R6/R7/R14 amended · `AGENTS.md` · `xaui-component`
(rule row + vocabulary) · `xaui-review` (R14 and four checks: RN names and values, the set
comes from the type, own-node scope, component props win) · `xaui-system` (`splitStyleProps`
/ `useStyleProps`) · `button.md` · `ROADMAP.md`.

```
pnpm turbo run lint --filter=docs --filter=@xaui/*   6 successful
pnpm type-check                                      5 successful
pnpm test                                            8 successful
pnpm perf:button                                     7 passed
```

Both skill copies byte-identical. Edits applied by hand, no prettier reflow of the skills.
No changeset: nothing in a published package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
