### PR TITLE
feat(tabs): a hairline between the tabs the pill is nowhere near

### DIFF
--- a/.changeset/tabs-separators.md
+++ b/.changeset/tabs-separators.md
@@ -1,0 +1,25 @@
+---
+'@xaui/native': patch
+---
+
+`Tabs` draws a hairline between the tabs the pill is nowhere near.
+
+`hasSeparator` is what separates a segmented control from a tab bar wearing the same
+clothes. It is off by default: the pill already says which tab is chosen, and the rules are
+what a segmented control adds when its options are peers to compare rather than places to
+go.
+
+Both edges of the pill stay clear — a rule running into a raised surface reads as a crack in
+it, which is the behaviour iOS has had since the segmented control was introduced and the
+reason one does not look like a table.
+
+The rule belongs to the tab on its trailing side, which is what lets a trigger decide alone:
+the list has no way to know which of its children is which without reading their props, and
+that is introspection this library does not do. Every trigger already publishes its
+rectangle for the indicator to slide to, and an ordering is all this needs — so before the
+first layout nothing is drawn, and the rules arrive with the pill rather than a frame ahead
+of it.
+
+This closes P5.9. A separate `SegmentButton` would have been `Tabs` in `primary` renamed:
+the pill, the track and the `segment` tokens are already there, and a segmented control used
+as a form choice is `accessibilityRole="radio"` on the trigger, which R9 has always allowed.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -86,7 +86,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.7   | `List` — slots over the existing group context                                   | todo   |
 | P5.7b  | `ListGroup` — net new, sectioned `List` with its headers                         | todo   |
 | P5.8   | `Menu` — Trigger · Overlay · Content · Label · Group · Item                      | done   |
-| P5.9   | `SegmentButton` — slots over the existing group context                          | todo   |
+| P5.9   | `SegmentButton` — covered by `Tabs` `primary` plus its separators                | done   |
 | P5.10  | `Autocomplete` — slots over the existing group context                           | todo   |
 | P5.10b | `Combobox` — the `Autocomplete` over a closed list                               | todo   |
 | P5.11  | `Accordion` — Item · Trigger · Indicator · Content, over legacy `ExpansionPanel` | done   |

--- a/apps/demo/app/tabs.tsx
+++ b/apps/demo/app/tabs.tsx
@@ -54,6 +54,14 @@ export default function TabsScreen() {
       </Section>
 
       <Section
+        title="Separators, for options that are peers"
+        note="hasSeparator draws a hairline between the tabs the pill is nowhere near. Off by default: the pill already says which tab is chosen, and the rules are what a segmented control adds when its options are things to compare rather than places to go. Both edges of the pill stay clear — a rule running into a raised surface reads as a crack in it, which is why iOS has drawn it this way since the segmented control existed."
+      >
+        <Panels hasSeparator />
+        <Panels hasSeparator variant="secondary" />
+      </Section>
+
+      <Section
         title="Sizes"
         note="size moves the trigger's padding, its gap and the type. The track's three-point inset does not scale: it is the gap between the pill and the track's edge, and at half a spacing step it would be two points and the pill would touch."
       >
@@ -123,17 +131,25 @@ function Panels({
   variant,
   size,
   color,
+  hasSeparator,
   hidePanels,
 }: {
   variant?: TabsVariant
   size?: TabsSize
   color?: string
+  hasSeparator?: boolean
   hidePanels?: boolean
 }) {
   const theme = useXAUITheme()
 
   return (
-    <Tabs defaultValue="all" variant={variant} size={size} color={color}>
+    <Tabs
+      defaultValue="all"
+      variant={variant}
+      size={size}
+      color={color}
+      hasSeparator={hasSeparator}
+    >
       <Tabs.List>
         <Tabs.Indicator />
         {PANELS.map(({ value, label }) => (

--- a/packages/native/src/__tests__/components/tabs/tabs.utils.test.ts
+++ b/packages/native/src/__tests__/components/tabs/tabs.utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { hasLeadingSeparator } from '../../../components/tabs/tabs.utils'
+
+/** Three tabs laid out left to right, in the order a row lays them out. */
+const RECTS = {
+  all: { x: 0, width: 80 },
+  open: { x: 80, width: 90 },
+  done: { x: 170, width: 70 },
+}
+
+describe('hasLeadingSeparator', () => {
+  it('never draws one before the first tab', () => {
+    expect(hasLeadingSeparator(RECTS, 'all', 'done')).toBe(false)
+  })
+
+  it('draws one between two tabs the pill is nowhere near', () => {
+    expect(hasLeadingSeparator(RECTS, 'done', 'all')).toBe(true)
+  })
+
+  it('leaves both edges of the pill clear', () => {
+    // `open` is selected: neither its own leading rule nor `done`'s, which sits on the
+    // pill's other side, is drawn.
+    expect(hasLeadingSeparator(RECTS, 'open', 'open')).toBe(false)
+    expect(hasLeadingSeparator(RECTS, 'done', 'open')).toBe(false)
+  })
+
+  it('reads the order off the rectangles rather than off the object', () => {
+    const shuffled = { done: RECTS.done, all: RECTS.all, open: RECTS.open }
+
+    expect(hasLeadingSeparator(shuffled, 'all', 'done')).toBe(false)
+    expect(hasLeadingSeparator(shuffled, 'open', 'all')).toBe(false)
+    expect(hasLeadingSeparator(shuffled, 'done', 'all')).toBe(true)
+  })
+
+  it('draws nothing before the first layout', () => {
+    expect(hasLeadingSeparator({}, 'all', 'all')).toBe(false)
+  })
+
+  it('draws every rule when nothing is selected', () => {
+    expect(hasLeadingSeparator(RECTS, 'open', undefined)).toBe(true)
+    expect(hasLeadingSeparator(RECTS, 'done', undefined)).toBe(true)
+  })
+})

--- a/packages/native/src/components/tabs/tabs-trigger.tsx
+++ b/packages/native/src/components/tabs/tabs-trigger.tsx
@@ -1,12 +1,14 @@
 import { forwardRef, useCallback, useMemo } from 'react'
-import type { LayoutChangeEvent, View } from 'react-native'
+import type { LayoutChangeEvent } from 'react-native'
 import { usePressState } from '../../hooks/use-press-state'
 import { PressableFeedback } from '../../system/pressable-feedback'
 import { childrenToString } from '../../system/slot'
 import { useStyleProps } from '../../system/style-props'
+import { View } from 'react-native'
 import { TabsLabel } from './tabs-label'
 import { TabsTriggerProvider, useTabs } from './tabs.context'
 import type { TabsTriggerProps } from './tabs.type'
+import { hasLeadingSeparator } from './tabs.utils'
 
 /**
  * One tab.
@@ -34,6 +36,9 @@ export const TabsTrigger = forwardRef<View, TabsTriggerProps>(function TabsTrigg
 ) {
   const {
     triggerStyle,
+    separatorStyle,
+    hasSeparator,
+    rects,
     value: selected,
     isDisabled: isRootDisabled,
     select,
@@ -94,6 +99,9 @@ export const TabsTrigger = forwardRef<View, TabsTriggerProps>(function TabsTrigg
         onPressIn={press.onPressIn}
         onPressOut={press.onPressOut}
       >
+        {hasSeparator && hasLeadingSeparator(rects, value, selected) ? (
+          <View style={separatorStyle} />
+        ) : null}
         {typeof children === 'function' ? (
           children(context)
         ) : text !== null ? (

--- a/packages/native/src/components/tabs/tabs.md
+++ b/packages/native/src/components/tabs/tabs.md
@@ -101,6 +101,26 @@ something the list conjures.
 
 Full RN names, full RN values (R14). Every node takes them.
 
+## Separators, for options that are peers
+
+`hasSeparator` draws a hairline between the tabs the pill is nowhere near — the thing that
+separates a segmented control from a tab bar wearing the same clothes.
+
+It is **off by default**. The pill already says which tab is chosen; the rules are what a
+segmented control adds when its options are things to compare rather than places to go.
+
+**Both edges of the pill stay clear.** A rule running into a raised surface reads as a crack
+in it, so neither the selected tab's own leading rule nor the one belonging to the tab after
+it is drawn. That is the behaviour iOS has had since the segmented control was introduced,
+and it is why a segmented control does not look like a table.
+
+The rule belongs to the tab on its trailing side, which is what lets a trigger decide alone:
+the list has no way to know which of its children is which without reading their props, and
+reading a child's props is introspection this library does not do. Every trigger already
+publishes its rectangle for the indicator to slide to, and an ordering is all this needs —
+so before the first layout nothing is drawn, and the rules arrive with the pill rather than
+a frame ahead of it.
+
 ## Props
 
 ### `Tabs`
@@ -114,6 +134,7 @@ Full RN names, full RN values (R14). Every node takes them.
 | `value`         | `string`                              | —         | Controlled                      |
 | `defaultValue`  | `string`                              | —         | Uncontrolled                    |
 | `onValueChange` | `(value: string) => void`             | —         | Fires on every choice           |
+| `hasSeparator`  | `boolean`                             | `false`   | Hairlines between the tabs      |
 | `isDisabled`    | `boolean`                             | `false`   | Dims the bar, stops every tab   |
 
 No `xs`. A tab is a target before it is a label, and at that height there is nothing left

--- a/packages/native/src/components/tabs/tabs.recipe.ts
+++ b/packages/native/src/components/tabs/tabs.recipe.ts
@@ -1,9 +1,21 @@
+import { StyleSheet } from 'react-native'
 import { createRecipe, radiusAxis } from '../../system/recipe'
 import type { SlotStyles, VariantTokens } from '../../system/recipe'
 import type { FontSizeKey, XAUITheme } from '../../theme/theme.type'
 import type { TabsSize, TabsSlot, TabsVariant } from './tabs.type'
 
-const SLOTS = ['root', 'list', 'trigger', 'label', 'indicator', 'content'] as const
+const SLOTS = [
+  'root',
+  'list',
+  'trigger',
+  'separator',
+  'label',
+  'indicator',
+  'content',
+] as const
+
+/** One device pixel — 0.33 at 3× — and no theme has an opinion about that. */
+const HAIRLINE = StyleSheet.hairlineWidth
 
 /**
  * The three shapes read the same three roles, and that is the point: a tint lands on any
@@ -51,6 +63,13 @@ function sizeAxis(step: SizeStep) {
       paddingVertical: theme.spacing(paddingVertical),
       gap: theme.spacing(gap),
     },
+    // Inset by the trigger's own vertical padding, so the rule spans exactly the label
+    // beside it. A hairline running the full height of the track reads as a table's
+    // column edge rather than as the seam between two segments.
+    separator: {
+      top: theme.spacing(paddingVertical),
+      bottom: theme.spacing(paddingVertical),
+    },
     label: {
       fontSize: theme.fontSizes[label],
       lineHeight: theme.lineHeights[label],
@@ -83,6 +102,14 @@ export const tabsRecipe = createRecipe({
     },
     // Behind the triggers, not over them: it is the surface the chosen tab sits on.
     indicator: { position: 'absolute', zIndex: 0, borderCurve: 'continuous' },
+    // Pinned to the trigger's own leading edge, which is the boundary between it and the
+    // tab before it: the list lays its triggers out with no gap, so the two edges coincide.
+    separator: {
+      position: 'absolute',
+      start: 0,
+      width: HAIRLINE,
+      backgroundColor: theme.colors.separator,
+    },
   }),
 
   variantTokens: VARIANT_TOKENS,

--- a/packages/native/src/components/tabs/tabs.tsx
+++ b/packages/native/src/components/tabs/tabs.tsx
@@ -39,6 +39,7 @@ export const TabsRoot = forwardRef<View, TabsProps>(function Tabs(
     value: controlledValue,
     defaultValue,
     onValueChange,
+    hasSeparator = false,
     isDisabled = false,
     style,
     ...props
@@ -85,15 +86,27 @@ export const TabsRoot = forwardRef<View, TabsProps>(function Tabs(
       labelStyle: styles.label,
       labelSelectedStyle: { color: selected.color },
       indicatorStyle: tint ? [styles.indicator, tint.indicator] : styles.indicator,
+      separatorStyle: styles.separator,
       contentStyle: undefined,
       variant: variant ?? 'primary',
+      hasSeparator,
       value,
       isDisabled,
       select,
       rects,
       setRect,
     }
-  }, [styles, tint, variant, value, isDisabled, select, rects, setRect])
+  }, [
+    styles,
+    tint,
+    variant,
+    hasSeparator,
+    value,
+    isDisabled,
+    select,
+    rects,
+    setRect,
+  ])
 
   return (
     <TabsProvider value={context}>

--- a/packages/native/src/components/tabs/tabs.type.ts
+++ b/packages/native/src/components/tabs/tabs.type.ts
@@ -15,6 +15,7 @@ export type TabsSlot =
   | 'list'
   | 'trigger'
   | 'label'
+  | 'separator'
   | 'indicator'
   | 'content'
 
@@ -47,6 +48,14 @@ type TabsOwnProps = {
   value?: string
   defaultValue?: string
   onValueChange?: (value: string) => void
+  /**
+   * Whether a hairline is drawn between the tabs the pill is nowhere near.
+   *
+   * Off by default: a pill sliding under the chosen tab already says which one it is, and
+   * the rules are what a segmented control adds when its options are peers to be compared
+   * rather than places to go. Both edges of the pill stay clear — see `hasLeadingSeparator`.
+   */
+  hasSeparator?: boolean
   isDisabled?: boolean
 }
 
@@ -100,8 +109,10 @@ export type TabsContextValue = {
   labelStyle: StyleProp<TextStyle>
   labelSelectedStyle: StyleProp<TextStyle>
   indicatorStyle: StyleProp<ViewStyle>
+  separatorStyle: StyleProp<ViewStyle>
   contentStyle: StyleProp<ViewStyle>
   variant: TabsVariant
+  hasSeparator: boolean
   value: string | undefined
   isDisabled: boolean
   select: (value: string) => void

--- a/packages/native/src/components/tabs/tabs.utils.ts
+++ b/packages/native/src/components/tabs/tabs.utils.ts
@@ -1,0 +1,41 @@
+import type { TabRect } from './tabs.type'
+
+/**
+ * Whether a tab draws the hairline at its own leading edge.
+ *
+ * The rule between two segments belongs to the one on its trailing side, which is what
+ * lets a trigger decide alone: the list has no way to know which of its children is which
+ * without reading their props, and reading a child's props is the introspection this
+ * library does not do. Every trigger already publishes its rectangle for the indicator to
+ * slide to, and an ordering is all this needs.
+ *
+ * Three cases draw nothing. The **first** tab has no neighbour to be separated from. The
+ * **selected** tab is wearing the pill, and a rule running into a raised surface reads as
+ * a crack in it. And the tab **after** the selected one is on the pill's other edge, for
+ * the same reason — which is the behaviour iOS has had since the segmented control was
+ * introduced, and the reason a segmented control does not look like a table.
+ *
+ * Before the first layout `rects` is empty and nothing is drawn, so the rules arrive with
+ * the pill rather than flashing a frame ahead of it.
+ */
+export function hasLeadingSeparator(
+  rects: Readonly<Record<string, TabRect>>,
+  value: string,
+  selected: string | undefined
+): boolean {
+  const self = rects[value]
+
+  if (self === undefined || value === selected) return false
+
+  let previous: string | undefined
+  let previousX = -Infinity
+
+  for (const [key, rect] of Object.entries(rects)) {
+    if (rect.x < self.x && rect.x > previousX) {
+      previous = key
+      previousX = rect.x
+    }
+  }
+
+  return previous !== undefined && previous !== selected
+}


### PR DESCRIPTION
Closes **P5.9 `SegmentButton`** — without adding a component.

## The finding first

P5.9 asked for a `SegmentButton`. `Tabs` in `variant="primary"` already **is** one: a pill
sliding under the chosen tab inside a filled track, painted with the theme's own `segment` /
`segmentForeground` tokens, which exist for exactly this. Its own type says so —
*"`primary` is the segmented control"*.

The two other things a separate component might have justified are already covered:

- **Panels.** `Tabs.Content` is optional. `Tabs.List` + `Tabs.Trigger` alone is a value
  picker.
- **Semantics.** A segmented control used as a form choice wants `radiogroup` / `radio`
  rather than `tablist` / `tab`. R9 has always made those overridable — the defaults are
  destructured defaults, not hardcoded.

What was genuinely missing is the **rules between segments**, which is the difference the
reference's own caption points at ("Without separators").

## What this adds

`hasSeparator`, off by default. The pill already says which tab is chosen; the rules are
what a segmented control adds when its options are peers to compare rather than places to go.

**Both edges of the pill stay clear.** A rule running into a raised surface reads as a crack
in it, so neither the selected tab's leading rule nor the one belonging to the tab after it
is drawn — the behaviour iOS has had since the segmented control was introduced, and the
reason one does not look like a table.

The rule belongs to the tab on its **trailing** side, which is what lets a trigger decide
alone. The list cannot know which of its children is which without reading their props, and
reading a child's props is introspection this library does not do; every trigger already
publishes its rectangle for the indicator to slide to, and an ordering is all `hasLeadingSeparator`
needs.

## Verified

`hasLeadingSeparator` is a pure function with 6 tests covering the first tab, both edges of
the pill, an unordered rect map, the pre-layout empty map and the nothing-selected case.

**Not verified on screen.** The rules only exist once every trigger has reported a rectangle,
and a server render has no layout — so the demo's static output cannot show them, unlike the
other components in this batch. The demo screen has the section; it wants a look on the
device.

## Gates

`pnpm lint`, `pnpm type-check` green. `pnpm test` green, 284 (6 new).

If you would rather have `Segment` as its own component anyway — a distinct name is worth
something on its own — say so and I will split it out; the mechanics land here either way.