### PR TITLE
feat(stepper): where you are in a sequence of steps

### DIFF
--- a/.changeset/stepper-v1.md
+++ b/.changeset/stepper-v1.md
@@ -1,0 +1,46 @@
+---
+'@xaui/native': patch
+---
+
+`Stepper` — where you are in a sequence of steps.
+
+**The value is the caller's, always.** There is no `defaultValue` and no `onValueChange`,
+because nothing inside a stepper can move it: a step is not a control, it is a report. The
+number comes from the form, the wizard or the route that actually knows, and an
+uncontrolled stepper would be a piece of state that could never change. It counts from one,
+so `value={2}` is "step 2 of 4" — the number you would say out loud rather than an index.
+
+**The root numbers its children.** An item declares no index and no key: JSX order is step
+order, so inserting a step in the middle renumbers the rest by being there. It is the
+reasoning that puts the `Accordion`'s separators on its root — what an item cannot know
+about its neighbours belongs to the thing that has them all.
+
+**Three statuses, and they are an order.** Every step before the current one is completed
+and every step after it is upcoming. A completed step keeps its full contrast — it is a
+thing you did, not a thing greyed out — and what recedes is the road ahead. The line under
+the current step is still track: the stepper has not left that step yet.
+
+**Two orientations that differ by more than the axis.** `vertical` puts the indicator beside
+the text and aligned to the top of it, with the line running down through whatever height
+that text takes; it is the layout that can carry a description at all. `horizontal` centres
+each indicator over its label and gives every step the same width, so the circles land at
+even intervals whatever the labels say.
+
+**The connectors belong to the indicator rather than to the root**, which is the opposite of
+the `Accordion`'s separators: a vertical line has to run from under one circle to the next
+through the text beside it, and only something inside that row can measure that height. A
+horizontal step carries two halves, one either side, so its circle stays centred over its
+label — and the two ends of the rail are drawn transparent rather than dropped, or the first
+and last circles would slide off theirs.
+
+**A step is not pressable**, and that is `asChild`'s job rather than a prop. A stepper where
+a completed step takes you back is one composition away; one where tapping ahead skips a
+form's validation is not something this component should make easy.
+
+`color` paints the **progress and not the track**: the travelled line, the ring around the
+step you are on, the disc behind the ones you are past. The road ahead stays grey, because
+the untravelled track is written from the theme rather than named as a role.
+
+The tick a completed step draws moves to `utils/check-glyph`, shared with the `Checkbox`:
+two borders of an empty box a quarter turn from where they look like one, so both work in a
+project that has installed no icon set.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -4,158 +4,160 @@ One line per task: ref, title, status. No commentary — update the status when 
 Task detail lives in `XAUI-V1-PLAN.md`.
 
 Status is `done` or `todo`, plus `ci`: everything in the repository is done and the
-remaining action belongs to a workflow rather than to a commit.
+remaining action belongs to a workflow rather than to a commit. A task can also be
+`dropped` — decided against rather than deferred, and kept on the list so the decision is
+recorded rather than rediscovered.
 
 `P*` refs follow the phases of the plan. `D*` refs are repository debt — they belong to no
 phase and block nothing, but each one is a place where the repo lies about itself.
 
 ## Phases
 
-| Ref    | Task                                                                             | Status |
-| ------ | -------------------------------------------------------------------------------- | ------ |
-| P0.1   | Split into `@xaui/native-legacy` and scaffold v1                                 | done   |
-| P0.2   | Single token source and generator                                                | done   |
-| P0.3   | OKLab colour engine                                                              | done   |
-| P0.4   | Derived colour layer                                                             | done   |
-| P0.5   | Contrast guard in CI                                                             | done   |
-| P0.6   | `createTheme`                                                                    | done   |
-| P0.7   | `XAUIProvider`                                                                   | done   |
-| P0.8   | Legacy `core-shim.ts`                                                            | done   |
-| P0.9   | Package hygiene and optional peers                                               | done   |
-| P0.10  | ESLint rule for R13                                                              | done   |
-| P0.11  | Publish `@xaui/native-legacy@0.2.11` and the codemod                             | done   |
-| P0.12  | Delete `@xaui/core` and `@xaui/icons`                                            | done   |
-| P0.13  | Publish `native` and `hybrid` on the `alpha` tag                                 | done   |
-| P1.1   | `system/recipe/` — engine, cache, tint                                           | done   |
-| P1.2   | `system/slot/` — context, `childrenToString`, merges                             | done   |
-| P1.3   | `system/pressable-feedback/`                                                     | done   |
-| P1.4   | `system/portal/`                                                                 | done   |
-| P1.5   | `system/icon/`                                                                   | done   |
-| P1.6   | Shared hooks                                                                     | done   |
-| P1.7   | `pnpm pack` uniqueness check on both packages                                    | done   |
-| P2     | The reference component and the API review                                       | done   |
-| P2.1   | The reference `Button`                                                           | done   |
-| P2.2   | Perf baseline — 200 buttons, re-renders and allocations                          | done   |
-| P2.3   | API review — blocking, nothing starts in P3 before it                            | done   |
-| P2.4   | Publish `@xaui/native` on the `alpha` tag                                        | ci     |
-| P2.5   | Fix the ripple — it renders nothing (P2-API-REVIEW §D)                           | done   |
-| P2.5b  | `PressableFeedback` composes its overlays — no `feedbackVariant`                 | done   |
-| P2.6   | Style as props (R14) — `system/style-props/`, then the `Button`                  | done   |
-| P2.7   | `*Pressed` moves one way — towards the mode ink (P2-API-REVIEW §E)               | done   |
-| P2.7b  | `asChild` reached `Slot` as an array — every pressable threw                     | done   |
-| P2.7c  | Light `default` reads as grey, not as near-white                                 | done   |
-| P2.7d  | `warning` moves from `amber` to `orange` — the dark one read as gold             | done   |
-| P3     | The fifteen-component core                                                       | done   |
-| P3.1   | `Typography` + `TextSpan` — ten roles, HeroUI's values                           | done   |
-| P3.2   | `Icon` — R14's boundary in the type, plus its demo screen                        | done   |
-| P3.3   | `view/` — `Row`, `Column`, `Stack`, `Grid`; the rest dropped                     | done   |
-| P3.4   | `Card` — Header · Body · Title · Description · Footer                            | done   |
-| P3.5   | `Chip` — Label · Icon · Dot · Avatar · Close                                     | done   |
-| P3.6   | `Alert` — Icon · Content · Title · Description · Close                           | done   |
-| P3.7   | `Input` — Label · Field · Description · Error                                    | done   |
-| P3.7b  | Rename `Input` → `TextField` — component, `./text-field` subpath, demo           | done   |
-| P3.8   | `Checkbox` — Indicator · Label                                                   | done   |
-| P3.9   | `Radio` — Indicator · Label, the `Checkbox` in a circle                          | done   |
-| P3.10  | `Switch` — Track · Thumb · Label, two shapes                                     | done   |
-| P3.11  | `Avatar` — Image · Fallback · Initials, the fallback as a layer                  | done   |
-| P3.12  | `Badge` — a count, a dot, and the corner it hangs off                            | done   |
-| P3.13  | `Divider` — three separator levels; keeps its name, not HeroUI's `Separator`     | done   |
-| P3.14  | `Skeleton` — one fill, one pulse, sized by R14 alone                             | done   |
-| P3.14b | `Skeleton` drops its `variant` — the second fill was the less visible            | done   |
-| P3.15  | `Spinner` — seven inks, two rings, no SVG; supersedes legacy `Indicator`         | done   |
-| P4     | Docs, generated tables, `1.0.0`                                                  | todo   |
-| P4.1   | Live previews — alias `react-native` → `react-native-web` in Next.js             | todo   |
-| P4.2   | Prop tables generated from the TS types                                          | todo   |
-| P4.3   | The fifteen pages, on the structure of plan §6                                   | todo   |
-| P4.4   | Migration guide legacy → v1, with the table of plan §7                           | todo   |
-| P4.5   | Regenerate `llms.txt`, unpublish `@xaui/mcp` and `@xaui/icons`                   | todo   |
-| P4.6   | Publish `@xaui/native@1.0.0` — needs `changeset pre exit` first                  | todo   |
-| P5     | The remaining components, shipped under `1.x`                                    | todo   |
-| P5.1   | `InputOTP` — Group · Box · Value · Placeholder · Caret · Separator               | done   |
-| P5.2   | `TextArea` — Label · Field · Description · Error, over the `Input`               | done   |
-| P5.3   | `InputGroup` — Prefix · Field · Suffix · Icon, inside the `Input`                | done   |
-| P5.3b  | Rename `InputGroup` → `FieldGroup`, following `TextField`                        | done   |
-| P5.3c  | `NumberInput` — over legacy `NumberInput`, inside `input/`                       | todo   |
-| P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share             | todo   |
-| P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not            | todo   |
-| P5.3f  | `PhoneNumberInput` — net new, country prefix over the `TextField`                | todo   |
-| P5.3g  | `SearchInput` — net new, a `TextField` with its clear and submit                 | todo   |
-| P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                | done   |
-| P5.5   | `Stepper` — slots over the existing group context                                | todo   |
-| P5.6   | `Toolbar` — slots over the existing group context                                | todo   |
-| P5.7   | `List` — slots over the existing group context                                   | todo   |
-| P5.7b  | `ListGroup` — net new, sectioned `List` with its headers                         | todo   |
-| P5.8   | `Menu` — Trigger · Overlay · Content · Label · Group · Item                      | done   |
-| P5.9   | `SegmentButton` — slots over the existing group context                          | todo   |
-| P5.10  | `Autocomplete` — slots over the existing group context                           | todo   |
-| P5.10b | `Combobox` — the `Autocomplete` over a closed list                               | todo   |
-| P5.11  | `Accordion` — Item · Trigger · Indicator · Content, over legacy `ExpansionPanel` | done   |
-| P5.12  | `BottomTabBar` — slots over the existing group context                           | todo   |
-| P5.13  | `Menubox` — slots over the existing group context                                | todo   |
-| P5.14  | `Progress` — circular, the determinate half of legacy `Indicator`                | todo   |
-| P5.14b | `ProgressBar` — linear, over legacy `LinearProgressIndicator`                    | todo   |
-| P5.15  | `Slider` — Output · Track · Fill · Thumb                                         | done   |
-| P5.16  | `Tabs` — List · Trigger · Label · Indicator · Content                            | done   |
-| P5.17  | `AppBar`                                                                         | todo   |
-| P5.18  | `Snackbar` — closed by P5.18b `Toast`, the same object renamed                   | done   |
-| P5.18b | `Toast` — Title · Description · Actions · Close, plus `ToastHost`                | done   |
-| P5.19  | `Snippet`                                                                        | todo   |
-| P5.20  | `Fab`                                                                            | todo   |
-| P5.21  | `FabMenu`                                                                        | todo   |
-| P5.22  | `Dialog` — Trigger · Overlay · Content · Title · Description · Close             | done   |
-| P5.23  | `BottomSheet` — Trigger · Overlay · Content · Handle · Title                     | done   |
-| P5.23b | `BottomSheetInput` — net new, a `TextField` that opens in a `BottomSheet`        | todo   |
-| P5.24  | `Drawer`                                                                         | todo   |
-| P5.24b | `Popover` — Trigger · Overlay · Content · Title · Description · Close            | done   |
-| P5.25  | `Picker`                                                                         | todo   |
-| P5.25b | `WheelPicker` — net new, the spinning column the three below share               | todo   |
-| P5.25c | `WheelDatePicker` — net new, `WheelPicker` columns for a date                    | todo   |
-| P5.25d | `WheelTimePicker` — net new, `WheelPicker` columns for a time                    | todo   |
-| P5.25e | `WheelDateTimePicker` — net new, the two above as one                            | todo   |
-| P5.26  | `DatePicker`                                                                     | todo   |
-| P5.26b | `Calendar` — net new, no legacy equivalent                                       | todo   |
-| P5.26c | `AgendaCalendar` — net new, the `Calendar` with its events                       | todo   |
-| P5.26d | `DateInput` — over legacy `DateInput`, with `TimeInput` and `DateTimeInput`      | todo   |
-| P5.26e | `DateRangePicker` — net new, two bounds over the `DatePicker`                    | todo   |
-| P5.26f | `DateTimePicker` — net new, `DatePicker` and `TimePicker` as one                 | todo   |
-| P5.26g | `RangeCalendar` — net new, the `Calendar` behind `DateRangePicker`               | todo   |
-| P5.27  | `TimePicker`                                                                     | todo   |
-| P5.28  | `ColorPicker`                                                                    | todo   |
-| P5.29  | `Carousel`                                                                       | todo   |
-| P5.30  | `Pager`                                                                          | todo   |
-| P5.31  | `RefreshControl`                                                                 | todo   |
-| P5.32  | `InputTrigger`                                                                   | todo   |
-| P5.33  | `FeatureDiscovery`                                                               | todo   |
-| P5.34  | `BarChart` — over legacy `VerticalBarChartCard`                                  | todo   |
-| P5.34b | `AreaChart` — net new, no legacy equivalent                                      | todo   |
-| P5.34c | `Chart` — Donut and Heatmap, the legacy cards left over                          | todo   |
-| P5.34d | `ComposedChart` — net new, several series on shared axes                         | todo   |
-| P5.34e | `LineChart` — over legacy `LineChartCard`                                        | todo   |
-| P5.34f | `PieChart` — over legacy `PieChartCard`                                          | todo   |
-| P5.34g | `RadarChart` — net new, no legacy equivalent                                     | todo   |
-| P5.34h | `RadialChart` — net new, no legacy equivalent                                    | todo   |
-| P5.35  | `CloseButton` — net new, the dismiss affordance Chip and Alert inline today      | todo   |
-| P5.35b | `LinkButton` — net new, a `Button` that reads as a link                          | todo   |
-| P5.35c | `MorphButton` — net new, a `Button` that animates between states                 | todo   |
-| P5.35d | `SlideButton` — net new, slide-to-confirm over the `Slider`                      | todo   |
-| P5.35e | `SocialAuthButton` — net new, provider marks over the `Button`                   | todo   |
-| P5.35f | `ToggleButton` — net new, a `Button` that holds a pressed state                  | todo   |
-| P5.35g | `ToggleButtonGroup` — net new, exclusive selection over `ToggleButton`           | todo   |
-| P5.36  | `EmptyState` — net new, no legacy equivalent                                     | todo   |
-| P5.37  | `FlipCard` — net new, a `Card` with two faces                                    | todo   |
-| P5.38  | `RadioGroup` — over legacy `RadioGroup`, the context P3.9 `Radio` lacks          | todo   |
-| P5.38b | `RadioButton` — net new, to reconcile with P3.9 `Radio`                          | todo   |
-| P5.38c | `RadioButtonGroup` — net new, to reconcile with `RadioGroup`                     | todo   |
-| P5.39  | `Rating` — net new, no legacy equivalent                                         | todo   |
-| P5.40  | `Surface` — four grounds, elevation asked for, no slots                          | done   |
-| P5.41  | `SplitView` — net new, a `view/` split on a draggable divider                    | todo   |
-| P5.42  | `Table` — net new, no legacy equivalent                                          | todo   |
-| P5.43  | `TagGroup` — List · Item · ItemLabel · ItemRemoveButton                          | done   |
-| P5.44  | `Timeline` — net new, no legacy equivalent                                       | todo   |
-| P5.45  | `Widget` — net new, no legacy equivalent                                         | todo   |
-| P5.46  | Parity milestone — `npm deprecate @xaui/native-legacy`                           | todo   |
-| P6     | `@xaui/hybrid` on the v1 API — frozen until P4 ships                             | todo   |
-| P7     | Delete `native-legacy` — not before the P5 parity milestone                      | todo   |
+| Ref    | Task                                                                             | Status  |
+| ------ | -------------------------------------------------------------------------------- | ------- |
+| P0.1   | Split into `@xaui/native-legacy` and scaffold v1                                 | done    |
+| P0.2   | Single token source and generator                                                | done    |
+| P0.3   | OKLab colour engine                                                              | done    |
+| P0.4   | Derived colour layer                                                             | done    |
+| P0.5   | Contrast guard in CI                                                             | done    |
+| P0.6   | `createTheme`                                                                    | done    |
+| P0.7   | `XAUIProvider`                                                                   | done    |
+| P0.8   | Legacy `core-shim.ts`                                                            | done    |
+| P0.9   | Package hygiene and optional peers                                               | done    |
+| P0.10  | ESLint rule for R13                                                              | done    |
+| P0.11  | Publish `@xaui/native-legacy@0.2.11` and the codemod                             | done    |
+| P0.12  | Delete `@xaui/core` and `@xaui/icons`                                            | done    |
+| P0.13  | Publish `native` and `hybrid` on the `alpha` tag                                 | done    |
+| P1.1   | `system/recipe/` — engine, cache, tint                                           | done    |
+| P1.2   | `system/slot/` — context, `childrenToString`, merges                             | done    |
+| P1.3   | `system/pressable-feedback/`                                                     | done    |
+| P1.4   | `system/portal/`                                                                 | done    |
+| P1.5   | `system/icon/`                                                                   | done    |
+| P1.6   | Shared hooks                                                                     | done    |
+| P1.7   | `pnpm pack` uniqueness check on both packages                                    | done    |
+| P2     | The reference component and the API review                                       | done    |
+| P2.1   | The reference `Button`                                                           | done    |
+| P2.2   | Perf baseline — 200 buttons, re-renders and allocations                          | done    |
+| P2.3   | API review — blocking, nothing starts in P3 before it                            | done    |
+| P2.4   | Publish `@xaui/native` on the `alpha` tag                                        | ci      |
+| P2.5   | Fix the ripple — it renders nothing (P2-API-REVIEW §D)                           | done    |
+| P2.5b  | `PressableFeedback` composes its overlays — no `feedbackVariant`                 | done    |
+| P2.6   | Style as props (R14) — `system/style-props/`, then the `Button`                  | done    |
+| P2.7   | `*Pressed` moves one way — towards the mode ink (P2-API-REVIEW §E)               | done    |
+| P2.7b  | `asChild` reached `Slot` as an array — every pressable threw                     | done    |
+| P2.7c  | Light `default` reads as grey, not as near-white                                 | done    |
+| P2.7d  | `warning` moves from `amber` to `orange` — the dark one read as gold             | done    |
+| P3     | The fifteen-component core                                                       | done    |
+| P3.1   | `Typography` + `TextSpan` — ten roles, HeroUI's values                           | done    |
+| P3.2   | `Icon` — R14's boundary in the type, plus its demo screen                        | done    |
+| P3.3   | `view/` — `Row`, `Column`, `Stack`, `Grid`; the rest dropped                     | done    |
+| P3.4   | `Card` — Header · Body · Title · Description · Footer                            | done    |
+| P3.5   | `Chip` — Label · Icon · Dot · Avatar · Close                                     | done    |
+| P3.6   | `Alert` — Icon · Content · Title · Description · Close                           | done    |
+| P3.7   | `Input` — Label · Field · Description · Error                                    | done    |
+| P3.7b  | Rename `Input` → `TextField` — component, `./text-field` subpath, demo           | done    |
+| P3.8   | `Checkbox` — Indicator · Label                                                   | done    |
+| P3.9   | `Radio` — Indicator · Label, the `Checkbox` in a circle                          | done    |
+| P3.10  | `Switch` — Track · Thumb · Label, two shapes                                     | done    |
+| P3.11  | `Avatar` — Image · Fallback · Initials, the fallback as a layer                  | done    |
+| P3.12  | `Badge` — a count, a dot, and the corner it hangs off                            | done    |
+| P3.13  | `Divider` — three separator levels; keeps its name, not HeroUI's `Separator`     | done    |
+| P3.14  | `Skeleton` — one fill, one pulse, sized by R14 alone                             | done    |
+| P3.14b | `Skeleton` drops its `variant` — the second fill was the less visible            | done    |
+| P3.15  | `Spinner` — seven inks, two rings, no SVG; supersedes legacy `Indicator`         | done    |
+| P4     | Docs, generated tables, `1.0.0`                                                  | todo    |
+| P4.1   | Live previews — alias `react-native` → `react-native-web` in Next.js             | todo    |
+| P4.2   | Prop tables generated from the TS types                                          | todo    |
+| P4.3   | The fifteen pages, on the structure of plan §6                                   | todo    |
+| P4.4   | Migration guide legacy → v1, with the table of plan §7                           | todo    |
+| P4.5   | Regenerate `llms.txt`, unpublish `@xaui/mcp` and `@xaui/icons`                   | todo    |
+| P4.6   | Publish `@xaui/native@1.0.0` — needs `changeset pre exit` first                  | todo    |
+| P5     | The remaining components, shipped under `1.x`                                    | todo    |
+| P5.1   | `InputOTP` — Group · Box · Value · Placeholder · Caret · Separator               | done    |
+| P5.2   | `TextArea` — Label · Field · Description · Error, over the `Input`               | done    |
+| P5.3   | `InputGroup` — Prefix · Field · Suffix · Icon, inside the `Input`                | done    |
+| P5.3b  | Rename `InputGroup` → `FieldGroup`, following `TextField`                        | done    |
+| P5.3c  | `NumberInput` — over legacy `NumberInput`, inside `input/`                       | todo    |
+| P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share             | todo    |
+| P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not            | todo    |
+| P5.3f  | `PhoneNumberInput` — net new, country prefix over the `TextField`                | todo    |
+| P5.3g  | `SearchInput` — net new, a `TextField` with its clear and submit                 | todo    |
+| P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                | done    |
+| P5.5   | `Stepper` — slots over the existing group context                                | done    |
+| P5.6   | `Toolbar` — slots over the existing group context                                | dropped |
+| P5.7   | `List` — slots over the existing group context                                   | todo    |
+| P5.7b  | `ListGroup` — net new, sectioned `List` with its headers                         | todo    |
+| P5.8   | `Menu` — Trigger · Overlay · Content · Label · Group · Item                      | done    |
+| P5.9   | `SegmentButton` — slots over the existing group context                          | todo    |
+| P5.10  | `Autocomplete` — slots over the existing group context                           | todo    |
+| P5.10b | `Combobox` — the `Autocomplete` over a closed list                               | todo    |
+| P5.11  | `Accordion` — Item · Trigger · Indicator · Content, over legacy `ExpansionPanel` | done    |
+| P5.12  | `BottomTabBar` — slots over the existing group context                           | dropped |
+| P5.13  | `Menubox` — slots over the existing group context                                | dropped |
+| P5.14  | `Progress` — circular, the determinate half of legacy `Indicator`                | todo    |
+| P5.14b | `ProgressBar` — linear, over legacy `LinearProgressIndicator`                    | todo    |
+| P5.15  | `Slider` — Output · Track · Fill · Thumb                                         | done    |
+| P5.16  | `Tabs` — List · Trigger · Label · Indicator · Content                            | done    |
+| P5.17  | `AppBar`                                                                         | todo    |
+| P5.18  | `Snackbar` — closed by P5.18b `Toast`, the same object renamed                   | done    |
+| P5.18b | `Toast` — Title · Description · Actions · Close, plus `ToastHost`                | done    |
+| P5.19  | `Snippet`                                                                        | todo    |
+| P5.20  | `Fab`                                                                            | todo    |
+| P5.21  | `FabMenu`                                                                        | todo    |
+| P5.22  | `Dialog` — Trigger · Overlay · Content · Title · Description · Close             | done    |
+| P5.23  | `BottomSheet` — Trigger · Overlay · Content · Handle · Title                     | done    |
+| P5.23b | `BottomSheetInput` — net new, a `TextField` that opens in a `BottomSheet`        | todo    |
+| P5.24  | `Drawer`                                                                         | todo    |
+| P5.24b | `Popover` — Trigger · Overlay · Content · Title · Description · Close            | done    |
+| P5.25  | `Picker`                                                                         | todo    |
+| P5.25b | `WheelPicker` — net new, the spinning column the three below share               | todo    |
+| P5.25c | `WheelDatePicker` — net new, `WheelPicker` columns for a date                    | todo    |
+| P5.25d | `WheelTimePicker` — net new, `WheelPicker` columns for a time                    | todo    |
+| P5.25e | `WheelDateTimePicker` — net new, the two above as one                            | todo    |
+| P5.26  | `DatePicker`                                                                     | todo    |
+| P5.26b | `Calendar` — net new, no legacy equivalent                                       | todo    |
+| P5.26c | `AgendaCalendar` — net new, the `Calendar` with its events                       | todo    |
+| P5.26d | `DateInput` — over legacy `DateInput`, with `TimeInput` and `DateTimeInput`      | todo    |
+| P5.26e | `DateRangePicker` — net new, two bounds over the `DatePicker`                    | todo    |
+| P5.26f | `DateTimePicker` — net new, `DatePicker` and `TimePicker` as one                 | todo    |
+| P5.26g | `RangeCalendar` — net new, the `Calendar` behind `DateRangePicker`               | todo    |
+| P5.27  | `TimePicker`                                                                     | todo    |
+| P5.28  | `ColorPicker`                                                                    | todo    |
+| P5.29  | `Carousel`                                                                       | todo    |
+| P5.30  | `Pager`                                                                          | todo    |
+| P5.31  | `RefreshControl`                                                                 | todo    |
+| P5.32  | `InputTrigger`                                                                   | todo    |
+| P5.33  | `FeatureDiscovery`                                                               | todo    |
+| P5.34  | `BarChart` — over legacy `VerticalBarChartCard`                                  | todo    |
+| P5.34b | `AreaChart` — net new, no legacy equivalent                                      | todo    |
+| P5.34c | `Chart` — Donut and Heatmap, the legacy cards left over                          | todo    |
+| P5.34d | `ComposedChart` — net new, several series on shared axes                         | todo    |
+| P5.34e | `LineChart` — over legacy `LineChartCard`                                        | todo    |
+| P5.34f | `PieChart` — over legacy `PieChartCard`                                          | todo    |
+| P5.34g | `RadarChart` — net new, no legacy equivalent                                     | todo    |
+| P5.34h | `RadialChart` — net new, no legacy equivalent                                    | todo    |
+| P5.35  | `CloseButton` — net new, the dismiss affordance Chip and Alert inline today      | todo    |
+| P5.35b | `LinkButton` — net new, a `Button` that reads as a link                          | todo    |
+| P5.35c | `MorphButton` — net new, a `Button` that animates between states                 | todo    |
+| P5.35d | `SlideButton` — net new, slide-to-confirm over the `Slider`                      | todo    |
+| P5.35e | `SocialAuthButton` — net new, provider marks over the `Button`                   | todo    |
+| P5.35f | `ToggleButton` — net new, a `Button` that holds a pressed state                  | todo    |
+| P5.35g | `ToggleButtonGroup` — net new, exclusive selection over `ToggleButton`           | todo    |
+| P5.36  | `EmptyState` — net new, no legacy equivalent                                     | todo    |
+| P5.37  | `FlipCard` — net new, a `Card` with two faces                                    | todo    |
+| P5.38  | `RadioGroup` — over legacy `RadioGroup`, the context P3.9 `Radio` lacks          | todo    |
+| P5.38b | `RadioButton` — net new, to reconcile with P3.9 `Radio`                          | todo    |
+| P5.38c | `RadioButtonGroup` — net new, to reconcile with `RadioGroup`                     | todo    |
+| P5.39  | `Rating` — net new, no legacy equivalent                                         | todo    |
+| P5.40  | `Surface` — four grounds, elevation asked for, no slots                          | done    |
+| P5.41  | `SplitView` — net new, a `view/` split on a draggable divider                    | todo    |
+| P5.42  | `Table` — net new, no legacy equivalent                                          | todo    |
+| P5.43  | `TagGroup` — List · Item · ItemLabel · ItemRemoveButton                          | done    |
+| P5.44  | `Timeline` — net new, no legacy equivalent                                       | todo    |
+| P5.45  | `Widget` — net new, no legacy equivalent                                         | todo    |
+| P5.46  | Parity milestone — `npm deprecate @xaui/native-legacy`                           | todo    |
+| P6     | `@xaui/hybrid` on the v1 API — frozen until P4 ships                             | todo    |
+| P7     | Delete `native-legacy` — not before the P5 parity milestone                      | todo    |
 
 ## Repository debt
 

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout() {
           <Stack.Screen name="skeleton" options={{ title: 'Skeleton (v1)' }} />
           <Stack.Screen name="slider" options={{ title: 'Slider (v1)' }} />
           <Stack.Screen name="spinner" options={{ title: 'Spinner (v1)' }} />
+          <Stack.Screen name="stepper" options={{ title: 'Stepper (v1)' }} />
           <Stack.Screen name="surface" options={{ title: 'Surface (v1)' }} />
           <Stack.Screen name="switch" options={{ title: 'Switch (v1)' }} />
           <Stack.Screen name="tabs" options={{ title: 'Tabs (v1)' }} />

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -38,6 +38,7 @@ const SCREENS = [
   { href: '/skeleton', label: 'Skeleton' },
   { href: '/slider', label: 'Slider' },
   { href: '/spinner', label: 'Spinner' },
+  { href: '/stepper', label: 'Stepper' },
   { href: '/surface', label: 'Surface' },
   { href: '/switch', label: 'Switch' },
   { href: '/tabs', label: 'Tabs' },

--- a/apps/demo/app/stepper.tsx
+++ b/apps/demo/app/stepper.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { Button } from '@xaui/native/button'
+import { Stepper } from '@xaui/native/stepper'
+import type { StepperSize } from '@xaui/native/stepper'
+import { useXAUITheme } from '@xaui/native/theme'
+
+const SIZES: StepperSize[] = ['xs', 'sm', 'md', 'lg']
+
+const STEPS = [
+  { title: 'Account', description: 'Create your account' },
+  { title: 'Profile', description: 'Set up your profile' },
+  { title: 'Settings', description: 'Configure preferences' },
+  { title: 'Review', description: 'Review and confirm' },
+]
+
+const CHECKOUT = ['Cart', 'Shipping', 'Payment']
+
+/**
+ * The verification screen for the `Stepper`. A component is verified here and in the docs
+ * preview, in light and in dark — there is no test file for it.
+ */
+export default function StepperScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 16, gap: 32, paddingBottom: 96 }}
+    >
+      <Section
+        title="Vertical, which is the layout that carries a description"
+        note="The indicator sits at the top of the text beside it, and the line runs down through whatever height that text takes — so the connector is the indicator's rather than the root's. A completed step keeps its full contrast: it is a thing you did, not a thing greyed out."
+      >
+        <Stepper value={2}>
+          {STEPS.map(step => (
+            <Stepper.Item key={step.title}>
+              <Stepper.Indicator />
+              <Stepper.Content>
+                <Stepper.Title>{step.title}</Stepper.Title>
+                <Stepper.Description>{step.description}</Stepper.Description>
+              </Stepper.Content>
+            </Stepper.Item>
+          ))}
+        </Stepper>
+      </Section>
+
+      <Controlled />
+
+      <Section
+        title="Horizontal centres each step over its label"
+        note="Every step gets the same width and carries a line on both sides of its circle, so the circles land at even intervals whatever the labels say. The two ends of the rail are drawn transparent rather than dropped — removing them would slide the first and last circles off their labels."
+      >
+        <Stepper orientation="horizontal" value={1}>
+          {CHECKOUT.map(label => (
+            <Stepper.Item key={label}>
+              <Stepper.Indicator />
+              <Stepper.Content>
+                <Stepper.Title>{label}</Stepper.Title>
+              </Stepper.Content>
+            </Stepper.Item>
+          ))}
+        </Stepper>
+      </Section>
+
+      <Section
+        title="Sizes move the indicator and the type"
+        note="Never a width. A vertical stepper is as wide as its parent lets it be and a horizontal one splits that width evenly, which is RN's own behaviour and the reason there is no fullWidth prop here either."
+      >
+        {SIZES.map(size => (
+          <View key={size} style={{ gap: 8 }}>
+            <Label>{size}</Label>
+            <Stepper orientation="horizontal" size={size} value={2}>
+              {CHECKOUT.map(step => (
+                <Stepper.Item key={step}>
+                  <Stepper.Indicator />
+                  <Stepper.Content>
+                    <Stepper.Title>{step}</Stepper.Title>
+                  </Stepper.Content>
+                </Stepper.Item>
+              ))}
+            </Stepper>
+          </View>
+        ))}
+      </Section>
+
+      <Section
+        title="A tint paints the progress, not the track"
+        note="color is a raw value, never a token. It moves the travelled line, the ring around the step you are on and the disc behind the ones you are past — and leaves the road ahead grey, which is the whole point of showing progress."
+      >
+        <Stepper color="#15803d" value={3}>
+          {STEPS.slice(0, 3).map(step => (
+            <Stepper.Item key={step.title}>
+              <Stepper.Indicator />
+              <Stepper.Content>
+                <Stepper.Title>{step.title}</Stepper.Title>
+                <Stepper.Description>{step.description}</Stepper.Description>
+              </Stepper.Content>
+            </Stepper.Item>
+          ))}
+        </Stepper>
+      </Section>
+
+      <Section
+        title="Without the rail, and with a step of your own"
+        note="hasConnector={false} leaves the circles on their own. An Indicator with children replaces the number and the check — here the last step is locked, and the item is pressable through asChild rather than through a prop the component would have had to invent."
+      >
+        <Stepper hasConnector={false} value={2}>
+          {STEPS.slice(0, 3).map((step, index) => (
+            <Stepper.Item key={step.title} asChild>
+              <Pressable onPress={() => {}}>
+                <Stepper.Indicator>
+                  {index === 2 ? <Label>×</Label> : undefined}
+                </Stepper.Indicator>
+                <Stepper.Content>
+                  <Stepper.Title>{step.title}</Stepper.Title>
+                  <Stepper.Description>{step.description}</Stepper.Description>
+                </Stepper.Content>
+              </Pressable>
+            </Stepper.Item>
+          ))}
+        </Stepper>
+      </Section>
+    </ScrollView>
+  )
+}
+
+/** The value is the caller's, always — there is no state inside a stepper to move. */
+function Controlled() {
+  const [step, setStep] = useState(1)
+
+  return (
+    <Section
+      title="Controlled, because there is no other kind"
+      note="There is no defaultValue and no onValueChange: nothing inside a stepper can move the value, so it comes from the form, the wizard or the route that actually knows. An uncontrolled one would be a piece of state that could never change."
+    >
+      <Stepper value={step}>
+        {STEPS.map(item => (
+          <Stepper.Item key={item.title}>
+            <Stepper.Indicator />
+            <Stepper.Content>
+              <Stepper.Title>{item.title}</Stepper.Title>
+              <Stepper.Description>{item.description}</Stepper.Description>
+            </Stepper.Content>
+          </Stepper.Item>
+        ))}
+      </Stepper>
+
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 16,
+        }}
+      >
+        <Button
+          variant="tertiary"
+          size="sm"
+          isDisabled={step === 1}
+          onPress={() => setStep(current => current - 1)}
+        >
+          Précédent
+        </Button>
+        <Label>{`${step} / ${STEPS.length}`}</Label>
+        <Button
+          variant="tertiary"
+          size="sm"
+          isDisabled={step === STEPS.length}
+          onPress={() => setStep(current => current + 1)}
+        >
+          Suivant
+        </Button>
+      </View>
+    </Section>
+  )
+}
+
+function Label({ children }: { children: string }) {
+  const theme = useXAUITheme()
+
+  return (
+    <Text style={{ color: theme.colors.muted, fontSize: theme.fontSizes.sm }}>
+      {children}
+    </Text>
+  )
+}
+
+function Section({
+  title,
+  note,
+  children,
+}: {
+  title: string
+  note: string
+  children: React.ReactNode
+}) {
+  const theme = useXAUITheme()
+
+  return (
+    <View style={{ gap: 12 }}>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontSize: theme.fontSizes.md,
+          fontWeight: theme.fontWeights.semibold,
+        }}
+      >
+        {title}
+      </Text>
+      <Text style={{ color: theme.colors.muted, fontSize: theme.fontSizes.xs }}>
+        {note}
+      </Text>
+      {children}
+    </View>
+  )
+}

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -227,6 +227,16 @@
         "default": "./dist/components/spinner/index.cjs"
       }
     },
+    "./stepper": {
+      "import": {
+        "types": "./dist/components/stepper/index.d.ts",
+        "default": "./dist/components/stepper/index.js"
+      },
+      "require": {
+        "types": "./dist/components/stepper/index.d.cts",
+        "default": "./dist/components/stepper/index.cjs"
+      }
+    },
     "./surface": {
       "import": {
         "types": "./dist/components/surface/index.d.ts",

--- a/packages/native/src/__tests__/components/stepper/stepper.utils.test.ts
+++ b/packages/native/src/__tests__/components/stepper/stepper.utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isConnectorDone,
+  isLeadDone,
+  stepStatus,
+} from '../../../components/stepper/stepper.utils'
+
+describe('stepStatus', () => {
+  it('reads the index from zero and the value from one', () => {
+    // "Step 2 of 4": the first is behind, the second is where you are.
+    expect(stepStatus(0, 2)).toBe('completed')
+    expect(stepStatus(1, 2)).toBe('current')
+    expect(stepStatus(2, 2)).toBe('upcoming')
+  })
+
+  it('has exactly one current step', () => {
+    const statuses = [0, 1, 2, 3].map(index => stepStatus(index, 3))
+
+    expect(statuses.filter(status => status === 'current')).toHaveLength(1)
+  })
+
+  it('leaves every step upcoming before the first one', () => {
+    expect(stepStatus(0, 0)).toBe('upcoming')
+  })
+
+  it('completes every step past the last one', () => {
+    expect(stepStatus(3, 9)).toBe('completed')
+  })
+})
+
+describe('isConnectorDone', () => {
+  it('travels the line leaving a step only once that step is behind you', () => {
+    expect(isConnectorDone('completed')).toBe(true)
+    expect(isConnectorDone('current')).toBe(false)
+    expect(isConnectorDone('upcoming')).toBe(false)
+  })
+})
+
+describe('isLeadDone', () => {
+  it('travels the line arriving at a step you have reached', () => {
+    expect(isLeadDone('completed')).toBe(true)
+    expect(isLeadDone('current')).toBe(true)
+    expect(isLeadDone('upcoming')).toBe(false)
+  })
+
+  it('meets the outgoing half of the step before it', () => {
+    // The two halves either side of one boundary have to agree, or the rail breaks at
+    // every step: step i's outgoing line and step i+1's incoming one are the same line.
+    const value = 3
+    const boundaries = [0, 1, 2, 3].map(index => ({
+      out: isConnectorDone(stepStatus(index, value)),
+      in: isLeadDone(stepStatus(index + 1, value)),
+    }))
+
+    for (const boundary of boundaries) expect(boundary.out).toBe(boundary.in)
+  })
+})

--- a/packages/native/src/__tests__/utils/check-glyph.test.ts
+++ b/packages/native/src/__tests__/utils/check-glyph.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { CHECK_SPAN, checkGlyph } from '../../utils/check-glyph'
+
+describe('checkGlyph', () => {
+  it('derives both strokes from the box rather than from a table', () => {
+    const small = checkGlyph(16, 2)
+    const large = checkGlyph(32, 2)
+
+    expect(small.width).toBe(8)
+    expect(small.height).toBe(4)
+    expect(large.width).toBe(16)
+    expect(large.height).toBe(8)
+  })
+
+  it('draws the L with the two borders that survive the turn', () => {
+    const glyph = checkGlyph(24, 2)
+
+    expect(glyph.borderStartWidth).toBe(2)
+    expect(glyph.borderBottomWidth).toBe(2)
+  })
+
+  it('lifts the mark by the ink centre the rotation leaves below the box centre', () => {
+    const side = 24
+    const stroke = 2
+    const rise = side * 0.25
+
+    expect(checkGlyph(side, stroke).transform).toEqual([
+      { translateY: -((rise - stroke) * Math.SQRT2) / 4 },
+      { rotate: '-45deg' },
+    ])
+  })
+
+  it('keeps the lift and the turn in one value, in that order', () => {
+    // `transform` is whole: a caller merging a second transform replaces this one rather
+    // than blending into it, so both steps have to leave here together.
+    const transform = checkGlyph(24, 2).transform
+
+    expect(Array.isArray(transform) && transform).toHaveLength(2)
+  })
+
+  it('a mark with no rise is not lifted at all', () => {
+    expect(checkGlyph(8, 2).transform).toEqual([
+      { translateY: -0 },
+      { rotate: '-45deg' },
+    ])
+  })
+
+  it('exports the span the dash shares with the tick', () => {
+    expect(checkGlyph(20, 2).width).toBe(20 * CHECK_SPAN)
+  })
+})

--- a/packages/native/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/native/src/components/checkbox/checkbox.recipe.ts
@@ -1,4 +1,5 @@
 import { createRecipe, radiusAxis } from '../../system/recipe'
+import { CHECK_SPAN, checkGlyph } from '../../utils/check-glyph'
 import type { SlotStyles, VariantTokens } from '../../system/recipe'
 import type { FontSizeKey, RadiusKey, XAUITheme } from '../../theme/theme.type'
 import type { CheckboxSize, CheckboxSlot, CheckboxVariant } from './checkbox.type'
@@ -44,10 +45,8 @@ const VARIANT_TOKENS: Record<CheckboxVariant, VariantTokens> = {
  * width**. A checkbox hugs its label, and a row that has to fill its parent is a `style`
  * away rather than a `fullWidth` prop.
  *
- * The check is **derived from the box** rather than tabulated: half its width, a quarter
- * its height. Two numbers in a table would drift from the box the day someone changes it,
- * and a check that is not proportional to its box reads as a different glyph at every
- * size.
+ * The check itself is `utils/check-glyph`: derived from the box rather than tabulated, so
+ * it reads as the same glyph at every size.
  */
 function sizeAxis(step: SizeStep) {
   const { box, radius, label, gap, stroke } = step
@@ -58,29 +57,12 @@ function sizeAxis(step: SizeStep) {
     return {
       root: { gap: theme.spacing(gap) },
       indicator: { width: side, height: side, borderRadius: theme.radius[radius] },
-      check: {
-        width: side * CHECK_WIDTH,
-        height: side * CHECK_HEIGHT,
-        borderStartWidth: stroke,
-        borderBottomWidth: stroke,
-        // An "L" has its ink in one corner, not in the middle of its box, so rotating it
-        // about that box's centre leaves the tick sitting low. Rotating by −45° maps a
-        // point to `(dy − dx)·√2/2`, and over the two strokes that spans `H` at the top
-        // and `H − t − W` at the bottom — an ink centre `(H − t)·√2/4` **below** the box
-        // centre, which flexbox then dutifully centres. Lifting by exactly that is what
-        // makes the mark look centred rather than measure centred.
-        //
-        // Both transforms live here, and not half here and half in a sheet, because
-        // `transform` is a whole value: the recipe's merge replaces it rather than
-        // blending, so a second step would drop the first.
-        transform: [
-          { translateY: -((side * CHECK_HEIGHT - stroke) * Math.SQRT2) / 4 },
-          { rotate: '-45deg' },
-        ],
-      },
+      // The tick is `utils/check-glyph`, shared with the completed step of a `Stepper`:
+      // both mark a box they fill, and both have to work with no icon set installed.
+      check: checkGlyph(side, stroke),
       // The third state's mark: the check's long stroke, on its own and level.
       dash: {
-        width: side * CHECK_WIDTH,
+        width: side * CHECK_SPAN,
         height: stroke,
         borderRadius: stroke / 2,
       },
@@ -91,13 +73,6 @@ function sizeAxis(step: SizeStep) {
     }
   }
 }
-
-/**
- * The long stroke and the short one, as fractions of the box. The two together are an
- * "L" that becomes a check once rotated, and lifted — see `sizeAxis`.
- */
-const CHECK_WIDTH = 0.5
-const CHECK_HEIGHT = 0.25
 
 type SizeStep = {
   /** The box's side, in spacing steps — `spacing(6)` is 24 on the base-4 scale. */

--- a/packages/native/src/components/stepper/index.ts
+++ b/packages/native/src/components/stepper/index.ts
@@ -1,0 +1,38 @@
+import { StepperRoot } from './stepper'
+import { StepperContent } from './stepper-content'
+import { StepperDescription } from './stepper-description'
+import { StepperIndicator } from './stepper-indicator'
+import { StepperItem } from './stepper-item'
+import { StepperTitle } from './stepper-title'
+
+export const Stepper = Object.assign(StepperRoot, {
+  Item: StepperItem,
+  Indicator: StepperIndicator,
+  Content: StepperContent,
+  Title: StepperTitle,
+  Description: StepperDescription,
+})
+
+export { StepperRoot } from './stepper'
+export { StepperContent } from './stepper-content'
+export { StepperDescription } from './stepper-description'
+export { StepperIndicator } from './stepper-indicator'
+export { StepperItem } from './stepper-item'
+export { StepperTitle } from './stepper-title'
+export { useStep, useStepper } from './stepper.context'
+export { stepperRecipe } from './stepper.recipe'
+export type {
+  StepContextValue,
+  StepStatus,
+  StepperContentProps,
+  StepperContextValue,
+  StepperDescriptionProps,
+  StepperIndicatorProps,
+  StepperItemProps,
+  StepperOrientation,
+  StepperProps,
+  StepperSize,
+  StepperSlot,
+  StepperTitleProps,
+  StepperVariant,
+} from './stepper.type'

--- a/packages/native/src/components/stepper/stepper-content.tsx
+++ b/packages/native/src/components/stepper/stepper-content.tsx
@@ -1,0 +1,39 @@
+import { forwardRef } from 'react'
+import { View } from 'react-native'
+import { useStyleProps } from '../../system/style-props'
+import { useStep, useStepper } from './stepper.context'
+import { sheet } from './stepper.style'
+import type { StepperContentProps } from './stepper.type'
+
+/**
+ * What the step is about: its title, its description, and anything else you put there.
+ *
+ * ```tsx
+ * <Stepper.Content>
+ *   <Stepper.Title>Profil</Stepper.Title>
+ *   <Stepper.Description>Renseignez votre profil</Stepper.Description>
+ * </Stepper.Content>
+ * ```
+ *
+ * In a vertical stepper it is the column beside the rail, and it carries the space between
+ * one step and the next **under** its own text — that space is what the line runs through,
+ * so it belongs to the text rather than to a gap on the root. The last step takes it back:
+ * there is no line under it and no step after it, only trailing whitespace.
+ */
+export const StepperContent = forwardRef<View, StepperContentProps>(
+  function StepperContent({ children, style, ...props }, ref) {
+    const { contentStyle, orientation } = useStepper()
+    const { isLast } = useStep()
+    const [styleProps, rest] = useStyleProps(props)
+
+    const flush = isLast && orientation === 'vertical' ? sheet.flush : null
+
+    return (
+      <View ref={ref} {...rest} style={[contentStyle, flush, styleProps, style]}>
+        {children}
+      </View>
+    )
+  }
+)
+
+StepperContent.displayName = 'XAUI.Stepper.Content'

--- a/packages/native/src/components/stepper/stepper-description.tsx
+++ b/packages/native/src/components/stepper/stepper-description.tsx
@@ -1,0 +1,28 @@
+import { forwardRef } from 'react'
+import { Text } from 'react-native'
+import { useStyleProps } from '../../system/style-props'
+import { useStepper } from './stepper.context'
+import type { StepperDescriptionProps } from './stepper.type'
+
+/**
+ * The line under the title.
+ *
+ * It is a **vertical** affair: a horizontal step has a label centred under its circle and
+ * no room for a second line, so a description there will render but will not read as one.
+ * It does not move with the status — it is already the quiet line, and dimming the quiet
+ * line twice makes an upcoming step unreadable rather than distant.
+ */
+export const StepperDescription = forwardRef<Text, StepperDescriptionProps>(
+  function StepperDescription({ children, style, ...props }, ref) {
+    const { descriptionStyle } = useStepper()
+    const [styleProps, rest] = useStyleProps(props)
+
+    return (
+      <Text ref={ref} {...rest} style={[descriptionStyle, styleProps, style]}>
+        {children}
+      </Text>
+    )
+  }
+)
+
+StepperDescription.displayName = 'XAUI.Stepper.Description'

--- a/packages/native/src/components/stepper/stepper-indicator.tsx
+++ b/packages/native/src/components/stepper/stepper-indicator.tsx
@@ -1,0 +1,107 @@
+import { forwardRef } from 'react'
+import { Text, View } from 'react-native'
+import { useStyleProps } from '../../system/style-props'
+import { useStep, useStepper } from './stepper.context'
+import { sheet } from './stepper.style'
+import type { StepperIndicatorProps } from './stepper.type'
+import { isConnectorDone, isLeadDone } from './stepper.utils'
+
+/**
+ * The circle, and the rail it sits on.
+ *
+ * ```tsx
+ * <Stepper.Indicator />
+ *
+ * <Stepper.Indicator>
+ *   <Icon as={LockIcon} />
+ * </Stepper.Indicator>
+ * ```
+ *
+ * With no children it shows its own number, and a check once the step is behind you —
+ * drawn out of two borders (`utils/check-glyph`, the `Checkbox`'s tick) so a stepper works
+ * in a project that has installed no icon set.
+ *
+ * **The connectors are the indicator's, not the root's.** A vertical line has to run from
+ * under one circle to the next through whatever height the text beside it takes, and only
+ * something inside that row can measure it — the opposite of the `Accordion`, whose
+ * separator spans the full width and can only be drawn by the root.
+ *
+ * A horizontal step carries **two** halves, one on each side, so its circle stays centred
+ * over its label whatever the neighbours do. The two ends of the rail are drawn transparent
+ * rather than dropped: removing them would let the first and last circles slide off centre.
+ */
+export const StepperIndicator = forwardRef<View, StepperIndicatorProps>(
+  function StepperIndicator({ children, style, ...props }, ref) {
+    const {
+      trackStyle,
+      indicatorStyle,
+      indicatorCurrentStyle,
+      indicatorCompletedStyle,
+      orientation,
+    } = useStepper()
+    const { index, status, isFirst, isLast } = useStep()
+    const [styleProps, rest] = useStyleProps(props)
+
+    // `indicatorStyle` is what an upcoming step looks like; the other two statuses lay a
+    // colour over it — see the recipe on why the status is an overlay rather than an axis.
+    const statusStyle =
+      status === 'current'
+        ? indicatorCurrentStyle
+        : status === 'completed'
+          ? indicatorCompletedStyle
+          : null
+
+    return (
+      <View style={trackStyle}>
+        {orientation === 'horizontal' ? (
+          <Connector isDone={isLeadDone(status)} isEdge={isFirst} />
+        ) : null}
+
+        <View
+          ref={ref}
+          {...rest}
+          style={[indicatorStyle, statusStyle, styleProps, style]}
+        >
+          {children ??
+            (status === 'completed' ? <Check /> : <Mark>{index + 1}</Mark>)}
+        </View>
+
+        <Connector isDone={isConnectorDone(status)} isEdge={isLast} />
+      </View>
+    )
+  }
+)
+
+StepperIndicator.displayName = 'XAUI.Stepper.Indicator'
+
+/** One half of the rail. `isEdge` keeps its space and drops its ink. */
+function Connector({ isDone, isEdge }: { isDone: boolean; isEdge: boolean }) {
+  const { connectorStyle, connectorDoneStyle, hasConnector } = useStepper()
+
+  if (!hasConnector) return null
+
+  return (
+    <View
+      style={[connectorStyle, isDone && connectorDoneStyle, isEdge && sheet.hidden]}
+    />
+  )
+}
+
+/** The step's number, in the colour its status calls for. */
+function Mark({ children }: { children: number }) {
+  const { markStyle, markCurrentStyle } = useStepper()
+  const { status } = useStep()
+
+  return (
+    <Text style={[markStyle, status === 'current' && markCurrentStyle]}>
+      {children}
+    </Text>
+  )
+}
+
+/** The built-in tick, for a step that is behind you. */
+function Check() {
+  const { checkStyle } = useStepper()
+
+  return <View style={checkStyle} />
+}

--- a/packages/native/src/components/stepper/stepper-item.tsx
+++ b/packages/native/src/components/stepper/stepper-item.tsx
@@ -1,0 +1,54 @@
+import { forwardRef } from 'react'
+import { View } from 'react-native'
+import { Slot } from '../../system/slot'
+import { useStyleProps } from '../../system/style-props'
+import { useStep, useStepper } from './stepper.context'
+import type { StepperItemProps } from './stepper.type'
+
+/**
+ * One step: its indicator and what the indicator is about.
+ *
+ * ```tsx
+ * <Stepper.Item>
+ *   <Stepper.Indicator />
+ *   <Stepper.Content>
+ *     <Stepper.Title>Profil</Stepper.Title>
+ *   </Stepper.Content>
+ * </Stepper.Item>
+ * ```
+ *
+ * It declares nothing about where it sits — the root numbers it. What it is, is the box
+ * the two columns run in: a row in a vertical stepper, stretched so the line beside the
+ * text can reach the full height of it, and an equal-width column in a horizontal one.
+ *
+ * **A step is not pressable**, and that is `asChild`'s job rather than a prop: a stepper
+ * where a completed step takes you back is one composition away, and one where tapping
+ * ahead skips validation is not something this component should make easy.
+ *
+ * ```tsx
+ * <Stepper.Item asChild>
+ *   <Pressable onPress={() => setStep(1)}>…</Pressable>
+ * </Stepper.Item>
+ * ```
+ *
+ * `children` may be a function, which is how a step reads its own standing without the
+ * caller wiring `useStep` themselves.
+ */
+export const StepperItem = forwardRef<View, StepperItemProps>(function StepperItem(
+  { children, asChild = false, style, ...props },
+  ref
+) {
+  const { itemStyle } = useStepper()
+  const step = useStep()
+  const [styleProps, rest] = useStyleProps(props)
+
+  const Node = asChild ? Slot : View
+
+  return (
+    <Node ref={ref} {...rest} style={[itemStyle, styleProps, style]}>
+      {typeof children === 'function' ? children(step) : children}
+    </Node>
+  )
+})
+
+StepperItem.displayName = 'XAUI.Stepper.Item'

--- a/packages/native/src/components/stepper/stepper-title.tsx
+++ b/packages/native/src/components/stepper/stepper-title.tsx
@@ -1,0 +1,37 @@
+import { forwardRef } from 'react'
+import { Text } from 'react-native'
+import { useStyleProps } from '../../system/style-props'
+import { useStep, useStepper } from './stepper.context'
+import type { StepperTitleProps } from './stepper.type'
+
+/**
+ * The step's name.
+ *
+ * It recedes once the step is ahead of you — the whole step does, indicator and all — so
+ * that the eye finds where it is rather than counting from the top. A step you have
+ * already done keeps its full contrast: it is a thing you did, not a thing greyed out.
+ */
+export const StepperTitle = forwardRef<Text, StepperTitleProps>(
+  function StepperTitle({ children, style, ...props }, ref) {
+    const { titleStyle, titleUpcomingStyle } = useStepper()
+    const { status } = useStep()
+    const [styleProps, rest] = useStyleProps(props)
+
+    return (
+      <Text
+        ref={ref}
+        {...rest}
+        style={[
+          titleStyle,
+          status === 'upcoming' && titleUpcomingStyle,
+          styleProps,
+          style,
+        ]}
+      >
+        {children}
+      </Text>
+    )
+  }
+)
+
+StepperTitle.displayName = 'XAUI.Stepper.Title'

--- a/packages/native/src/components/stepper/stepper.context.ts
+++ b/packages/native/src/components/stepper/stepper.context.ts
@@ -1,0 +1,20 @@
+import { createSlotContext } from '../../system/slot'
+import type { StepContextValue, StepperContextValue } from './stepper.type'
+
+/**
+ * R10 — `useStepper` is exported so a third party can write its own slot against the same
+ * resolved values the built-in ones read. Outside a `<Stepper>` it throws by name.
+ */
+export const [StepperProvider, useStepper] =
+  createSlotContext<StepperContextValue>('Stepper')
+
+/**
+ * One step's standing, and it comes from the **root** rather than from the item.
+ *
+ * That is the difference from an `Accordion.Item`, which declares its own `value`: a row
+ * of an accordion is open or closed on its own, where a step only means something in the
+ * order it sits in. The root numbers its children and hands each one where it stands, so
+ * a step inserted in the middle renumbers the rest by being there.
+ */
+export const [StepProvider, useStep] =
+  createSlotContext<StepContextValue>('Stepper.Item')

--- a/packages/native/src/components/stepper/stepper.md
+++ b/packages/native/src/components/stepper/stepper.md
@@ -1,0 +1,181 @@
+# Stepper
+
+Where you are in a sequence of steps.
+
+## Import
+
+```tsx
+import { Stepper } from '@xaui/native/stepper'
+```
+
+## Usage
+
+```tsx
+<Stepper value={2}>
+  <Stepper.Item>
+    <Stepper.Indicator />
+    <Stepper.Content>
+      <Stepper.Title>Compte</Stepper.Title>
+      <Stepper.Description>Créez votre compte</Stepper.Description>
+    </Stepper.Content>
+  </Stepper.Item>
+  <Stepper.Item>
+    <Stepper.Indicator />
+    <Stepper.Content>
+      <Stepper.Title>Profil</Stepper.Title>
+    </Stepper.Content>
+  </Stepper.Item>
+</Stepper>
+```
+
+## Anatomy
+
+| slot                  | what it is                                             |
+| --------------------- | ------------------------------------------------------ |
+| `Stepper`             | The container, and the thing that numbers its children |
+| `Stepper.Item`        | One step                                               |
+| `Stepper.Indicator`   | Its circle, and the rail the circle sits on            |
+| `Stepper.Content`     | What the step is about                                 |
+| `Stepper.Title`       | The step's name                                        |
+| `Stepper.Description` | The line under it — vertical steppers only             |
+
+## The value is the caller's, always
+
+There is **no `defaultValue` and no `onValueChange`**. Nothing inside a stepper can move the
+value: a step is not a control, it is a report. The number comes from the form, the wizard
+or the route that actually knows which step it is on, and an uncontrolled stepper would be a
+piece of state that could never change.
+
+`value` counts from **one**, so `value={2}` is "step 2 of 4" — the number you would say out
+loud, not an array index.
+
+Out of range is not an error. `value={0}` leaves every step upcoming, which is the honest
+reading of a flow that has not started, and a value past the last step completes them all,
+which is what a finished one looks like.
+
+## The root numbers its children
+
+An item declares no index and no key of its own. JSX order is step order (R4), so inserting
+a step in the middle renumbers the rest by being there:
+
+```tsx
+<Stepper value={3}>
+  <Stepper.Item>…</Stepper.Item> {/* completed */}
+  <Stepper.Item>…</Stepper.Item> {/* completed */}
+  <Stepper.Item>…</Stepper.Item> {/* current   */}
+</Stepper>
+```
+
+It is the reasoning that puts the `Accordion`'s separators on its root: what an item cannot
+know about its neighbours belongs to the thing that has them all. A step reads its own
+standing through `useStep`, or through a function child:
+
+```tsx
+<Stepper.Item>
+  {({ status }) => (status === 'current' ? <Now /> : <Later />)}
+</Stepper.Item>
+```
+
+## Three statuses, and they are an order
+
+| status      | indicator          | title      | line leaving it |
+| ----------- | ------------------ | ---------- | --------------- |
+| `completed` | accent disc, check | foreground | travelled       |
+| `current`   | accent ring        | foreground | track           |
+| `upcoming`  | neutral ring       | muted      | track           |
+
+Every step before the current one is `completed` and every step after it is `upcoming` — a
+stepper with two current steps is not a stepper.
+
+A **completed step keeps its full contrast**: it is a thing you did, not a thing greyed out.
+What recedes is the road ahead, so the eye finds where it is rather than counting from the
+top.
+
+The line under the current step is still track, not progress: the stepper has not left that
+step yet.
+
+## Two orientations, and they differ by more than the axis
+
+`vertical` puts the indicator beside the text and aligned to the **top** of it, with the
+line running down through whatever height that text takes. It is the layout that can carry
+a description at all.
+
+`horizontal` centres each indicator over a label and gives every step the same width, so the
+circles land at even intervals whatever the labels say. There is no room under a label for a
+second line, which is why `Stepper.Description` is a vertical affair.
+
+### Why the connectors belong to the indicator
+
+A vertical line has to run from under one circle to the next **through the text beside it**,
+and only something inside that row can measure that height. That is the opposite of the
+`Accordion`, whose separator spans the full width and can only be drawn by the root.
+
+A horizontal step carries **two** halves, one on each side of its circle, so the circle stays
+centred over its label whatever the neighbours do — two halves meeting at the item boundary
+draw one continuous rail. The two ends of that rail are drawn transparent rather than
+dropped: removing them would slide the first and last circles off their labels.
+
+`hasConnector={false}` leaves the circles on their own.
+
+## A step is not pressable
+
+There is no `onPress` and no `isLocked`. A stepper where a completed step takes you back is
+one composition away:
+
+```tsx
+<Stepper.Item asChild>
+  <Pressable onPress={() => setStep(1)}>…</Pressable>
+</Stepper.Item>
+```
+
+and one where tapping ahead skips a form's validation is not something this component should
+make easy.
+
+## The indicator draws its own mark
+
+With no children it shows its number, and a check once the step is behind you — drawn out of
+two borders (`utils/check-glyph`, the same tick the `Checkbox` uses) so a stepper works in a
+project that has installed no icon set. Children replace both:
+
+```tsx
+<Stepper.Indicator>
+  <Icon as={LockIcon} size={14} />
+</Stepper.Indicator>
+```
+
+## Props
+
+| prop           | type                           | default    | description                  |
+| -------------- | ------------------------------ | ---------- | ---------------------------- |
+| `value`        | `number`                       | `1`        | Which step, counted from one |
+| `orientation`  | `'vertical' \| 'horizontal'`   | `vertical` | Which way the steps run      |
+| `size`         | `'xs' \| 'sm' \| 'md' \| 'lg'` | `md`       | Indicator and type           |
+| `color`        | `string`                       | —          | The tint (R7) — a raw value  |
+| `hasConnector` | `boolean`                      | `true`     | Whether the rail is drawn    |
+| `asChild`      | `boolean`                      | `false`    | Renders the caller's element |
+
+`size` moves the indicator and the type — **never a width**. A vertical stepper is as wide as
+its parent lets it be and a horizontal one splits that width evenly, which is RN's own
+behaviour and the reason there is no `fullWidth` prop here either.
+
+## A tint paints the progress, not the track
+
+`color` moves the travelled line, the ring around the step you are on and the disc behind the
+ones you are past. The road ahead stays grey — the untravelled track is written from the theme
+rather than named as a role, which is what makes that guaranteed rather than incidental. A
+stepper whose whole rail took the tint would have stopped showing progress.
+
+## Accessibility
+
+The **root** announces the progress — `accessibilityRole="progressbar"` with an
+`accessibilityValue` of `{ min: 1, max: <count>, now: value }`, so a screen reader says "step
+2 of 4" once rather than a status on each of the four. Both stay overridable (R9).
+
+The titles and descriptions are read as the text they are. An indicator's number is
+decoration on top of that announcement — give it an `accessibilityLabel` if you replace it
+with something that carries meaning of its own.
+
+## Everything else is a style prop
+
+`padding`, `gap`, `backgroundColor` — full RN names, full RN values (R14), on the root and on
+every slot. There is nothing here a prop had to be invented for.

--- a/packages/native/src/components/stepper/stepper.recipe.ts
+++ b/packages/native/src/components/stepper/stepper.recipe.ts
@@ -1,0 +1,249 @@
+import { createRecipe } from '../../system/recipe'
+import type { SlotStyles, VariantTokens } from '../../system/recipe'
+import { checkGlyph } from '../../utils/check-glyph'
+import type { FontSizeKey, Size, XAUITheme } from '../../theme/theme.type'
+import type { StepperSlot, StepperVariant } from './stepper.type'
+
+const SLOTS = [
+  'root',
+  'item',
+  'track',
+  'connector',
+  'connectorDone',
+  'indicator',
+  'indicatorCurrent',
+  'indicatorCompleted',
+  'mark',
+  'markCurrent',
+  'check',
+  'content',
+  'title',
+  'titleUpcoming',
+  'description',
+] as const
+
+/**
+ * One variant, and two roles: **the accent is the progress**.
+ *
+ * A stepper reports where you are rather than how loud it is, so there is no emphasis
+ * ladder to walk — what a `color` should move is the travelled part of the line, the ring
+ * around the step you are on and the disc behind the ones you are past. Those three are
+ * the accent, and `fg` is what a check has to read against once it is on that disc.
+ *
+ * **The untravelled track is deliberately not a role.** `border` and `muted` are written
+ * from the theme in `base` below, so they stay neutral under a tint: a stepper coloured
+ * `#7c3aed` paints its progress purple and leaves the road ahead grey, which is the whole
+ * point of showing progress at all.
+ */
+const VARIANT_TOKENS: Record<StepperVariant, VariantTokens> = {
+  default: { bg: 'accent', fg: 'accentForeground' },
+}
+
+type SizeStep = {
+  /** The indicator's diameter, in spacing steps. */
+  indicator: number
+  /** The connector's thickness, in points — a line is not a gap. */
+  stroke: number
+  /** The check's stroke, which is heavier than the line it replaces. */
+  tick: number
+  /** Between the track and the content, along whichever axis the item runs. */
+  gap: number
+  /** What a vertical step leaves under its content for the line to run through. */
+  run: number
+  mark: FontSizeKey
+  title: FontSizeKey
+  description: FontSizeKey
+}
+
+/**
+ * `size` moves the indicator and the type — **never a width**. A vertical stepper is as
+ * wide as its parent lets it be and a horizontal one splits that width evenly, which is
+ * RN's own behaviour and the reason there is no `fullWidth` prop here either.
+ *
+ * `md`'s indicator is twenty-eight points, HeroUI's, measured off their own stepper.
+ */
+const SIZES: Record<Size, SizeStep> = {
+  xs: {
+    indicator: 5,
+    stroke: 1,
+    tick: 1.5,
+    gap: 2,
+    run: 4,
+    mark: 'xs',
+    title: 'sm',
+    description: 'xs',
+  },
+  sm: {
+    indicator: 6,
+    stroke: 1,
+    tick: 2,
+    gap: 2.5,
+    run: 5,
+    mark: 'xs',
+    title: 'md',
+    description: 'sm',
+  },
+  md: {
+    indicator: 7,
+    stroke: 2,
+    tick: 2,
+    gap: 3,
+    run: 6,
+    mark: 'sm',
+    title: 'md',
+    description: 'sm',
+  },
+  lg: {
+    indicator: 8,
+    stroke: 2,
+    tick: 2.5,
+    gap: 3.5,
+    run: 7,
+    mark: 'md',
+    title: 'lg',
+    description: 'md',
+  },
+}
+
+/**
+ * The connector is given **both** a width and a height, and the orientation axis then adds
+ * the `flex` that picks which one survives: flex governs the main axis and leaves the
+ * cross axis to the explicit value. One line of data covers a rail that runs down and a
+ * rail that runs across, instead of eight compound variants that would say the same thing.
+ */
+function sizeAxis(step: SizeStep) {
+  return (theme: XAUITheme): SlotStyles<StepperSlot> => {
+    const side = theme.spacing(step.indicator)
+
+    return {
+      item: { gap: theme.spacing(step.gap) },
+      connector: { width: step.stroke, height: step.stroke },
+      indicator: { width: side, height: side },
+      mark: {
+        fontSize: theme.fontSizes[step.mark],
+        lineHeight: theme.lineHeights[step.mark],
+      },
+      check: checkGlyph(side, step.tick),
+      title: {
+        fontSize: theme.fontSizes[step.title],
+        lineHeight: theme.lineHeights[step.title],
+      },
+      description: {
+        fontSize: theme.fontSizes[step.description],
+        lineHeight: theme.lineHeights[step.description],
+      },
+    }
+  }
+}
+
+/**
+ * Vertical is the layout that can carry a description: the indicator sits at the **top**
+ * of the text beside it rather than centred on it, and the line runs down through whatever
+ * height that text takes.
+ *
+ * Horizontal centres each indicator over its label and gives every step the same width, so
+ * the circles land at even intervals whatever their labels say. That is why the track
+ * stretches and carries a line on **both** sides of the indicator: two halves meeting at
+ * the item boundary draw one continuous rail, where a single trailing line would have to
+ * reach across a neighbour it cannot measure.
+ */
+const ORIENTATIONS = {
+  vertical: (): SlotStyles<StepperSlot> => ({
+    root: { flexDirection: 'column' },
+    item: { flexDirection: 'row', alignItems: 'stretch' },
+    track: { flexDirection: 'column', alignItems: 'center' },
+    connector: { flexGrow: 1, flexBasis: 0 },
+    content: { flex: 1 },
+  }),
+
+  horizontal: (): SlotStyles<StepperSlot> => ({
+    root: { flexDirection: 'row', alignItems: 'flex-start' },
+    item: { flexDirection: 'column', alignItems: 'center', flex: 1 },
+    track: { flexDirection: 'row', alignItems: 'center', alignSelf: 'stretch' },
+    connector: { flexGrow: 1, flexBasis: 0 },
+    content: { alignItems: 'center' },
+  }),
+}
+
+/**
+ * The one thing the two axes genuinely cross on: how far a vertical step's content reaches
+ * past its own text, which is the space the line has to run through and therefore the gap
+ * between two steps. A horizontal step has no such space — its neighbour is beside it —
+ * so only the vertical half is written.
+ */
+const VERTICAL_RUN = (Object.keys(SIZES) as Size[]).map(size => ({
+  when: { size, orientation: 'vertical' } as const,
+  style: (theme: XAUITheme): SlotStyles<StepperSlot> => ({
+    content: { paddingBottom: theme.spacing(SIZES[size].run) },
+  }),
+}))
+
+export const stepperRecipe = createRecipe({
+  slots: SLOTS,
+
+  /**
+   * The neutral half of the component, written from the theme rather than from a role so
+   * that a `color` cannot reach it — see `VARIANT_TOKENS`.
+   *
+   * Each of the three statuses is a base slot plus, for the two that differ, an overlay
+   * the item lays on top: `indicator` is what an upcoming step looks like, and
+   * `indicatorCurrent` and `indicatorCompleted` are what the other two add. That keeps the
+   * status out of the cache key and inside the tint pass at the same time — an axis would
+   * have given up the second, because `tint` re-runs `paint` and the states, not the axes.
+   */
+  base: theme => ({
+    connector: { backgroundColor: theme.colors.border },
+    indicator: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: theme.radius.full,
+      borderWidth: theme.borderWidth.default,
+      borderColor: theme.colors.border,
+      borderCurve: 'continuous',
+    },
+    mark: {
+      fontFamily: theme.fontFamilies.body,
+      fontWeight: theme.fontWeights.medium,
+      color: theme.colors.muted,
+    },
+    title: {
+      fontFamily: theme.fontFamilies.body,
+      fontWeight: theme.fontWeights.medium,
+      color: theme.colors.foreground,
+    },
+    titleUpcoming: { color: theme.colors.muted },
+    description: {
+      fontFamily: theme.fontFamilies.body,
+      color: theme.colors.muted,
+    },
+  }),
+
+  variantTokens: VARIANT_TOKENS,
+
+  paint: (_theme, colors) => ({
+    connectorDone: { backgroundColor: colors.bg },
+    indicatorCurrent: { borderColor: colors.bg },
+    indicatorCompleted: { backgroundColor: colors.bg, borderColor: colors.bg },
+    markCurrent: { color: colors.bg },
+    // A completed step marks itself with the tick rather than with its number, so `fg`
+    // lands on the glyph and there is no completed mark colour to name.
+    check: { borderColor: colors.fg },
+  }),
+
+  variants: {
+    size: {
+      xs: sizeAxis(SIZES.xs),
+      sm: sizeAxis(SIZES.sm),
+      md: sizeAxis(SIZES.md),
+      lg: sizeAxis(SIZES.lg),
+    },
+
+    orientation: ORIENTATIONS,
+  },
+
+  compoundVariants: VERTICAL_RUN,
+
+  defaultVariants: { variant: 'default', size: 'md', orientation: 'vertical' },
+})
+
+export type { StepperSlot }

--- a/packages/native/src/components/stepper/stepper.style.ts
+++ b/packages/native/src/components/stepper/stepper.style.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native'
+
+/**
+ * The two static corrections, neither of which depends on a token.
+ *
+ * `hidden` is how the rail ends: the first step's incoming line and the last step's
+ * outgoing one are drawn transparent rather than dropped, because a horizontal step keeps
+ * its indicator centred by having a line on both sides of it — removing one would slide
+ * every end circle off its label.
+ *
+ * `flush` takes the run-off space back from the last vertical step. That padding exists to
+ * give the line somewhere to run; under the last step there is no line and no next step,
+ * only trailing whitespace.
+ */
+export const sheet = StyleSheet.create({
+  hidden: { backgroundColor: 'transparent' },
+  flush: { paddingBottom: 0 },
+})

--- a/packages/native/src/components/stepper/stepper.tsx
+++ b/packages/native/src/components/stepper/stepper.tsx
@@ -1,0 +1,121 @@
+import { Children, forwardRef, useMemo } from 'react'
+import { View } from 'react-native'
+import { Slot } from '../../system/slot'
+import { useStyleProps } from '../../system/style-props'
+import { useXAUITheme } from '../../theme/theme-hooks'
+import { StepProvider, StepperProvider } from './stepper.context'
+import { stepperRecipe } from './stepper.recipe'
+import type { StepperProps } from './stepper.type'
+import { stepStatus } from './stepper.utils'
+
+/**
+ * Where you are in a sequence of steps.
+ *
+ * ```tsx
+ * <Stepper value={2}>
+ *   <Stepper.Item>
+ *     <Stepper.Indicator />
+ *     <Stepper.Content>
+ *       <Stepper.Title>Compte</Stepper.Title>
+ *       <Stepper.Description>Créez votre compte</Stepper.Description>
+ *     </Stepper.Content>
+ *   </Stepper.Item>
+ * </Stepper>
+ * ```
+ *
+ * **The value is the caller's, always.** There is no `defaultValue` and no
+ * `onValueChange`, because nothing inside a stepper can move it: a step is not a control,
+ * it is a report. The number comes from the form, the wizard or the route that actually
+ * knows which step it is on, and an uncontrolled one would be a piece of state that could
+ * never change.
+ *
+ * **The root numbers its children.** JSX order is step order (R4), so an item declares no
+ * index and no key of its own — insert a step in the middle and the rest renumber by being
+ * there. It is the same reasoning that puts the `Accordion`'s separators on its root: what
+ * an item cannot know about its neighbours belongs to the thing that has them all.
+ */
+export const StepperRoot = forwardRef<View, StepperProps>(function Stepper(
+  {
+    children,
+    value = 1,
+    orientation = 'vertical',
+    size,
+    color,
+    hasConnector = true,
+    asChild = false,
+    style,
+    ...props
+  },
+  ref
+) {
+  const theme = useXAUITheme()
+  const [styleProps, rest] = useStyleProps(props)
+
+  const selection = { size, orientation }
+  const styles = stepperRecipe.resolve({ theme, selection })
+  const tint = color ? stepperRecipe.tint({ theme, color, selection }) : undefined
+
+  const context = useMemo(() => {
+    // The tint touches only what the accent painted — the progress — so the neutral slots
+    // are passed through untouched rather than merged with an entry that is never there.
+    const tinted = <K extends keyof typeof styles>(slot: K) =>
+      tint?.[slot] ? [styles[slot], tint[slot]] : styles[slot]
+
+    return {
+      orientation,
+      hasConnector,
+      itemStyle: styles.item,
+      trackStyle: styles.track,
+      connectorStyle: styles.connector,
+      connectorDoneStyle: tinted('connectorDone'),
+      indicatorStyle: styles.indicator,
+      indicatorCurrentStyle: tinted('indicatorCurrent'),
+      indicatorCompletedStyle: tinted('indicatorCompleted'),
+      markStyle: styles.mark,
+      markCurrentStyle: tinted('markCurrent'),
+      checkStyle: tinted('check'),
+      contentStyle: styles.content,
+      titleStyle: styles.title,
+      titleUpcomingStyle: styles.titleUpcoming,
+      descriptionStyle: styles.description,
+    }
+  }, [styles, tint, orientation, hasConnector])
+
+  // `Children.toArray` rather than `Children.map`: it drops nulls, so a step rendered
+  // conditionally does not leave a number behind in the ones after it.
+  const steps = Children.toArray(children)
+
+  const numbered = steps.map((child, index) => (
+    <StepProvider
+      key={index}
+      value={{
+        index,
+        status: stepStatus(index, value),
+        isFirst: index === 0,
+        isLast: index === steps.length - 1,
+      }}
+    >
+      {child}
+    </StepProvider>
+  ))
+
+  const Node = asChild ? Slot : View
+
+  return (
+    <StepperProvider value={context}>
+      <Node
+        ref={ref}
+        // One announcement for the whole component rather than a status spoken on each
+        // step: "step 2 of 4" is what a reader needs, and it is what the root alone knows.
+        accessibilityRole="progressbar"
+        accessibilityValue={{ min: 1, max: steps.length, now: value }}
+        {...rest}
+        style={[styles.root, styleProps, style]}
+      >
+        {numbered}
+      </Node>
+    </StepperProvider>
+  )
+})
+
+StepperRoot.displayName = 'XAUI.Stepper.Root'

--- a/packages/native/src/components/stepper/stepper.type.ts
+++ b/packages/native/src/components/stepper/stepper.type.ts
@@ -1,0 +1,144 @@
+import type { ReactNode } from 'react'
+import type { StyleProp, TextProps, TextStyle, ViewProps } from 'react-native'
+import type { TextStyleProps, ViewStyleProps } from '../../system/style-props'
+import type { Size } from '../../theme/theme.type'
+
+export type StepperSlot =
+  | 'root'
+  | 'item'
+  | 'track'
+  | 'connector'
+  | 'connectorDone'
+  | 'indicator'
+  | 'indicatorCurrent'
+  | 'indicatorCompleted'
+  | 'mark'
+  | 'markCurrent'
+  | 'check'
+  | 'content'
+  | 'title'
+  | 'titleUpcoming'
+  | 'description'
+
+/**
+ * Where a step stands relative to the one the stepper is on.
+ *
+ * Three, and they are an order rather than three independent flags: every step before the
+ * current one is `completed` and every step after it is `upcoming`. A stepper with two
+ * current steps is not a stepper.
+ */
+export type StepStatus = 'completed' | 'current' | 'upcoming'
+
+/**
+ * Which way the steps run — and it changes more than the axis.
+ *
+ * `vertical` puts the indicator beside a title and a description, aligned to the top of
+ * them, with the connector running down through whatever height the text takes. That is
+ * the layout that can carry a description at all.
+ *
+ * `horizontal` centres each indicator over a label and gives every step the same width,
+ * so the row reads as a scale. There is no room under a label for a second line, which is
+ * why `Stepper.Description` is a vertical affair.
+ */
+export type StepperOrientation = 'vertical' | 'horizontal'
+
+export type StepperSize = Size
+
+/** One: a stepper reports where you are, and has no emphasis to add to it. */
+export type StepperVariant = 'default'
+
+type StepperOwnProps = {
+  children?: ReactNode
+  /**
+   * Which step the stepper is on, counted from **one**.
+   *
+   * There is no `defaultValue` and no `onValueChange`. A step is not a control — nothing
+   * inside a stepper can move it — so the value is the caller's, always: it comes from the
+   * form, the wizard or the route that actually knows. Making a step pressable is
+   * `asChild` on the item.
+   */
+  value?: number
+  orientation?: StepperOrientation
+  size?: StepperSize
+  /** The tint (R7) — a raw value, never a token. It paints the progress, not the track. */
+  color?: string
+  /** Whether the line between the steps is drawn. */
+  hasConnector?: boolean
+  asChild?: boolean
+}
+
+export type StepperProps = StepperOwnProps &
+  Omit<ViewProps, keyof StepperOwnProps> &
+  Omit<ViewStyleProps, keyof StepperOwnProps | keyof ViewProps>
+
+type StepperItemOwnProps = {
+  /** A function child receives the step's own standing, so it can branch on it. */
+  children?: ReactNode | ((step: StepContextValue) => ReactNode)
+  asChild?: boolean
+}
+
+export type StepperItemProps = StepperItemOwnProps &
+  Omit<ViewProps, keyof StepperItemOwnProps> &
+  Omit<ViewStyleProps, keyof StepperItemOwnProps | keyof ViewProps>
+
+type StepperIndicatorOwnProps = {
+  /** Replaces the number, and the check a completed step draws in its place. */
+  children?: ReactNode
+}
+
+export type StepperIndicatorProps = StepperIndicatorOwnProps &
+  Omit<ViewProps, keyof StepperIndicatorOwnProps> &
+  Omit<ViewStyleProps, keyof StepperIndicatorOwnProps | keyof ViewProps>
+
+type StepperContentOwnProps = {
+  children?: ReactNode
+}
+
+export type StepperContentProps = StepperContentOwnProps &
+  Omit<ViewProps, keyof StepperContentOwnProps> &
+  Omit<ViewStyleProps, keyof StepperContentOwnProps | keyof ViewProps>
+
+type StepperTextOwnProps = {
+  children?: ReactNode
+}
+
+export type StepperTitleProps = StepperTextOwnProps &
+  Omit<TextProps, keyof StepperTextOwnProps> &
+  Omit<TextStyleProps, keyof StepperTextOwnProps | keyof TextProps>
+
+export type StepperDescriptionProps = StepperTitleProps
+
+/** R5 — resolved style ids and the orientation, never a token to resolve again. */
+export type StepperContextValue = {
+  orientation: StepperOrientation
+  hasConnector: boolean
+  itemStyle: StyleProp<TextStyle>
+  trackStyle: StyleProp<TextStyle>
+  connectorStyle: StyleProp<TextStyle>
+  connectorDoneStyle: StyleProp<TextStyle>
+  indicatorStyle: StyleProp<TextStyle>
+  indicatorCurrentStyle: StyleProp<TextStyle>
+  indicatorCompletedStyle: StyleProp<TextStyle>
+  markStyle: StyleProp<TextStyle>
+  markCurrentStyle: StyleProp<TextStyle>
+  checkStyle: StyleProp<TextStyle>
+  contentStyle: StyleProp<TextStyle>
+  titleStyle: StyleProp<TextStyle>
+  titleUpcomingStyle: StyleProp<TextStyle>
+  descriptionStyle: StyleProp<TextStyle>
+}
+
+/**
+ * What one step knows about itself, given to it by the root rather than declared on it.
+ *
+ * JSX order is step order (R4), so an item carries no `index` and no `value` prop: the
+ * root numbers its children, and a step inserted in the middle renumbers the rest by
+ * being there.
+ */
+export type StepContextValue = {
+  /** Counted from zero; the mark shows `index + 1`. */
+  index: number
+  status: StepStatus
+  isFirst: boolean
+  isLast: boolean
+}

--- a/packages/native/src/components/stepper/stepper.utils.ts
+++ b/packages/native/src/components/stepper/stepper.utils.ts
@@ -1,0 +1,45 @@
+import type { StepStatus } from './stepper.type'
+
+/**
+ * Where one step stands, from its position and the step the stepper is on.
+ *
+ * `value` counts from one and `index` from zero, which is the whole of the arithmetic:
+ * the caller writes "step 2 of 4" and the root numbers its children from the array it
+ * already has. Keeping the two conventions apart in one place is what stops a fencepost
+ * from being rediscovered in each slot.
+ *
+ * Out of range is not an error. A `value` of 0 leaves every step upcoming — the honest
+ * reading of a wizard that has not started — and a value past the last one completes them
+ * all, which is what a finished flow looks like.
+ */
+export function stepStatus(index: number, value: number): StepStatus {
+  const step = index + 1
+
+  if (step < value) return 'completed'
+  if (step === value) return 'current'
+
+  return 'upcoming'
+}
+
+/**
+ * Whether the line **leaving** a step is drawn as travelled.
+ *
+ * The line between two steps belongs to the one above it, so it is done exactly when that
+ * step is: the connector under the current step is still track, because the stepper has
+ * not left it yet.
+ */
+export function isConnectorDone(status: StepStatus): boolean {
+  return status === 'completed'
+}
+
+/**
+ * Whether the line **arriving** at a step is drawn as travelled — the horizontal half a
+ * step draws to its start, which belongs to the step before it.
+ *
+ * That line is done when the previous step is completed, and a step is preceded by a
+ * completed one exactly when it is not upcoming. It has no vertical equivalent: a vertical
+ * step draws only the line leaving it, so nothing is drawn twice.
+ */
+export function isLeadDone(status: StepStatus): boolean {
+  return status !== 'upcoming'
+}

--- a/packages/native/src/utils/check-glyph.ts
+++ b/packages/native/src/utils/check-glyph.ts
@@ -1,0 +1,47 @@
+import type { ViewStyle } from 'react-native'
+
+/**
+ * The long stroke of the tick, as a fraction of the box it sits in. Exported because the
+ * `Checkbox`'s indeterminate dash is that same stroke on its own and level, and the two
+ * marks drifting apart would read as two different glyph sets.
+ */
+export const CHECK_SPAN = 0.5
+
+/** The short stroke, as a fraction of the box. */
+const CHECK_RISE = 0.25
+
+/**
+ * A tick drawn out of two borders of an empty box, a quarter turn from where they look
+ * like one — so a control can mark itself in a project that has installed no icon set.
+ *
+ * It is **derived from the box** rather than tabulated: half its width, a quarter its
+ * height. Two numbers in a table would drift from the box the day someone changes it, and
+ * a check that is not proportional to its box reads as a different glyph at every size.
+ *
+ * The lift is the part worth having in one place. An "L" has its ink in one corner, not in
+ * the middle of its box, so rotating it about that box's centre leaves the tick sitting
+ * low. Rotating by −45° maps a point to `(dy − dx)·√2/2`, and over the two strokes that
+ * spans `H` at the top and `H − t − W` at the bottom — an ink centre `(H − t)·√2/4`
+ * **below** the box centre, which flexbox then dutifully centres. Lifting by exactly that
+ * is what makes the mark look centred rather than measure centred.
+ *
+ * Both transforms are returned together, and never split across two style objects:
+ * `transform` is a whole value, so a later step replaces it rather than blending into it.
+ *
+ * The colour is not here. A mark takes it from the variant that owns it — the box it fills
+ * for a `Checkbox`, the accent's contrast for a completed `Stepper` step.
+ */
+export function checkGlyph(side: number, stroke: number): ViewStyle {
+  const rise = side * CHECK_RISE
+
+  return {
+    width: side * CHECK_SPAN,
+    height: rise,
+    borderStartWidth: stroke,
+    borderBottomWidth: stroke,
+    transform: [
+      { translateY: -((rise - stroke) * Math.SQRT2) / 4 },
+      { rotate: '-45deg' },
+    ],
+  }
+}

--- a/packages/native/tsup.config.ts
+++ b/packages/native/tsup.config.ts
@@ -22,6 +22,7 @@ const entries = {
   'components/skeleton/index': 'src/components/skeleton/index.ts',
   'components/slider/index': 'src/components/slider/index.ts',
   'components/spinner/index': 'src/components/spinner/index.ts',
+  'components/stepper/index': 'src/components/stepper/index.ts',
   'components/surface/index': 'src/components/surface/index.ts',
   'components/switch/index': 'src/components/switch/index.ts',
   'components/tabs/index': 'src/components/tabs/index.ts',


### PR DESCRIPTION
Closes P5.5. **Toolbar (P5.6), BottomTabBar (P5.12) and Menubox (P5.13) are dropped** —
decided against rather than deferred, and kept on the roadmap under a new `dropped` status
so the decision is recorded rather than rediscovered.

## What

`Stepper` — root plus `Item`, `Indicator`, `Content`, `Title`, `Description`.

```tsx
<Stepper value={2}>
  <Stepper.Item>
    <Stepper.Indicator />
    <Stepper.Content>
      <Stepper.Title>Compte</Stepper.Title>
      <Stepper.Description>Créez votre compte</Stepper.Description>
    </Stepper.Content>
  </Stepper.Item>
</Stepper>
```

## Why it is shaped this way

**The value is the caller's, always.** No `defaultValue`, no `onValueChange`: nothing inside
a stepper can move the value, because a step is a report rather than a control. An
uncontrolled stepper would be a piece of state that could never change. It counts from one,
so `value={2}` is "step 2 of 4" — the number you would say out loud, not an index.

**The root numbers its children.** An item declares no index and no key. JSX order is step
order (R4), so inserting a step in the middle renumbers the rest by being there — the
reasoning that puts the `Accordion`'s separators on its root.

**The connectors, unlike those separators, belong to the indicator.** A vertical line runs
from under one circle to the next *through the text beside it*, and only something inside
that row can measure that height. A horizontal step carries two halves, one either side, so
its circle stays centred over its label whatever the neighbours do; the two ends of the rail
are drawn transparent rather than dropped, or the first and last circles would slide off.

**A step is not pressable**, and that is `asChild`'s job rather than an `onPress` prop. The
composition is one line, and a stepper where tapping ahead skips a form's validation is not
something the component should make easy.

**`color` paints the progress, not the track.** The untravelled half is written from the
theme rather than named as a role, which is what makes that guaranteed rather than
incidental — a stepper whose whole rail took the tint would have stopped showing progress.

**The status is an overlay, not an axis.** `indicator` is what an upcoming step looks like
and the other two statuses lay a colour over it — the `Checkbox`'s `bgSelected` trick, and
for its reason: `tint` re-runs `paint` and the states, not the axes, so an axis would have
kept the status out of the cache key at the cost of tinting.

## Shared with the Checkbox

The tick a completed step draws moves to `utils/check-glyph` — the second use, which is when
§2 bis says to extract. Two borders of an empty box a quarter turn from where they look like
one, so both controls work in a project that has installed no icon set. The lift that makes
the mark look centred rather than measure centred is the part worth having in one place.

## Verified

Rendered in the demo and read off the emitted styles, in **light and dark**:

| | fill | ring | line leaving it |
| --- | --- | --- | --- |
| completed | accent disc, check in `accentForeground` | — | accent |
| current | — | accent | `border` |
| upcoming | — | `border` | `border` |

Dark flips both sides from the tokens alone (`#c084fc` / `#27272a`). A `color="#15803d"`
stepper paints the disc, the check's contrast, the ring, the number and the travelled line
green, and leaves the untravelled rail `#e4e4e7` — the claim above, checked rather than
asserted. Horizontal renders equal-width items with a stretched track and a transparent lead
on the first step.

## Gates

- `pnpm type-check` — green.
- `pnpm test` — green, 274 tests (13 new: `stepStatus`, the two connector predicates, and
  `checkGlyph`; no component test, per the repo's convention).
- `pnpm lint` — green on `@xaui/native`. The demo keeps 5 pre-existing
  `react/no-unescaped-entities` errors in `popover.tsx` and `select.tsx`, both outside this
  diff.
- Review found two things, both fixed before commit: a `disabled` state in the recipe that
  nothing could reach, and a barrel exporting its utils where the convention exports the
  slots.