### PR TITLE
feat(demo): bring back the PressableFeedback screen

### DIFF
--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -22,6 +22,10 @@ export default function RootLayout() {
         <PortalHost>
           <Stack>
             <Stack.Screen name="index" options={{ title: 'Button (v1)' }} />
+            <Stack.Screen
+              name="pressable-feedback"
+              options={{ title: 'PressableFeedback (v1)' }}
+            />
           </Stack>
         </PortalHost>
       </XAUIProvider>

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
 import Svg, { Path } from 'react-native-svg'
 import { Button } from '@xaui/native/button'
 import type { ButtonVariant } from '@xaui/native/button'
@@ -36,6 +37,8 @@ export default function ButtonScreen() {
       style={{ backgroundColor: theme.colors.background }}
       contentContainerStyle={{ padding: 16, gap: 28, paddingBottom: 64 }}
     >
+      <OtherScreens />
+
       <Section
         title="The ten variants"
         note="Emphasis and intention in one flat union. Each names tokens; none computes a colour."
@@ -275,5 +278,23 @@ function TrashIcon({ size, color }: IconComponentProps) {
         strokeLinecap="round"
       />
     </Svg>
+  )
+}
+
+/**
+ * The other v1 verification screens. The demo is one screen per primitive, and each one is
+ * how that primitive is verified — there is no test file for any of them.
+ */
+function OtherScreens() {
+  const router = useRouter()
+
+  return (
+    <Button
+      variant="tertiary"
+      size="sm"
+      onPress={() => router.push('/pressable-feedback')}
+    >
+      PressableFeedback →
+    </Button>
   )
 }

--- a/apps/demo/app/pressable-feedback.tsx
+++ b/apps/demo/app/pressable-feedback.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react'
+import { ScrollView, Text, View } from 'react-native'
+import { PressableFeedback } from '@xaui/native/system'
+import type { AnimationProp, FeedbackVariant } from '@xaui/native/system'
+import { useXAUITheme } from '@xaui/native/theme'
+
+/**
+ * The verification screen for P1.3. `PressableFeedback` is controlled, so each tile owns
+ * its press state exactly the way a component root will — which is also what makes the
+ * pressed *colour* below a real stand-in for a recipe's `pressed` state.
+ */
+export default function PressableFeedbackScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 16, gap: 24, paddingBottom: 48 }}
+    >
+      <Section title="feedbackVariant — the four values">
+        <Tile variant="scale-highlight" label="scale-highlight" />
+        <Tile variant="scale-ripple" label="scale-ripple" />
+        <Tile variant="scale" label="scale" />
+        <Tile variant="none" label="none" />
+      </Section>
+
+      <Section title="animation — off mounts no worklet">
+        <Tile
+          variant="scale-highlight"
+          animation={false}
+          label="animation={false}"
+        />
+        <Tile variant="scale-highlight" animation="disabled" label="'disabled'" />
+        <Tile
+          variant="scale-highlight"
+          animation={{ scale: false }}
+          label="{ scale: false } — wash only"
+        />
+        <Tile
+          variant="scale-ripple"
+          animation={{ ripple: false }}
+          label="{ ripple: false } — scale only"
+        />
+      </Section>
+
+      <Section title="animation='disable-all' — inherited by descendants">
+        <PressableFeedback
+          animation="disable-all"
+          feedbackVariant="none"
+          style={{
+            padding: 12,
+            gap: 8,
+            borderRadius: theme.radius.lg,
+            borderWidth: theme.borderWidth.default,
+            borderColor: theme.colors.border,
+          }}
+        >
+          <Text style={{ color: theme.colors.foreground }}>
+            Both tiles below ask for animations. Neither should move.
+          </Text>
+          <Tile variant="scale-highlight" label="nested, asks for scale-highlight" />
+          <Tile variant="scale-ripple" label="nested, asks for scale-ripple" />
+        </PressableFeedback>
+      </Section>
+
+      <Section title="A styled overlay — variant 'scale', slot rendered by hand">
+        <StyledOverlayTile />
+      </Section>
+
+      <Section title="asChild — the feedback must survive the merge">
+        <AsChildTile />
+      </Section>
+
+      <Section title="animation per slot — same variant, slower and stronger">
+        <SlowHighlightTile />
+      </Section>
+    </ScrollView>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  const theme = useXAUITheme()
+
+  return (
+    <View style={{ gap: 8 }}>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontSize: theme.fontSizes.sm,
+          fontWeight: theme.fontWeights.semibold,
+        }}
+      >
+        {title}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+function Tile({
+  variant,
+  animation,
+  label,
+}: {
+  variant: FeedbackVariant
+  animation?: AnimationProp
+  label: string
+}) {
+  const theme = useXAUITheme()
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <PressableFeedback
+      isPressed={isPressed}
+      feedbackVariant={variant}
+      animation={animation}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+      style={{
+        height: theme.controlHeights.lg,
+        justifyContent: 'center',
+        paddingHorizontal: theme.spacing(4),
+        borderRadius: theme.radius.md,
+        // The pressed colour comes from a token, the way a recipe's `pressed` state
+        // gives it — so this also shows the wash and the token treatment side by side.
+        backgroundColor: isPressed
+          ? theme.colors.accentPressed
+          : theme.colors.accent,
+      }}
+    >
+      <Text style={{ color: theme.colors.accentForeground }}>{label}</Text>
+    </PressableFeedback>
+  )
+}
+
+function StyledOverlayTile() {
+  const theme = useXAUITheme()
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <PressableFeedback
+      isPressed={isPressed}
+      feedbackVariant="scale"
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+      style={{
+        height: theme.controlHeights.lg,
+        justifyContent: 'center',
+        paddingHorizontal: theme.spacing(4),
+        borderRadius: theme.radius.md,
+        overflow: 'hidden',
+        backgroundColor: theme.colors.surface,
+      }}
+    >
+      <PressableFeedback.Highlight
+        style={{ backgroundColor: theme.colors.danger }}
+      />
+      <Text style={{ color: theme.colors.surfaceForeground }}>
+        scale + a Highlight tinted by the slot&apos;s own style
+      </Text>
+    </PressableFeedback>
+  )
+}
+
+/**
+ * The case that would break silently if `asChild` went around `PressableFeedback`
+ * instead of through it: the child must scale and wash exactly like a plain tile.
+ */
+function AsChildTile() {
+  const theme = useXAUITheme()
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <PressableFeedback
+      asChild
+      isPressed={isPressed}
+      feedbackVariant="scale-highlight"
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+    >
+      <View
+        style={{
+          height: theme.controlHeights.lg,
+          justifyContent: 'center',
+          paddingHorizontal: theme.spacing(4),
+          borderRadius: theme.radius.md,
+          overflow: 'hidden',
+          backgroundColor: theme.colors.success,
+        }}
+      >
+        <Text style={{ color: theme.colors.successForeground }}>
+          asChild — merged into this View, feedback intact
+        </Text>
+      </View>
+    </PressableFeedback>
+  )
+}
+
+function SlowHighlightTile() {
+  const theme = useXAUITheme()
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <PressableFeedback
+      isPressed={isPressed}
+      feedbackVariant="scale"
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+      style={{
+        height: theme.controlHeights.lg,
+        justifyContent: 'center',
+        paddingHorizontal: theme.spacing(4),
+        borderRadius: theme.radius.md,
+        overflow: 'hidden',
+        backgroundColor: theme.colors.warning,
+      }}
+    >
+      <PressableFeedback.Highlight animation={{ duration: 600, opacity: 0.35 }} />
+      <Text style={{ color: theme.colors.warningForeground }}>
+        Highlight with animation={'{'} duration: 600, opacity: 0.35 {'}'}
+      </Text>
+    </PressableFeedback>
+  )
+}


### PR DESCRIPTION
Stacked on #187.

## What

`apps/demo/app/pressable-feedback.tsx` is back, routed, and reachable from a link at the
top of the Button screen.

## Why

**#175 cannot be verified without it.** P1.3's acceptance criteria are render checks — the
four `feedbackVariant` values render, `animation={false}` mounts no worklet — and a demo
screen is how a primitive is verified in this repo. That screen went out with the other 58
routes when the demo was cut down to the Button in #185.

## How

Restored unchanged from history (`76441cd~1`), so it is the same screen #175 was written
against: the four variants, `animation={false} / 'disabled' / { scale: false } /
{ ripple: false }`, an inherited `'disable-all'`, and a `Highlight` styled through the
slot's own `style`.

A `<Stack.Screen>` in the layout and a `tertiary` Button at the top of the index. The demo
stays one screen per primitive — that is the shape the P3 components will add to.

Expo Router's generated route types needed a dev-server run to pick up the new file; that
is why the type-check passes now and would not have on a cold checkout without one.

## Verification

Rendered on an **iPhone 17 Pro** simulator, light and dark: navigation from the Button
screen, and both sections of the feedback screen.

```
pnpm turbo run lint --filter=docs --filter=@xaui/*   6 successful
pnpm type-check                                      5 successful
pnpm test                                            8 successful
```

Worth knowing while reviewing #175: `scale-ripple` still draws nothing — that is **P2.5**,
written up in `P2-API-REVIEW.md` §D, and this is the screen where the fix gets checked.

No changeset: the demo is not published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
