### PR TITLE
fix(release): the chip and alert changesets no longer name the frozen package

### DIFF
--- a/.changeset/alert-v1.md
+++ b/.changeset/alert-v1.md
@@ -1,6 +1,5 @@
 ---
 '@xaui/native': patch
-'@xaui/native-legacy': patch
 ---
 
 feat(alert): the v1 `Alert` — P3.6

--- a/.changeset/chip-v1.md
+++ b/.changeset/chip-v1.md
@@ -1,6 +1,5 @@
 ---
 '@xaui/native': patch
-'@xaui/native-legacy': patch
 ---
 
 feat(chip): the v1 `Chip` — P3.5


### PR DESCRIPTION
## What

`.changeset/alert-v1.md` and `.changeset/chip-v1.md` stop naming `@xaui/native-legacy`.

## Why

The release workflow has been failing since #216:

```
error Found mixed changeset alert-v1
error Found ignored packages: @xaui/native-legacy
error Found not ignored packages: @xaui/native
error Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`@xaui/native-legacy` sits in `ignore` (`.changeset/config.json`) because it is frozen at
`0.2.11`, and changesets refuses a changeset that names an ignored package alongside a
released one. Both of these named it without either PR touching a line of that package —
the entry was habit, not a release.

`alert-v1` is the one the run reports because it is read first; `chip-v1` carries the same
line and would fail the next run, so both go.

## Verification

`changeset version` locally: clean, no error. `@xaui/native` → `0.9.1-alpha.22`,
`@xaui/hybrid` → `0.9.1-alpha.3`, `@xaui/native-legacy` still `0.2.11`. The generated
bumps were discarded — the workflow produces them itself on `changeset-release/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
