### PR TITLE
feat(system): R14 reaches every component that renders a node

### DIFF
--- a/.agents/skills/xaui-component/SKILL.md
+++ b/.agents/skills/xaui-component/SKILL.md
@@ -89,6 +89,11 @@ union to the four emphasis levels. That's a subtype, not a different prop.
   Two lines in a component: `Omit<ViewStyleProps, keyof OwnProps>` in the type — a name
   the component already uses stays the component's — and `useStyleProps` on what is left
   after destructuring, applied between the tint and `style`.
+
+  **Every node gets them, not just roots.** A slot has them like its root, a view slot in
+  `ViewStyle` and a text slot in `TextStyle`; the `system/` primitives have them too. A
+  component that renders a node and does not expose them is the defect — there is no list
+  of which components have them, because the answer is all of them.
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.agents/skills/xaui-system/SKILL.md
+++ b/.agents/skills/xaui-system/SKILL.md
@@ -186,6 +186,11 @@ by measuring on screen. The scale stays explicit: `padding={t.spacing(4)}`.
 A style prop styles **its own node**, never a descendant (R1), which is what separates it
 from `customAppearance`.
 
+**Every component that renders a node exposes them, primitives included** —
+`PressableFeedback` and its overlays, `PortalHost`, `Icon` (its `source` form, as far as
+its `style` reaches). Adding a primitive that renders a node without them is the defect;
+there is no exception list, because the rule has no exceptions.
+
 Two pieces, and the split is the point:
 
 ```ts

--- a/.changeset/style-props-everywhere.md
+++ b/.changeset/style-props-everywhere.md
@@ -1,0 +1,24 @@
+---
+'@xaui/native': patch
+---
+
+R14 reaches every component that renders a node, not only the `Button`.
+
+`PressableFeedback` and its `Highlight` / `Ripple` overlays, `PortalHost` and `Icon` now
+take the style keys of the node they render, the same way the `Button` and its slots do.
+The primitive every pressable control in the library is built on cannot be the one place
+where `padding={16}` has to become an object again.
+
+```tsx
+<PressableFeedback padding={12} borderRadius={16}>…</PressableFeedback>
+<Icon source={logo} marginEnd={8} />
+```
+
+`Icon`'s reach the **`source` form only**, exactly as far as its `style` already does: the
+other two forms render a third-party component or clone the caller's element, so there is
+no node of ours to style. That is the rule applied, not an exception to it — the rule says
+*the node the component renders*, and there is one in three.
+
+On `PressableFeedback` they merge into `style` before either branch sees it, so the ink and
+the corners an overlay reads off its surface include a `backgroundColor` or a
+`borderRadius` written as a prop.

--- a/.claude/skills/xaui-component/SKILL.md
+++ b/.claude/skills/xaui-component/SKILL.md
@@ -89,6 +89,11 @@ union to the four emphasis levels. That's a subtype, not a different prop.
   Two lines in a component: `Omit<ViewStyleProps, keyof OwnProps>` in the type — a name
   the component already uses stays the component's — and `useStyleProps` on what is left
   after destructuring, applied between the tint and `style`.
+
+  **Every node gets them, not just roots.** A slot has them like its root, a view slot in
+  `ViewStyle` and a text slot in `TextStyle`; the `system/` primitives have them too. A
+  component that renders a node and does not expose them is the defect — there is no list
+  of which components have them, because the answer is all of them.
 - **Anything else goes through `style`.** Tinted shadow, border in a different colour than
   the background, gradient — `style`.
 

--- a/.claude/skills/xaui-system/SKILL.md
+++ b/.claude/skills/xaui-system/SKILL.md
@@ -186,6 +186,11 @@ by measuring on screen. The scale stays explicit: `padding={t.spacing(4)}`.
 A style prop styles **its own node**, never a descendant (R1), which is what separates it
 from `customAppearance`.
 
+**Every component that renders a node exposes them, primitives included** —
+`PressableFeedback` and its overlays, `PortalHost`, `Icon` (its `source` form, as far as
+its `style` reaches). Adding a primitive that renders a node without them is the defect;
+there is no exception list, because the rule has no exceptions.
+
 Two pieces, and the split is the point:
 
 ```ts

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -73,6 +73,8 @@ Desserrer un contrôle, lui donner une largeur, changer un fond ne doit pas dema
 
 Le jeu n'est pas une liste mais un type : **les clés de style du nœud du composant** — `ViewStyle`, `TextStyle` sur un slot texte — **moins les formes directionnelles que R13 interdit**, qui ne sont pas exposées du tout.
 
+**Tout ce qui rend un nœud les expose**, sans exception par composant : un root, un slot, et les primitives de `system/` — `PressableFeedback` et ses overlays, `PortalHost`, `Icon` — au même titre. Une liste des composants « qui les ont » serait exactement la liste que cette règle dit de ne pas maintenir.
+
 Trois choses les gardent compatibles avec le reste :
 
 - **La portée s'arrête au nœud sur lequel la prop est écrite.** Jamais un descendant : R1 tient, et c'est ce qui les sépare de `customAppearance`.
@@ -525,6 +527,34 @@ comme il porte déjà son `style` (R2) :
 C'est ce qui les distingue de l'ancien `customAppearance`, qui atteignait l'intérieur d'un
 composant depuis l'extérieur : ici l'endroit où on écrit la prop est l'endroit où elle
 s'applique.
+
+### Tout ce qui rend un nœud les expose — pas seulement les roots
+
+**La règle n'a pas d'exception par composant.** Dès qu'un composant rend un nœud, il expose
+les clés de style de ce nœud : un root, un slot, et les primitives de `system/` au même
+titre. Une liste de « ceux qui les ont » serait exactement la liste que R14 dit de ne pas
+maintenir — et un appelant qui doit deviner lesquels en ont a une API à apprendre par cœur.
+
+| Ce qui rend                         | Le nœud           | Le jeu            |
+| ----------------------------------- | ----------------- | ----------------- |
+| Un root — `Button`, `Card`, `Chip`  | une vue pressable | `ViewStyleProps`  |
+| Un slot vue — `Button.Spinner`      | une vue           | `ViewStyleProps`  |
+| Un slot texte — `Button.Label`      | un `Text`         | `TextStyleProps`  |
+| `PressableFeedback` et ses overlays | un `Pressable`    | `ViewStyleProps`  |
+| `PortalHost`                        | sa vue conteneur  | `ViewStyleProps`  |
+| `Icon`                              | une `Image`       | `ImageStyleProps` |
+
+Deux cas méritent leur phrase :
+
+- **`Icon` ne rend un nœud que dans sa forme `source`.** Les deux autres — `as` et l'enfant
+  SVG — rendent le composant de quelqu'un d'autre. Ses props de style portent donc
+  exactement aussi loin que son `style`, qui a déjà cette limite, et `size` / `color`
+  restent l'échappatoire des deux autres formes. Ce n'est pas une exception à la règle :
+  la règle dit « le nœud que le composant rend », et il n'y en a qu'un sur trois.
+- **Un root les déclare pour son propre nœud**, même quand le primitif qu'il rend les porte
+  déjà. `Button` les redéclare bien que `PressableFeedback` les ait : c'est le `Button` qui
+  les doit à son appelant, et un composant ne doit pas dépendre de ce qu'il rend
+  aujourd'hui pour tenir sa promesse d'API demain.
 
 ### `color` garde son sens, et ce n'est pas une exception
 

--- a/apps/demo/app/pressable-feedback.tsx
+++ b/apps/demo/app/pressable-feedback.tsx
@@ -90,6 +90,16 @@ export default function PressableFeedbackScreen() {
         />
       </Section>
 
+      <Section title="Style props — R14, on the primitive too">
+        <Note>
+          The tile below is styled entirely in props: no <Bold>style</Bold> object
+          anywhere. It must look like the ones above — and its wash must still be
+          visible, which is the real check: the ink is computed from the surface&apos;s
+          background, and that background was written as a prop rather than in a style.
+        </Note>
+        <StylePropsTile />
+      </Section>
+
       <Section title="animation — off mounts no worklet">
         <Tile
           label="animation={false}"
@@ -203,6 +213,38 @@ function Tile({
       {overlayLast ? null : overlay}
       <Text style={{ color: labelOn(theme, background) }}>{label}</Text>
       {overlayLast ? overlay : null}
+    </PressableFeedback>
+  )
+}
+
+/**
+ * The same tile as above, written without a single `style` object — the primitive takes
+ * the style keys of the `Pressable` it renders (R14), and the overlay takes its own.
+ *
+ * What it proves is the merge order inside `PressableFeedback`: the style props land in
+ * `style` before either branch reads the surface, so the ink stays contrasted against a
+ * background the caller never put in a style object.
+ */
+function StylePropsTile() {
+  const theme = useXAUITheme()
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <PressableFeedback
+      isPressed={isPressed}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+      height={theme.controlHeights.lg}
+      justifyContent="center"
+      paddingHorizontal={theme.spacing(4)}
+      borderRadius={theme.radius.lg}
+      backgroundColor={theme.colors.accent}
+    >
+      <PressableFeedback.Highlight />
+      <Text style={{ color: labelOn(theme, theme.colors.accent) }}>
+        every measurement is a prop
+      </Text>
     </PressableFeedback>
   )
 }

--- a/packages/native/src/components/button/button.md
+++ b/packages/native/src/components/button/button.md
@@ -210,10 +210,10 @@ The set is not a list but a type — the node's style keys (`ViewStyle` on the r
 `TextStyle` on `Button.Label`) **minus the directional forms R13 bans**, which are not
 exposed at all: `paddingStart`, never `paddingLeft`.
 
-`Button.Icon` is the exception, and deliberately: two of `Icon`'s three forms have no view
-of ours to style — `as` hands its props to a third-party component, and the children form
-clones the caller's own element — so a `padding` there would apply in one form out of
-three. `size` and `color` remain its escape hatch, as they already are for `style`.
+`Button.Icon` has them too, in `ImageStyle`, and they reach the **`source` form only** —
+exactly as far as its `style` already does. The other two forms render a third-party
+component or clone the caller's element, so there is no node of ours to style, and `size`
+and `color` stay the escape hatch there.
 
 Each one styles **the node it is written on**, never a descendant — which is what separates
 this from the legacy `customAppearance`. `width="100%"` is what replaces `fullWidth`, said
@@ -269,8 +269,9 @@ Everything `Text` accepts, plus the `TextStyle` keys as props (R14) — `fontSiz
 
 ### `Button.Icon`
 
-`Icon`'s props. `size` and `color` default to what the root resolved; passing either wins.
-`style` reaches the `source` form only — the other two are not views this renders.
+`Icon`'s props, plus the `ImageStyle` keys as props (R14). `size` and `color` default to
+what the root resolved; passing either wins. Both `style` and the style props reach the
+`source` form only — the other two are not views this renders.
 
 ### `Button.Spinner`
 

--- a/packages/native/src/components/button/button.type.ts
+++ b/packages/native/src/components/button/button.type.ts
@@ -77,13 +77,17 @@ type ButtonBehaviourProps = Omit<
 
 /**
  * R14 — the button's own props, the press behaviour it forwards, and every `ViewStyle`
- * key the two do not already claim. `height` therefore beats the height `size` chose and
- * `width="100%"` is what replaced `fullWidth`, both because the style props resolve after
- * the recipe. That is the escape hatch, not the normal path.
+ * key its own vocabulary does not already claim. `height` therefore beats the height
+ * `size` chose and `width="100%"` is what replaced `fullWidth`, both because the style
+ * props resolve after the recipe. That is the escape hatch, not the normal path.
+ *
+ * `PressableFeedback` carries the same keys, so the third term is redundant today. It
+ * stays because it is the `Button` that owes them: a root states the rule for its own
+ * node rather than inheriting it from whatever it happens to render.
  */
 export type ButtonProps = ButtonOwnProps &
   ButtonBehaviourProps &
-  Omit<ViewStyleProps, keyof ButtonOwnProps | keyof ButtonBehaviourProps>
+  Omit<ViewStyleProps, keyof ButtonOwnProps>
 
 /** `Text`'s own props win over the `TextStyle` keys of the same name (R14). */
 export type ButtonLabelProps = TextProps &

--- a/packages/native/src/system/README.md
+++ b/packages/native/src/system/README.md
@@ -248,12 +248,21 @@ name while multiplying its value by a scale would be the most expensive trap in 
 the kind only a ruler on the screen catches. The scale stays one word away:
 `padding={t.spacing(4)}`.
 
+**Everything in this folder that renders a node takes them**, and so does everything built
+on it: `PressableFeedback` and its two overlays, `PortalHost`, `Icon`. A list of which
+primitives have them is the list R14 says not to maintain — if it renders a node, it has
+them.
+
+`Icon` carries the one nuance worth stating: its props reach the **`source` form only**,
+exactly as far as its `style` already does. The other two forms render a third-party
+component or clone the caller's element, so there is no node of ours to style, and `size`
+and `color` stay the escape hatch there.
+
 A component author needs two things from here — a type for its props, and the split at
 the top of its render:
 
 ```tsx
-export type CardProps = CardOwnProps &
-  Omit<ViewStyleProps, keyof CardOwnProps>
+export type CardProps = CardOwnProps & Omit<ViewStyleProps, keyof CardOwnProps>
 
 function Card({ variant, style, ...props }: CardProps) {
   const [styleProps, rest] = useStyleProps(props)

--- a/packages/native/src/system/icon/icon.tsx
+++ b/packages/native/src/system/icon/icon.tsx
@@ -2,6 +2,7 @@ import { cloneElement, isValidElement } from 'react'
 import type { ReactElement } from 'react'
 import { Image } from 'react-native'
 import { useXAUITheme } from '../../theme/theme-hooks'
+import { useStyleProps } from '../style-props'
 import { useIconContext } from './icon-context'
 import type { IconProps } from './icon.type'
 
@@ -27,9 +28,11 @@ export function Icon({
   size,
   color,
   style,
+  ...props
 }: IconProps) {
   const inherited = useIconContext()
   const theme = useXAUITheme()
+  const [styleProps] = useStyleProps(props)
 
   const resolvedSize = size ?? inherited.size ?? theme.fontSizes.md
   const resolvedColor = color ?? inherited.color ?? theme.colors.foreground
@@ -55,6 +58,7 @@ export function Icon({
         source={source}
         style={[
           { width: resolvedSize, height: resolvedSize, tintColor: resolvedColor },
+          styleProps,
           style,
         ]}
       />

--- a/packages/native/src/system/icon/icon.type.ts
+++ b/packages/native/src/system/icon/icon.type.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, ReactNode } from 'react'
 import type { ImageSourcePropType, ImageStyle, StyleProp } from 'react-native'
+import type { ImageStyleProps } from '../style-props'
 
 /**
  * The props Lucide, Ionicons and `react-native-vector-icons` all accept — the shape
@@ -11,7 +12,12 @@ export type IconComponentProps = {
   color?: string
 }
 
-export type IconProps = {
+/**
+ * R14 reaches the **`source` form only**, exactly like `style` below and for the same
+ * reason: it is the one of the three forms where we render the node. On the other two,
+ * `size` and `color` are what shapes the icon.
+ */
+export type IconProps = ImageStyleProps & {
   /** An icon component. `size` and `color` are injected into it. */
   as?: ComponentType<IconComponentProps>
   /** A raw `react-native-svg` element, cloned with the resolved size and colour. */

--- a/packages/native/src/system/portal/portal-host.tsx
+++ b/packages/native/src/system/portal/portal-host.tsx
@@ -2,8 +2,11 @@ import { Fragment, useCallback, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { StyleSheet, View } from 'react-native'
 import { PortalContext } from './portal-context'
+import { useStyleProps } from '../style-props'
+import type { ViewStyleProps } from '../style-props'
 
-export type PortalHostProps = {
+/** R14 — it renders a view of its own, so it takes that view's style keys as props. */
+export type PortalHostProps = ViewStyleProps & {
   children: ReactNode
 }
 
@@ -15,7 +18,8 @@ const styles = StyleSheet.create({
  * Where every `Portal` in the tree below renders. Mounted once, at the root of the app,
  * above navigation — an overlay that renders inside a screen is clipped by it.
  */
-export function PortalHost({ children }: PortalHostProps) {
+export function PortalHost({ children, ...props }: PortalHostProps) {
+  const [styleProps] = useStyleProps(props)
   const [portals, setPortals] = useState<ReadonlyMap<string, ReactNode>>(new Map())
 
   // A new Map per change rather than a mutated ref with a forced re-render: the rendered
@@ -41,7 +45,7 @@ export function PortalHost({ children }: PortalHostProps) {
 
   return (
     <PortalContext.Provider value={methods}>
-      <View style={styles.container}>
+      <View style={[styles.container, styleProps]}>
         {children}
         {Array.from(portals, ([key, element]) => (
           <Fragment key={key}>{element}</Fragment>

--- a/packages/native/src/system/pressable-feedback/pressable-feedback-highlight.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback-highlight.tsx
@@ -15,8 +15,10 @@ import {
   resolveSlotAnimation,
 } from './pressable-feedback.animation'
 import type { SlotAnimation } from './pressable-feedback.type'
+import { useStyleProps } from '../style-props'
+import type { ViewStyleProps } from '../style-props'
 
-export type PressableFeedbackHighlightProps = {
+export type PressableFeedbackHighlightProps = ViewStyleProps & {
   style?: StyleProp<ViewStyle>
   animation?: SlotAnimation
   /**
@@ -55,8 +57,10 @@ export function PressableFeedbackHighlight({
   style,
   animation: override,
   children,
+  ...props
 }: PressableFeedbackHighlightProps) {
   const { isPressed, animation, progress, ink, corners } = useFeedback()
+  const [styleProps] = useStyleProps(props)
 
   const settings = resolveSlotAnimation(
     override,
@@ -75,6 +79,7 @@ export function PressableFeedbackHighlight({
     StyleSheet.absoluteFillObject,
     { backgroundColor: ink, pointerEvents: 'none' },
     corners,
+    styleProps,
     style,
   ]
 

--- a/packages/native/src/system/pressable-feedback/pressable-feedback-ripple.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback-ripple.tsx
@@ -12,8 +12,10 @@ import {
   rippleRadiusFor,
 } from './pressable-feedback.animation'
 import type { RippleWave as Wave, SlotAnimation } from './pressable-feedback.type'
+import { useStyleProps } from '../style-props'
+import type { ViewStyleProps } from '../style-props'
 
-export type PressableFeedbackRippleProps = {
+export type PressableFeedbackRippleProps = ViewStyleProps & {
   /** Applies to the wave itself, not to the container that clips it. */
   style?: StyleProp<ViewStyle>
   animation?: SlotAnimation
@@ -62,8 +64,13 @@ export function PressableFeedbackRipple({
   style,
   animation: override,
   children,
+  ...props
 }: PressableFeedbackRippleProps) {
   const { animation, waves, ink, corners } = useFeedback()
+  const [styleProps] = useStyleProps(props)
+  // Merged once here: the wave is what a caller sees, so a style prop reaches it the same
+  // way `style` does rather than landing on the container that clips it.
+  const waveStyle = [styleProps, style]
 
   const settings = resolveSlotAnimation(override, animation.ripple, RIPPLE_OPACITY)
   const [size, setSize] = useState({ width: 0, height: 0 })
@@ -100,7 +107,7 @@ export function PressableFeedbackRipple({
             center={{ x: size.width / 2, y: size.height / 2 }}
             color={ink}
             opacity={settings.opacity}
-            style={style}
+            style={waveStyle}
           />
         ))}
       </View>

--- a/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback.tsx
@@ -32,6 +32,7 @@ import {
   resolveAnimation,
 } from './pressable-feedback.animation'
 import { partitionOverlays } from './pressable-feedback.overlay'
+import { useStyleProps } from '../style-props'
 import { inkFor, radiusFrom } from './pressable-feedback.surface'
 import type {
   PressableFeedbackProps,
@@ -79,16 +80,27 @@ const AnimatedSlot = Animated.createAnimatedComponent(Slot)
  * is visible on it and a shape that matches it.
  */
 export const PressableFeedback = forwardRef<View, PressableFeedbackProps>(
-  function PressableFeedback({ animation, ...rest }, ref) {
+  function PressableFeedback({ animation, style, ...props }, ref) {
     const inheritedDisableAll = useContext(DisableAllContext)
     const resolved = resolveAnimation(animation, inheritedDisableAll)
+    // R14, resolved here rather than in each branch: merged into `style` before either of
+    // them sees it, so the ink and the corners an overlay reads off the surface include a
+    // `backgroundColor` or a `borderRadius` written as a prop.
+    const [styleProps, rest] = useStyleProps(props)
 
     // Two components, not one with a branch inside: hooks cannot be conditional, and
     // "animation={false} mounts no worklet" is only true if the Reanimated hooks are
     // never reached at all.
     const Feedback = resolved.none ? StaticFeedback : AnimatedFeedback
 
-    const body = <Feedback ref={ref} animation={resolved} {...rest} />
+    const body = (
+      <Feedback
+        ref={ref}
+        animation={resolved}
+        style={[styleProps, style]}
+        {...rest}
+      />
+    )
 
     return resolved.disableAll ? (
       <DisableAllContext.Provider value={true}>{body}</DisableAllContext.Provider>

--- a/packages/native/src/system/pressable-feedback/pressable-feedback.type.ts
+++ b/packages/native/src/system/pressable-feedback/pressable-feedback.type.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { PressableProps, StyleProp, ViewStyle } from 'react-native'
 import type { SharedValue } from 'react-native-reanimated'
+import type { ViewStyleProps } from '../style-props'
 
 export type AnimationConfig = {
   scale?: boolean
@@ -26,10 +27,16 @@ export type ResolvedAnimation = {
   disableAll: boolean
 }
 
+/**
+ * R14 — it renders a `Pressable`, so it takes that node's style keys as props. The
+ * primitive every pressable component in the library is built on cannot be the one place
+ * where `padding={16}` has to become an object again.
+ */
 export type PressableFeedbackProps = Omit<
   PressableProps,
   'style' | 'children' | 'disabled'
-> & {
+> &
+  ViewStyleProps & {
   /** Controlled: the root owns the state, because its recipe resolves on it (R5). */
   isPressed?: boolean
   /** R8: `disabled` is not part of the public vocabulary, `isX` is. */


### PR DESCRIPTION
> **Stacked on #200.** Base is `fix/p27-pressed-direction`; it retargets as the queue drains.

## What

R14 stops being the `Button`'s rule and becomes the library's. Everything that renders a node takes the style keys of that node:

| Renders | Node | Set |
| --- | --- | --- |
| `Button`, `Button.Spinner` | a view | `ViewStyleProps` |
| `Button.Label` | a `Text` | `TextStyleProps` |
| **`PressableFeedback`** | a `Pressable` | `ViewStyleProps` |
| **`PressableFeedback.Highlight` / `.Ripple`** | the overlay | `ViewStyleProps` |
| **`PortalHost`** | its container view | `ViewStyleProps` |
| **`Icon`** | an `Image` | `ImageStyleProps` |

```tsx
<PressableFeedback padding={12} borderRadius={16}>…</PressableFeedback>
<Icon source={logo} marginEnd={8} />
```

## Why

#197 shipped R14 on the `Button` and its slots. That left the primitive **every** pressable control in the library is built on without it — so the moment anyone writes their own XAUI component on `PressableFeedback`, they are back to opening a style object, and the rule reads as a `Button` feature rather than an API.

**There is no exception list, deliberately.** A list of which components have style props is exactly the list R14 says not to maintain. If it renders a node, it exposes that node's keys. The plan, `system/README.md` and both skills now state it that way rather than describing the Button's case.

## How

`useStyleProps` at the top of each, merged in the same position as everywhere else — after what the component resolved, before its own `style`.

**On `PressableFeedback` the split happens once, above the branch**, and merges into `style` before either branch reads it. That matters: the root flattens its own `style` to pick the ink an overlay contrasts against and the corners it rounds to. Splitting inside each branch would have left a `backgroundColor` written as a prop invisible to that computation, and the wash on such a control would have come out black on a saturated fill — visible only on screen, never in a type.

**`Icon` reaches its `source` form only**, exactly as far as its `style` already does. The other two forms hand props to a third-party component or clone the caller's element, so there is no node of ours to style; `size` and `color` stay the escape hatch there. That is the rule applied and not an exception to it — it says *the node the component renders*, and `Icon` renders one in three. `Button.Icon` inherits this, which is why the exception #197 documented for it is gone.

**One fix this surfaced.** `ButtonProps` omitted `keyof ButtonBehaviourProps` from its style props. Now that `PressableFeedback` carries them, that term would have removed every style prop from the `Button` — silently, since the props still arrived through the behaviour half. It omits only the button's own vocabulary now.

## Verification

The new demo tile in *PressableFeedback (v1)* is **styled without a single `style` object** — height, padding, radius and background are all props — and it mounts a `Highlight`. If the wash is visible on it, the ink was computed from a background the caller never put in a style; if the merge order were wrong it would be black on purple.

Typed from a call site, `paddingLeft` and `fontSize` are rejected on `PressableFeedback` — R13's exclusion and the View/Text split hold on the primitives exactly as they do on the `Button`.

```
pnpm turbo run lint type-check test --filter=docs --filter=@xaui/*   15/15
pnpm --filter demo exec tsc --noEmit                                 clean
pnpm perf:button                                                     9/9 — the baseline does not move
```

- [ ] **The demo screens, by you** — *Style props — R14* on the PressableFeedback screen, light and dark.

## About #186

This PR is also the answer to it. #186 specifies the opposite API — a **closed set of abbreviations** (`p`, `px`, `mt`, `gap`) whose value is a *step on the spacing scale*. #187 replaced that with full RN names and full RN values, and #197 implemented that version; the tree is correct today because #187 sits on top of #186. But #186's own instruction still teaches the abbreviations, and it is still an open PR. It should not merge as written — see the note in the thread.
