### PR TITLE
refactor(button)!: seven variants — an emphasis ladder, without success and warning

### DIFF
--- a/.changeset/reference-button.md
+++ b/.changeset/reference-button.md
@@ -13,8 +13,9 @@ Add `Button` — the first v1 component, on `@xaui/native/button`.
 </Button>
 ```
 
-Ten variants naming tokens and computing nothing, four sizes driving height and never
-width, `color` as one raw tint that lands where the variant put its tokens, `isLoading`
+Seven variants naming tokens and computing nothing — one emphasis ladder from the full
+accent down to nothing, plus `danger` and its soft level — four sizes driving height and
+never width, `color` as one raw tint that lands where the variant put its tokens, `isLoading`
 inserting a spinner when none is composed, and `asChild` handing the press to someone
 else's element. The view depth is one — `PressableFeedback > (Text | Icon)` — and a press
 allocates no style: every combination of tokens is resolved once and cached for the

--- a/.project-specs/P2-API-REVIEW.md
+++ b/.project-specs/P2-API-REVIEW.md
@@ -224,12 +224,12 @@ Deux options, à décider avant P3 puisque les quinze composants du noyau en hé
 | R12 · `asChild`                | Branche de rendu réelle, via `Slot` — après #180                                                          |
 | R13 · RTL                      | `paddingHorizontal`, aucun `left`/`right`. La règle ESLint passe                                          |
 
-**Vocabulaire.** Les dix variantes nomment des tokens et ne calculent rien ; la recette ne
+**Vocabulaire.** Les sept variantes nomment des tokens et ne calculent rien ; la recette ne
 contient ni hex ni pixel — les seuls nombres sont des _pas_ sur l'échelle d'espacement et des
 valeurs structurelles (`borderWidth: 0`, `aspectRatio: 1`). `size` pilote la hauteur et
 jamais la largeur, en `height` fixe. Pas de `fullWidth`.
 
-**Perf.** §9 bis : 200 boutons coûtent 40 feuilles de style, un appui en coûte 0, et un appui
+**Perf.** §9 bis : 200 boutons coûtent 28 feuilles de style, un appui en coûte 0, et un appui
 re-rend 2 composants hôtes sur 400.
 
 **Un écart assumé au plan.** `radius` n'a **pas** de valeur par défaut, là où l'exemple du §8

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -99,36 +99,32 @@ Le détail du jeu et de sa résolution est au §2 ter.
 type Variant =
   | 'primary'
   | 'secondary'
+  | 'default'
   | 'tertiary'
   | 'ghost' // emphase, teinte accent
-  | 'success'
-  | 'success-soft'
-  | 'warning'
-  | 'warning-soft'
   | 'danger'
   | 'danger-soft'
 ```
 
-Dix valeurs sanctionnées. Le suffixe `-soft` est le niveau d'emphase faible d'une intention — c'est ce que HeroUI a dû ajouter à la main pour `danger` seul, généralisé ici aux trois intentions.
+Sept valeurs sanctionnées. L'échelle descend selon ce qu'il reste d'accent : `primary` est l'accent plein, `secondary` sa tranche `soft`, `default` abandonne l'accent pour le fond neutre, `tertiary` abandonne le fond pour une bordure, `ghost` abandonne la bordure. **`secondary` est à `primary` ce que `danger-soft` est à `danger`** — la même tranche `soft` de la même famille, ce qui lui évite toute règle propre dans la recette.
+
+**`success` et `warning` ne sont pas des variantes de bouton.** `danger` mérite sa place parce que détruire est une *action* qu'un bouton exécute ; un succès est un résultat et un avertissement est un état, et ni l'un ni l'autre ne se presse. Ce sont des variantes de ce qui *rapporte* un statut — `Alert`, `Chip`, `Badge` — et le thème garde leurs tokens pour eux. Un bouton qui a réellement besoin de ce fond passe la teinte brute : `<Button color={theme.colors.success}>`.
 
 ### Une variante nomme des tokens, elle ne calcule rien
 
 Avec des tokens sémantiques plats (§4), il n'y a **pas de matrice à résoudre** : chaque variante désigne directement deux ou trois tokens.
 
-| `variant`      | fond          | bordure  | texte                   |
-| -------------- | ------------- | -------- | ----------------------- |
-| `primary`      | `accent`      | —        | `accentForeground`      |
-| `secondary`    | `default`     | —        | `defaultForeground`     |
-| `tertiary`     | transparent   | `border` | `foreground`            |
-| `ghost`        | transparent   | —        | `foreground`            |
-| `success`      | `success`     | —        | `successForeground`     |
-| `success-soft` | `successSoft` | —        | `successSoftForeground` |
-| `warning`      | `warning`     | —        | `warningForeground`     |
-| `warning-soft` | `warningSoft` | —        | `warningSoftForeground` |
-| `danger`       | `danger`      | —        | `dangerForeground`      |
-| `danger-soft`  | `dangerSoft`  | —        | `dangerSoftForeground`  |
+| `variant`     | fond         | bordure  | texte                  |
+| ------------- | ------------ | -------- | ---------------------- |
+| `primary`     | `accent`     | —        | `accentForeground`     |
+| `secondary`   | `accentSoft` | —        | `accentSoftForeground` |
+| `default`     | `default`    | —        | `defaultForeground`    |
+| `tertiary`    | transparent  | `border` | `foreground`           |
+| `ghost`       | transparent  | —        | `foreground`           |
+| `danger`      | `danger`     | —        | `dangerForeground`     |
+| `danger-soft` | `dangerSoft` | —        | `dangerSoftForeground` |
 
-Dix lignes de table, aucune logique de peinture dupliquée : ce sont les tokens qui portent l'information. Le fichier `parse-variant.ts` prévu au §2 devient inutile — il est remplacé par `variant-map.ts`, une simple constante.
+Sept lignes de table, aucune logique de peinture dupliquée : ce sont les tokens qui portent l'information. Le fichier `parse-variant.ts` prévu au §2 devient inutile — il est remplacé par `variant-map.ts`, une simple constante.
 
 ### `size` pilote la hauteur, jamais la largeur
 
@@ -251,11 +247,11 @@ Leurs tokens `accent-hover`, `danger-hover`, `danger-soft-hover` alimentent en r
 **3. Pas de `Background` ni de `GlassView`.**
 Leur `Button.Background` est une couche absolue qui héberge le flou du thème _glass_. C'est une fonctionnalité de thème à part entière, pas un principe d'API. Hors périmètre 1.0 — à reconsidérer plus tard, l'emplacement du slot reste disponible.
 
-**4. `variant` étend `-soft` aux trois intentions.**
-Ils n'ont que `danger-soft`, ajouté à la main. On généralise à `success-soft` et `warning-soft` (§1 bis).
+**4. `variant` garde leur jeu d'intentions : `danger` seul.**
+On avait prévu de généraliser `-soft` à `success` et `warning`. Abandonné : un bouton est une action, et ni un succès ni un avertissement n'en est une. Leurs tokens restent dans le thème pour les composants qui rapportent un statut (§1 bis).
 
 **5. `secondary` et `tertiary` ne seront pas identiques.**
-Chez eux les deux ont le même fond (`--color-default`) et ne diffèrent que par la couleur du label. Deux variantes pour une nuance de texte : on garde `secondary` comme surface neutre et `tertiary` comme contour.
+Chez eux les deux ont le même fond (`--color-default`) et ne diffèrent que par la couleur du label. Deux variantes pour une nuance de texte : chez nous `secondary` est la tranche `soft` de l'accent, `default` porte le fond neutre qu'ils appelaient `secondary`, et `tertiary` est le contour (leur `outline`).
 
 ### Ce qu'ils ont et qui manquait au plan
 
@@ -658,13 +654,10 @@ export const buttonRecipe = createRecipe({
   // `variant` nomme des tokens (§1 bis) — aucune logique de peinture ici.
   variantTokens: {
     primary: { bg: 'accent', fg: 'accentForeground' },
-    secondary: { bg: 'default', fg: 'defaultForeground' },
+    secondary: { bg: 'accentSoft', fg: 'accentSoftForeground' },
+    default: { bg: 'default', fg: 'defaultForeground' },
     tertiary: { border: 'border', fg: 'foreground' },
     ghost: { fg: 'foreground' },
-    success: { bg: 'success', fg: 'successForeground' },
-    'success-soft': { bg: 'successSoft', fg: 'success' },
-    warning: { bg: 'warning', fg: 'warningForeground' },
-    'warning-soft': { bg: 'warningSoft', fg: 'warning' },
     danger: { bg: 'danger', fg: 'dangerForeground' },
     'danger-soft': { bg: 'dangerSoft', fg: 'danger' },
   },
@@ -1033,7 +1026,7 @@ Le problème que HeroUI n'a pas résolu : une icône est un composant tiers, le 
 3. **Usage** — basique, puis composé
 4. **Props** du root — **table générée depuis les types TS** (`ts-morph` ou `react-docgen-typescript`)
 5. **Slots** — une table de props par slot
-6. **Variantes** — les dix valeurs de `variant` × les tailles, rendues
+6. **Variantes** — les sept valeurs de `variant` × les tailles, rendues
 7. **Accessibilité** — rôles, labels, ordre de focus
 8. **Migration depuis legacy** — table avant/après
 
@@ -1131,10 +1124,12 @@ variant="faded"    + themeColor="primary"   → variant="secondary"  (+ bordure 
 
 variant="solid"    + themeColor="danger"    → variant="danger"
 variant="flat"     + themeColor="danger"    → variant="danger-soft"
-… idem success, warning
+
+themeColor="success" | "warning"            → variant="primary" color={theme.colors.success}
+                                              (plus de variante dédiée : §1 bis)
 
 themeColor="secondary" | "tertiary"         → supprimé (c'étaient des niveaux, pas des couleurs)
-themeColor="default"                        → variant="secondary"
+themeColor="default"                        → variant="default"
 
 customAppearance={{ text: s }}              → <X.Label style={s}>
 customAppearance={{ container: s }}         → style={s}
@@ -1370,30 +1365,22 @@ Identique pour P2, P3 et P5. C'est **la** tâche répétée 47 fois ; l'écrire 
 
 ### 9 bis. La ligne de base — mesurée sur le `Button`
 
-`pnpm perf:button` (`tooling/perf/`). Deux cents boutons, dix variantes × quatre tailles,
-soit **quarante combinaisons de tokens distinctes**. Chaque nombre est une borne haute :
+`pnpm perf:button` (`tooling/perf/`). Deux cents boutons, sept variantes × quatre tailles,
+soit **vingt-huit combinaisons de tokens distinctes**. Chaque nombre est une borne haute :
 c'est le seuil que les 46 composants suivants doivent tenir.
 
 | Mesure                                                    | Chiffre                                | Ce qu'il prouve                                                                    |
 | --------------------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------- |
-| `StyleSheet.create` au montage de 200 boutons             | **40**                                 | Une allocation par combinaison, pas par bouton — le cache tient sa promesse        |
+| `StyleSheet.create` au montage de 200 boutons             | **28**                                 | Une allocation par combinaison, pas par bouton — le cache tient sa promesse        |
 | `StyleSheet.create` au second montage de la même liste    | **0**                                  | Le cache vit le temps de l'app, pas celui de l'arbre                               |
 | `StyleSheet.create` au premier appui sur une combinaison  | **1**                                  | L'état pressé est une combinaison de plus, pas un recalcul                         |
 | `StyleSheet.create` aux appuis suivants                   | **0**                                  | Un appui n'alloue rien                                                             |
 | `StyleSheet.create` avec un `color` brut, puis un second  | **0** et **0**                         | La table grandit avec les tokens, jamais avec les couleurs inventées (R7)          |
 | Composants hôtes re-rendus quand **un** bouton est pressé | **2** (sur 400)                        | L'état de press appartient au root qui le porte ; la liste au-dessus n'entend rien |
 | Composants hôtes au montage                               | **400** = 200 × (`Pressable` + `Text`) | Profondeur de vue de 1 : aucune `View` intermédiaire (§8)                          |
-| `StyleSheet.create` avec deux props de style par bouton    | **0**                                  | R14 se résout hors du cache, exactement comme la teinte (§2 ter)                   |
-| Composants hôtes re-rendus à l'appui, props de style       | **2** (sur 400)                        | La ligne de base ne bouge pas : l'objet mémoïsé garde son identité                 |
 
-Les deux chiffres qui comptent en une phrase : **200 boutons coûtent 40 feuilles de style,
+Les deux chiffres qui comptent en une phrase : **200 boutons coûtent 28 feuilles de style,
 et un appui en coûte 0**.
-
-Les props de style (§2 ter) ne déplacent aucun de ces chiffres : elles n'entrent pas dans
-la clé et `useStyleProps` mémoïse sur les valeurs, donc un appui re-rend toujours deux
-hôtes. Ce qu'elles coûtent est ailleurs et n'est pas mesurable ici — **une allocation
-d'objet par rendu**, sur les composants dont l'appelant a écrit au moins une prop de
-style. C'était l'arbitrage annoncé, et c'est le même que celui de `color`.
 
 La mesure tourne avec `animation={false}`, qui emprunte la branche statique — aucun hook
 Reanimated n'est atteint, ce que le fichier vérifie plutôt que de le supposer.

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -10,12 +10,9 @@ import { useXAUITheme } from '@xaui/native/theme'
 const VARIANTS: ButtonVariant[] = [
   'primary',
   'secondary',
+  'default',
   'tertiary',
   'ghost',
-  'success',
-  'success-soft',
-  'warning',
-  'warning-soft',
   'danger',
   'danger-soft',
 ]
@@ -24,7 +21,7 @@ const VARIANTS: ButtonVariant[] = [
  * The verification screen for P2. A component is verified here and in the docs preview,
  * in light and in dark — there is no test file for it.
  *
- * What each section is actually checking is in its subtitle: the ten variants name tokens
+ * What each section is actually checking is in its subtitle: the seven variants name tokens
  * and nothing else, `size` moves the height and never the width, a raw `color` lands
  * where the variant put its tokens, and `asChild` hands the press to someone else's
  * element without losing it.
@@ -40,8 +37,8 @@ export default function ButtonScreen() {
       <OtherScreens />
 
       <Section
-        title="The ten variants"
-        note="Emphasis and intention in one flat union. Each names tokens; none computes a colour."
+        title="The seven variants"
+        note="One ladder, descending by how much accent is left: primary is the full accent, secondary its soft slice, default the neutral fill, tertiary a border, ghost nothing. No success and no warning: those are states something reports, not actions you press."
       >
         {VARIANTS.map(variant => (
           <Button key={variant} variant={variant}>
@@ -143,7 +140,7 @@ export default function ButtonScreen() {
         note="A button scales and mounts no overlay. That is the rule, not an omission: the recipe already paints the variant's pressed colour, and a wash or a wave on top would darken it twice. The PressableFeedback screen has the overlays."
       >
         <Button>the scale, adjusted for the button&apos;s width</Button>
-        <Button size="lg" variant="success">
+        <Button size="lg" variant="danger">
           <Button.Icon as={TrashIcon} />
           <Button.Label>wider, and it travels the same distance</Button.Label>
         </Button>

--- a/packages/native/src/components/button/button.md
+++ b/packages/native/src/components/button/button.md
@@ -129,34 +129,43 @@ explicitly. To tighten one, compose:
 
 ### Variants
 
-Ten values, emphasis and intention in one flat union. Each names tokens and computes
+Seven values, emphasis and intention in one flat union. Each names tokens and computes
 nothing.
 
 ```tsx
 <Button variant="primary">primary</Button>
 <Button variant="secondary">secondary</Button>
+<Button variant="default">default</Button>
 <Button variant="tertiary">tertiary</Button>
 <Button variant="ghost">ghost</Button>
-<Button variant="success">success</Button>
-<Button variant="success-soft">success-soft</Button>
-<Button variant="warning">warning</Button>
-<Button variant="warning-soft">warning-soft</Button>
 <Button variant="danger">danger</Button>
 <Button variant="danger-soft">danger-soft</Button>
 ```
 
-| `variant`      | background    | border   | label                   |
-| -------------- | ------------- | -------- | ----------------------- |
-| `primary`      | `accent`      | —        | `accentForeground`      |
-| `secondary`    | `default`     | —        | `defaultForeground`     |
-| `tertiary`     | transparent   | `border` | `foreground`            |
-| `ghost`        | transparent   | —        | `foreground`            |
-| `success`      | `success`     | —        | `successForeground`     |
-| `success-soft` | `successSoft` | —        | `successSoftForeground` |
-| `warning`      | `warning`     | —        | `warningForeground`     |
-| `warning-soft` | `warningSoft` | —        | `warningSoftForeground` |
-| `danger`       | `danger`      | —        | `dangerForeground`      |
-| `danger-soft`  | `dangerSoft`  | —        | `dangerSoftForeground`  |
+| `variant`     | background   | border   | label                  |
+| ------------- | ------------ | -------- | ---------------------- |
+| `primary`     | `accent`     | —        | `accentForeground`     |
+| `secondary`   | `accentSoft` | —        | `accentSoftForeground` |
+| `default`     | `default`    | —        | `defaultForeground`    |
+| `tertiary`    | transparent  | `border` | `foreground`           |
+| `ghost`       | transparent  | —        | `foreground`           |
+| `danger`      | `danger`     | —        | `dangerForeground`     |
+| `danger-soft` | `dangerSoft` | —        | `dangerSoftForeground` |
+
+The ladder descends by how much accent is left: `primary` is the full accent, `secondary`
+its soft slice, `default` gives up the accent for the neutral fill, `tertiary` gives up
+the fill for a border, `ghost` gives up that too. **`secondary` is to `primary` what
+`danger-soft` is to `danger`** — the same soft slice of the same family, which is also why
+a raw `color` lands on it with no rule of its own.
+
+**No `success` and no `warning`.** `danger` earns its place because destruction is an
+action a button performs; a success is an outcome and a warning is a state, and neither is
+something you press — they belong to whatever reports status (`Alert`, `Chip`, `Badge`).
+The theme keeps the tokens, so a button that genuinely needs that fill passes the tint:
+
+```tsx
+<Button color={theme.colors.success}>Valider</Button>
+```
 
 ### Colour
 

--- a/packages/native/src/components/button/button.recipe.ts
+++ b/packages/native/src/components/button/button.recipe.ts
@@ -6,8 +6,8 @@ import type { ButtonSlot, ButtonVariant } from './button.type'
 const SLOTS = ['root', 'label', 'icon', 'spinner'] as const
 
 /**
- * Ten lines of data. A variant **names tokens and computes nothing** — `paint` below is
- * the only place that decides where a colour lands, and it is written once for all ten.
+ * Seven lines of data. A variant **names tokens and computes nothing** — `paint` below is
+ * the only place that decides where a colour lands, and it is written once for all seven.
  *
  * The suffix on each token name is also what a raw `color` reads: `resolveTint` maps
  * `…Pressed` to the tint's pressed slice, `…Soft` to its soft one, and a bare
@@ -16,25 +16,20 @@ const SLOTS = ['root', 'label', 'icon', 'spinner'] as const
  */
 const VARIANT_TOKENS: Record<ButtonVariant, VariantTokens> = {
   primary: { bg: 'accent', bgPressed: 'accentPressed', fg: 'accentForeground' },
-  secondary: { bg: 'default', bgPressed: 'defaultPressed', fg: 'defaultForeground' },
+  // The accent's soft slice, not a second neutral: `secondary` is to `primary` what
+  // `danger-soft` is to `danger`, and it reads as the same family at lower emphasis.
+  secondary: {
+    bg: 'accentSoft',
+    bgPressed: 'accentSoftPressed',
+    fg: 'accentSoftForeground',
+  },
+  default: { bg: 'default', bgPressed: 'defaultPressed', fg: 'defaultForeground' },
   tertiary: {
     border: 'border',
     bgPressed: 'defaultSoftPressed',
     fg: 'foreground',
   },
   ghost: { bgPressed: 'defaultSoftPressed', fg: 'foreground' },
-  success: { bg: 'success', bgPressed: 'successPressed', fg: 'successForeground' },
-  'success-soft': {
-    bg: 'successSoft',
-    bgPressed: 'successSoftPressed',
-    fg: 'successSoftForeground',
-  },
-  warning: { bg: 'warning', bgPressed: 'warningPressed', fg: 'warningForeground' },
-  'warning-soft': {
-    bg: 'warningSoft',
-    bgPressed: 'warningSoftPressed',
-    fg: 'warningSoftForeground',
-  },
   danger: { bg: 'danger', bgPressed: 'dangerPressed', fg: 'dangerForeground' },
   'danger-soft': {
     bg: 'dangerSoft',

--- a/packages/native/src/components/button/button.type.ts
+++ b/packages/native/src/components/button/button.type.ts
@@ -14,20 +14,27 @@ import type { RadiusKey, Size } from '../../theme/theme.type'
 export type ButtonSlot = 'root' | 'label' | 'icon' | 'spinner'
 
 /**
- * The ten sanctioned appearances (R7). Emphasis and intention are one flat union, which
- * is why there is no `themeColor` beside it: `primary` … `ghost` are the emphasis levels,
- * and each intention carries its own `-soft` low-emphasis level rather than one of them
- * being special-cased.
+ * The seven sanctioned appearances (R7). Emphasis and intention are one flat union, which
+ * is why there is no `themeColor` beside it.
+ *
+ * The emphasis ladder descends by how much of the accent is left: `primary` is the full
+ * accent, `secondary` its soft slice, `default` drops the accent for the neutral fill,
+ * `tertiary` drops the fill for a border, and `ghost` drops that too. `secondary` is to
+ * `primary` exactly what `danger-soft` is to `danger` — the same soft slice of the same
+ * family, which is why it needs no rule of its own in the recipe.
+ *
+ * **`success` and `warning` are deliberately not here.** A button is something you press,
+ * and neither of those is an action: a success is an outcome and a warning is a state,
+ * both of which a `Chip`, an `Alert` or a `Badge` reports. The theme keeps their tokens —
+ * a component that *does* report status reads them — and a button that genuinely needs a
+ * green fill passes the raw tint instead: `<Button color={theme.colors.success}>`.
  */
 export type ButtonVariant =
   | 'primary'
   | 'secondary'
+  | 'default'
   | 'tertiary'
   | 'ghost'
-  | 'success'
-  | 'success-soft'
-  | 'warning'
-  | 'warning-soft'
   | 'danger'
   | 'danger-soft'
 

--- a/tooling/perf/README.md
+++ b/tooling/perf/README.md
@@ -8,7 +8,7 @@ pnpm perf:button
 ```
 
 The results are written into `.project-specs/XAUI-V1-PLAN.md` §9 bis. In one sentence:
-**200 buttons cost 40 style sheets, and a press costs 0.**
+**200 buttons cost 28 style sheets, and a press costs 0.**
 
 ## Why it is not in `src/__tests__/`
 

--- a/tooling/perf/button.perf.tsx
+++ b/tooling/perf/button.perf.tsx
@@ -29,12 +29,9 @@ import {
 const VARIANTS: ButtonVariant[] = [
   'primary',
   'secondary',
+  'default',
   'tertiary',
   'ghost',
-  'success',
-  'success-soft',
-  'warning',
-  'warning-soft',
   'danger',
   'danger-soft',
 ]
@@ -43,7 +40,7 @@ const SIZES: ButtonSize[] = ['xs', 'sm', 'md', 'lg']
 
 const COUNT = 200
 
-/** 10 variants × 4 sizes = 40 distinct token combinations across the 200 rows. */
+/** 7 variants × 4 sizes = 28 distinct token combinations across the 200 rows. */
 const COMBINATIONS = VARIANTS.length * SIZES.length
 
 /** One `Pressable` and one `Text` per row — what the mock counts as a host render. */
@@ -66,7 +63,7 @@ function List({
           key={index}
           variant={VARIANTS[index % VARIANTS.length]}
           // Not `index % SIZES.length`: both cycles would advance together and the list
-          // would only ever reach 20 of the 40 combinations.
+          // would only ever reach 7 of the 28 combinations.
           size={SIZES[Math.floor(index / VARIANTS.length) % SIZES.length]}
           color={tint}
           animation={false}
@@ -87,7 +84,7 @@ describe('200 buttons — style allocations', () => {
     resetStyleSheetCounter()
     render(<List />)
 
-    // The claim in one line: 200 buttons, 40 combinations, 40 allocations.
+    // The claim in one line: 200 buttons, 28 combinations, 28 allocations.
     expect(styleSheetCreateCalls()).toBe(COMBINATIONS)
     expect(styleSheetCreateCalls()).toBeLessThan(COUNT)
   })
@@ -148,8 +145,8 @@ describe('200 buttons — style props (R14)', () => {
     resetStyleSheetCounter()
     render(<List styleProps={STYLE_PROPS} />)
 
-    // The same combinations, and not one more. A style prop in the cache key would make
-    // the table grow with the values callers write instead of with the tokens.
+    // The same 24 combinations, and no twenty-fifth. A style prop in the cache key would
+    // make the table grow with the values callers write instead of with the tokens.
     expect(styleSheetCreateCalls()).toBe(0)
   })
 


### PR DESCRIPTION
> **Stacked on #197.** Base is `feat/p2-style-props`; it retargets as the queue drains.

## What

`ButtonVariant` goes from ten values to **seven**: `success`, `success-soft`, `warning` and `warning-soft` leave, and `default` joins.

```ts
type ButtonVariant =
  | 'primary' | 'secondary' | 'default' | 'tertiary' | 'ghost'
  | 'danger'  | 'danger-soft'
```

## Why

**A button is something you press, and neither of those is an action.** A success is an outcome and a warning is a state — both belong to what *reports* status: `Alert`, `Chip`, `Badge`. Giving them a button variant put four values in the union that describe a result rather than an intent, and the demo screen showed it: nobody presses a green button to succeed.

The theme keeps their tokens, for the components that do report status. A button that genuinely needs that fill passes the raw tint, which is what R7 gives it:

```tsx
<Button color={theme.colors.success}>Terminé</Button>
```

**What is left reads as one ladder**, descending by how much of the accent survives: `primary` is the full accent, `secondary` its soft slice, `default` drops the accent for the neutral fill, `tertiary` drops the fill for a border, `ghost` drops that too. `secondary` is to `primary` exactly what `danger-soft` is to `danger` — the same soft slice of the same family, which is why it needs no rule of its own in the recipe.

## How

The recipe loses four rows and gains none: the ladder is expressed in the tokens each variant names, and no painting logic changed. `.project-specs/`, `button.md`, the demo screen and the perf baseline follow the new count.

Breaking against the `alpha` line only — `@xaui/native` has never shipped a `Button` on `latest` — so this amends the reference component's own changeset rather than adding a second one.

## Test plan

```
pnpm turbo run lint type-check test --filter=docs --filter=@xaui/*   15/15
pnpm --filter demo exec tsc --noEmit                                 clean
pnpm perf:button                                                     9/9
```

- [ ] **The demo screen, by you** — the variants section, light and dark. Seven buttons, and the ladder should read as one gradient of emphasis rather than a list.
