### PR TITLE
refactor(surface): tertiary is an edge, and ghost is gone

### DIFF
--- a/.changeset/surface-v1.md
+++ b/.changeset/surface-v1.md
@@ -11,11 +11,16 @@ them out again. It is the smallest thing here and the most reused.
 **It is not a `Card`.** A card has decided things for you — it is always lifted, it has a
 header and a footer, and its levels carry an emphasis. A surface has decided nothing.
 
-**A ladder, not four emphases.** `primary` sits on the page, `secondary` inside a `primary`,
-`tertiary` inside a `secondary`, and each is a token the theme already names — so a nest is
-legible in both modes without anyone choosing greys. Three is as deep as that reading
-survives; a fourth would be a shade nobody could place. `ghost` at the end is not a level
-but the absence of one.
+**A ladder, not three emphases.** `primary` sits on the page, `secondary` inside a
+`primary`, `tertiary` inside a `secondary`, and each names tokens the theme already states
+per mode — so a nest is legible in light and in dark without anyone choosing greys. Three is
+as deep as that reading survives; a fourth would be a shade nobody could place.
+
+**`tertiary` is an edge rather than a third grey.** Below a `secondary` there is no grey
+left that still reads as a level, so it takes the page's own `background` and draws itself
+with a `border` — which lands darker than its ground in light and lighter than it in dark,
+from the tokens alone. There is no `ghost`: a surface with no ground is not a surface, and
+padding and a corner are already style props.
 
 **Elevation is asked for rather than tied to the variant**, and defaults to true for
 `primary` alone: a shadow under a ground that barely differs from the page reads as dirt

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -3,7 +3,7 @@ import { Surface } from '@xaui/native/surface'
 import type { SurfaceSize, SurfaceVariant } from '@xaui/native/surface'
 import { useXAUITheme } from '@xaui/native/theme'
 
-const VARIANTS: SurfaceVariant[] = ['primary', 'secondary', 'tertiary', 'ghost']
+const VARIANTS: SurfaceVariant[] = ['primary', 'secondary', 'tertiary']
 const SIZES: SurfaceSize[] = ['xs', 'sm', 'md', 'lg']
 
 /**
@@ -19,8 +19,8 @@ export default function SurfaceScreen() {
       contentContainerStyle={{ padding: 16, gap: 28, paddingBottom: 96 }}
     >
       <Section
-        title="A ladder, not four emphases"
-        note="primary sits on the page, secondary inside a primary, tertiary inside a secondary. A surface reports nothing — it is the thing other reporting sits on — so the levels say where something belongs rather than how loud it is. ghost at the end is not a level but the absence of one, for a Surface used only for its padding and its corner."
+        title="A ladder, not three emphases"
+        note="primary sits on the page, secondary inside a primary, tertiary inside a secondary. A surface reports nothing — it is the thing other reporting sits on — so the levels say where something belongs rather than how loud it is. Posée à même la page, la tertiary partage son fond : seule la bordure la dessine, ce qui est la variante qui marche et non un bug."
       >
         {VARIANTS.map(variant => (
           <Surface key={variant} variant={variant}>
@@ -31,7 +31,7 @@ export default function SurfaceScreen() {
 
       <Section
         title="Nested, which is the whole point"
-        note="Three levels is as deep as the reading survives — a fourth would be a shade nobody could place. Each level is a token the theme already names, so a nest is legible in both modes without anyone choosing greys."
+        note="Three levels is as deep as the reading survives — a fourth would be a shade nobody could place. Sous une secondary il ne reste aucun gris qui se lise encore comme un niveau : la tertiary reprend le fond de la page et se dessine à la bordure. Les deux sont des tokens que le thème énonce par mode, donc l'arête tombe plus sombre que le fond en light et plus claire en dark — à vérifier ici dans les deux modes."
       >
         <Surface>
           <Label>primary</Label>
@@ -77,8 +77,12 @@ export default function SurfaceScreen() {
         <Surface color="#7c3aed">
           <Label>teintée</Label>
         </Surface>
-        <Surface variant="ghost" borderWidth={1} borderColor={theme.colors.border}>
-          <Label>ghost, bordée en style props</Label>
+        <Surface
+          variant="secondary"
+          borderWidth={1}
+          borderColor={theme.colors.separator}
+        >
+          <Label>secondary, bordée en style props</Label>
         </Surface>
       </Section>
     </ScrollView>

--- a/packages/native/src/components/surface/surface.md
+++ b/packages/native/src/components/surface/surface.md
@@ -30,20 +30,35 @@ A surface has decided nothing: the levels are a ladder, the shadow is asked for,
 goes on it is entirely yours. Reach for a card when the thing is a card; reach for a surface
 when you need a ground.
 
-## A ladder, not four emphases
+## A ladder, not three emphases
 
-| variant     | fill               | typical place              |
-| ----------- | ------------------ | -------------------------- |
-| `primary`   | `surface`          | on the page                |
-| `secondary` | `surfaceSecondary` | inside a `primary`         |
-| `tertiary`  | `surfaceTertiary`  | inside a `secondary`       |
-| `ghost`     | none               | padding and a corner alone |
+| variant     | fill               | edge     | typical place        |
+| ----------- | ------------------ | -------- | -------------------- |
+| `primary`   | `surface`          | —        | on the page          |
+| `secondary` | `surfaceSecondary` | —        | inside a `primary`   |
+| `tertiary`  | `background`       | `border` | inside a `secondary` |
 
 A surface reports nothing — it is the thing other reporting sits on — so the levels say
 **where** something belongs rather than how loud it is. Three is as deep as that reading
 survives; a fourth would be a shade nobody could place.
 
-`ghost` is not a level but the absence of one.
+### `tertiary` is an edge, not a third grey
+
+It takes the page's own `background` and draws itself with a `border`. Below a `secondary`
+there is no grey left that still reads as a level, so what marks the level is the line.
+
+Both are tokens the theme states per mode, so the edge lands **darker than the ground in
+light and lighter than it in dark** — `#fafafa` inside `#e4e4e7`, `#09090b` inside
+`#27272a` — with no branch written in the recipe.
+
+Two consequences to know. A `tertiary` sitting _directly_ on the page shares its fill, so
+only the border draws it — the variant working rather than a bug, since it is meant for
+inside a `secondary`, where the fill also reads as a step back down.
+
+And a **tinted** `tertiary` loses its edge: `color` lands where the variant put its tokens,
+and here that is the fill _and_ the border, so both come back the same colour. A tinted
+surface is a filled surface at every level — reach for `borderColor` as a style prop if you
+want the edge to survive the tint.
 
 ## Props
 
@@ -62,7 +77,7 @@ ground: how tall it is, is how tall what is on it is.
 ## Elevation is asked for
 
 `isElevated` defaults to **true for `primary` only**. A shadow under a ground that barely
-differs from the page reads as dirt rather than as height, so the quieter three are flat
+differs from the page reads as dirt rather than as height, so the quieter two are flat
 until you say otherwise.
 
 That is the second thing separating this from a `Card`, which is always lifted. Whether a

--- a/packages/native/src/components/surface/surface.recipe.ts
+++ b/packages/native/src/components/surface/surface.recipe.ts
@@ -6,18 +6,20 @@ import type { SurfaceSlot, SurfaceVariant } from './surface.type'
 const SLOTS = ['root'] as const
 
 /**
- * The three surface levels the theme already names, plus nothing.
- *
- * They descend rather than compete: `primary` sits on the page, `secondary` inside a
+ * The three levels, descending: `primary` sits on the page, `secondary` inside a
  * `primary`, `tertiary` inside a `secondary`. That is the whole vocabulary — a fourth
- * level would be a shade nobody could place, and the `ghost` at the end is not a level but
- * the absence of one, for a `Surface` used only for its padding and its corner.
+ * level would be a shade nobody could place.
+ *
+ * **`tertiary` is an edge rather than a third grey.** It takes the page's own
+ * `background` and names a `border`, so what draws it is the line and not the fill: two
+ * tokens the theme states per mode, which is why the edge lands darker than the ground in
+ * light and lighter than it in dark with no branch written here. Below a `secondary`
+ * there is no grey left that reads as a level — there is only an outline.
  */
 const VARIANT_TOKENS: Record<SurfaceVariant, VariantTokens> = {
   primary: { bg: 'surface', fg: 'surfaceForeground' },
   secondary: { bg: 'surfaceSecondary', fg: 'surfaceSecondaryForeground' },
-  tertiary: { bg: 'surfaceTertiary', fg: 'surfaceTertiaryForeground' },
-  ghost: { fg: 'foreground' },
+  tertiary: { bg: 'background', fg: 'foreground', border: 'border' },
 }
 
 type SizeStep = { padding: number; gap: number; radius: RadiusKey }
@@ -54,7 +56,14 @@ export const surfaceRecipe = createRecipe({
 
   variantTokens: VARIANT_TOKENS,
 
-  paint: (_theme, colors) => ({ root: { backgroundColor: colors.bg } }),
+  /** Only `tertiary` names a border, so only `tertiary` gets a width to draw it with. */
+  paint: (theme, colors) => ({
+    root: {
+      backgroundColor: colors.bg,
+      borderColor: colors.border,
+      borderWidth: colors.border ? theme.borderWidth.default : 0,
+    },
+  }),
 
   variants: {
     size: {

--- a/packages/native/src/components/surface/surface.type.ts
+++ b/packages/native/src/components/surface/surface.type.ts
@@ -6,14 +6,14 @@ import type { RadiusKey, Size } from '../../theme/theme.type'
 export type SurfaceSlot = 'root'
 
 /**
- * Four grounds, descending. `primary` is the theme's surface, `secondary` and `tertiary`
- * the two under it, `ghost` nothing at all.
+ * Three grounds. `primary` is the theme's surface, `secondary` the level under it, and
+ * `tertiary` the page's own ground drawn by an edge rather than by a fill.
  *
  * It is a **ladder rather than an intent**: a surface reports nothing, it is the thing
  * other reporting sits on. Stacking one on another is how a layout says "this belongs
  * inside that", and three levels is as deep as that reading survives.
  */
-export type SurfaceVariant = 'primary' | 'secondary' | 'tertiary' | 'ghost'
+export type SurfaceVariant = 'primary' | 'secondary' | 'tertiary'
 
 export type SurfaceSize = Size
 
@@ -27,7 +27,7 @@ type SurfaceOwnProps = {
   /**
    * Whether the ground is lifted off what is behind it.
    *
-   * `primary` is by default and the quieter three are not: a shadow under a ground that
+   * `primary` is by default and the other two are not: a shadow under a ground that
    * barely differs from the page reads as dirt rather than as height.
    */
   isElevated?: boolean


### PR DESCRIPTION
## What

Two changes to the `Surface` variant vocabulary, which lands before it ships — the
`surface-v1` changeset is still pending on `main` (the `alpha.46` tag predates its merge),
so its release note is corrected in place rather than followed by a second one.

- **`ghost` is removed.** `SurfaceVariant` is now `'primary' | 'secondary' | 'tertiary'`.
- **`tertiary` stops being a third grey.** It takes the page's own `background` and draws
  itself with a `border`:

```ts
tertiary: { bg: 'background', fg: 'foreground', border: 'border' },
```

`paint` gains the border the way `Card` already does it — `borderWidth: colors.border ?
theme.borderWidth.default : 0`, so only the variant that names an edge gets a width to
draw it with.

## Why

`ghost` was not a level but the absence of one. A surface with no ground is not a surface,
and the padding and the corner it was kept for are already style props (R14) — the demo's
own example wrote `variant="ghost" borderWidth={1} borderColor={…}`, which is the
admission that the variant carried nothing.

Below a `secondary` there is no grey left that still reads as a level. `surfaceTertiary`
was `#e4e4e7`, one step from `#ececee` and indistinguishable in place. What marks that
level is the line, not the shade.

## How it holds in both modes

`background` and `border` are tokens the theme states per mode, so the edge lands darker
than its ground in light and lighter than it in dark **with no branch written in the
recipe**. Verified by rendering the demo screen, not by reading the tokens:

| mode  | fill      | edge      |
| ----- | --------- | --------- |
| light | `#fafafa` | `#e4e4e7` |
| dark  | `#09090b` | `#27272a` |

The two situations are drawn by different means, which is the happy part: sitting directly
on the page the fill matches and the border traces it; nested in a `secondary` the border
merges with the parent in dark, and the fill separates it instead.

## Two consequences, both documented

- A `tertiary` **on the page** shares its fill — only the border draws it. The variant
  working, not a bug; it is meant for inside a `secondary`.
- A **tinted** `tertiary` loses its edge: `color` lands where the variant put its tokens,
  and here that is the fill *and* the border, so both come back the same colour. Consistent
  with every other level — a tinted surface is a filled surface — and `borderColor` as a
  style prop is the way out.

`surfaceTertiary` / `surfaceTertiaryForeground` are now read by no component (`Card.tertiary`
was already a border without a fill). The tokens stay in the theme.

## Gates

- `pnpm type-check` — green.
- `pnpm test` — green, 261 tests.
- `pnpm lint` — green except 5 pre-existing `react/no-unescaped-entities` errors in
  `apps/demo/app/popover.tsx` and `select.tsx`, both outside this diff.
- Demo screen rendered in **light and dark**: the `tertiary` root carries the fill, the
  four border colours and the 1px width in both.