### PR TITLE
feat(radio): Radio.Group — the set an option belongs to

### DIFF
--- a/.changeset/radio-group-v1.md
+++ b/.changeset/radio-group-v1.md
@@ -1,0 +1,39 @@
+---
+'@xaui/native': patch
+---
+
+feat(radio): `Radio.Group` — the set an option belongs to
+
+`Radio` shipped without one, which meant the one thing a radio is for — exclusive selection
+— was the caller's `useState` and their `map`. This is the context it was written to read,
+not a second radio.
+
+**It is `Radio.Group`, not a `RadioGroup` import.** The set publishes the values an option
+already reads and nothing else; a second module to make three radios exclusive would be a
+seam with nothing behind it. `RadioGroup` is exported as an alias for a call site that reads
+better naming it.
+
+**Membership is a `value`, not a nesting.** The group holds the chosen one, each option
+compares the one it stands for, and nothing walks the children — so an option inside a
+`Card`, a `List.Item` or a `Fragment` is in the set exactly as much as a direct child is.
+That is also what keeps a standalone radio over its own `isSelected` working unchanged
+inside a group: an option with no `value` is not in the set at all.
+
+`variant`, `size`, `radius` and `color` are handed down as **defaults**, and an option that
+names its own wins — a set is usually uniform, and the row that differs is a design rather
+than a mistake. `isDisabled` and `isInvalid` are the two that do not work that way: a
+disabled set has no enabled option in it, and a set that is wrong is wrong on every row.
+
+The group lays its options out, which is R4 and the reason it has a recipe at all — the gap
+follows `size`, and `orientation="horizontal"` wraps rather than overflowing off a narrow
+screen. It paints nothing, because an option resolves its own colours and a group that
+painted would be painting over the row that disagreed with it.
+
+`isSelected` still outranks the set, so one option in a group can be driven by something the
+group knows nothing about, and both callbacks fire on a press: the option's
+`onSelectedChange` and the set's `onValueChange`. Pressing the chosen option fires neither —
+a press selects and never clears, one level up from where the `Radio` already said so.
+
+`useRadioGroup()` is exported (R10) for an option of your own that is in the set without
+being a `Radio`. `accessibilityRole="radiogroup"` moves onto the group, where the wrapper in
+the old three-line recipe used to carry it.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "demo-web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "demo", "web", "--port", "8081"],
+      "port": 8081
+    }
+  ]
+}

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -146,7 +146,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.35g | `ToggleButtonGroup` — net new, exclusive selection over `ToggleButton`           | todo    |
 | P5.36  | `EmptyState` — net new, no legacy equivalent                                     | todo    |
 | P5.37  | `FlipCard` — net new, a `Card` with two faces                                    | todo    |
-| P5.38  | `RadioGroup` — over legacy `RadioGroup`, the context P3.9 `Radio` lacks          | todo    |
+| P5.38  | `Radio.Group` — over legacy `RadioGroup`, the context P3.9 `Radio` lacked        | done    |
 | P5.38b | `RadioButton` — net new, to reconcile with P3.9 `Radio`                          | todo    |
 | P5.38c | `RadioButtonGroup` — net new, to reconcile with `RadioGroup`                     | todo    |
 | P5.39  | `Rating` — net new, no legacy equivalent                                         | todo    |

--- a/apps/demo/app/popover.tsx
+++ b/apps/demo/app/popover.tsx
@@ -169,9 +169,9 @@ function ControlledDemo() {
         </Popover.Trigger>
         <Popover.Overlay />
         <Popover.Content placement="top">
-          <Popover.Title>Piloté de l'extérieur</Popover.Title>
+          <Popover.Title>Piloté de l’extérieur</Popover.Title>
           <Popover.Description>
-            La racine ne possède plus l'état d'ouverture.
+            La racine ne possède plus l’état d’ouverture.
           </Popover.Description>
         </Popover.Content>
       </Popover>
@@ -179,7 +179,7 @@ function ControlledDemo() {
         onPress={() => setOpen(true)}
         style={{ color: theme.colors.accent, fontSize: theme.fontSizes.sm }}
       >
-        Ouvrir depuis l'extérieur
+        Ouvrir depuis l’extérieur
       </Text>
     </View>
   )

--- a/apps/demo/app/radio.tsx
+++ b/apps/demo/app/radio.tsx
@@ -12,10 +12,10 @@ const PLANS = ['monthly', 'yearly', 'lifetime'] as const
  * The verification screen for the `Radio`. A component is verified here and in the docs
  * preview, in light and in dark — there is no test file for it.
  *
- * What each section checks is in its subtitle: a press selects and never clears, the set
- * is a row of radios over one piece of state rather than a group component, and everything
- * else — the three levels, the four sizes, the tint, `isInvalid`, `isDisabled` — is the
- * `Checkbox`'s, on a circle.
+ * What each section checks is in its subtitle: a press selects and never clears, a set is
+ * a `Radio.Group` around options that name a `value`, and everything else — the three
+ * levels, the four sizes, the tint, `isInvalid`, `isDisabled` — is the `Checkbox`'s, on a
+ * circle.
  */
 export default function RadioScreen() {
   const theme = useXAUITheme()
@@ -26,6 +26,51 @@ export default function RadioScreen() {
       contentContainerStyle={{ padding: 16, gap: 28, paddingBottom: 96 }}
     >
       <Choice />
+
+      <Section
+        title="A set hands its options their appearance"
+        note="variant, size, radius and color are defaults — the second option names its own variant and keeps it. isDisabled and isInvalid are not defaults: they hold for every row."
+      >
+        <Radio.Group defaultValue="a" size="lg" color="#7c3aed">
+          <Radio value="a">size et color viennent du groupe</Radio>
+          <Radio value="b" variant="tertiary">
+            variant=&quot;tertiary&quot; est à elle
+          </Radio>
+        </Radio.Group>
+      </Section>
+
+      <Section
+        title="orientation — and a set that is disabled, then invalid"
+        note="horizontal wraps rather than overflowing. A disabled set has no enabled option in it, and a set that is wrong is wrong on every row."
+      >
+        <Radio.Group defaultValue="s" orientation="horizontal" size="sm">
+          <Radio value="s">S</Radio>
+          <Radio value="m">M</Radio>
+          <Radio value="l">L</Radio>
+          <Radio value="xl">XL</Radio>
+        </Radio.Group>
+        <Radio.Group defaultValue="a" orientation="horizontal" isDisabled>
+          <Radio value="a">Éteinte</Radio>
+          <Radio value="b">Éteinte aussi</Radio>
+        </Radio.Group>
+        <Radio.Group orientation="horizontal" isInvalid>
+          <Radio value="a">Aucune choisie</Radio>
+          <Radio value="b">Et c’est l’erreur</Radio>
+        </Radio.Group>
+      </Section>
+
+      <Section
+        title="Membership is the value, not the nesting"
+        note="Nothing walks the children: an option inside a wrapper is in the set, and one with no value is not in it at all — which is what keeps a standalone radio working inside a group."
+      >
+        <Radio.Group defaultValue="card">
+          <View style={{ gap: 12 }}>
+            <Radio value="card">Carte bancaire — dans un wrapper</Radio>
+            <Radio value="transfer">Virement — dans le même</Radio>
+          </View>
+          <Radio defaultSelected>Sans value — hors du jeu, et cochée</Radio>
+        </Radio.Group>
+      </Section>
 
       <Section
         title="A press selects, it never clears"
@@ -112,26 +157,25 @@ export default function RadioScreen() {
 /** What each size measures, for the row's own label. */
 const BOXES: Record<RadioSize, number> = { sm: 20, md: 24, lg: 28 }
 
-/** The set: three radios over one piece of state. There is no group component. */
+/** The set: a `Radio.Group` over one value, and options that say what they stand for. */
 function Choice() {
   const [plan, setPlan] = useState<(typeof PLANS)[number]>('monthly')
 
   return (
     <Section
-      title="A set is a row of radios over one value"
-      note="RadioGroup is a P5 component with a context of its own, not a prop this one is missing. Until it lands, the wrapper carries the radiogroup role and each option compares the value it stands for."
+      title="A set is a Radio.Group over one value"
+      note="The group holds the chosen value and each option compares the one it stands for. Tap the chosen one: neither onValueChange nor onSelectedChange fires."
     >
-      <View accessibilityRole="radiogroup" style={{ gap: 12 }}>
+      <Radio.Group
+        value={plan}
+        onValueChange={next => setPlan(next as (typeof PLANS)[number])}
+      >
         {PLANS.map(value => (
-          <Radio
-            key={value}
-            isSelected={plan === value}
-            onSelectedChange={() => setPlan(value)}
-          >
+          <Radio key={value} value={value}>
             {LABELS[value]}
           </Radio>
         ))}
-      </View>
+      </Radio.Group>
     </Section>
   )
 }

--- a/apps/demo/app/radio.tsx
+++ b/apps/demo/app/radio.tsx
@@ -27,6 +27,8 @@ export default function RadioScreen() {
     >
       <Choice />
 
+      <PlanCards />
+
       <Section
         title="A set hands its options their appearance"
         note="variant, size, radius and color are defaults — the second option names its own variant and keeps it. isDisabled and isInvalid are not defaults: they hold for every row."
@@ -184,6 +186,131 @@ const LABELS: Record<(typeof PLANS)[number], string> = {
   monthly: 'Tous les mois',
   yearly: 'Tous les ans — deux mois offerts',
   lifetime: 'À vie',
+}
+
+/** The two plans behind the cards below — the count is its own line, so it is its own key. */
+const OFFERS = [
+  { id: 'quarterly', count: '3', unit: 'mois', price: '3,99 €/sem.', tag: '-73 %' },
+  {
+    id: 'monthly',
+    count: '1',
+    unit: 'mois',
+    price: '5,77 €/sem.',
+    tag: 'Populaire',
+  },
+] as const
+
+/**
+ * The set as a row of pressable cards. Nothing about the component changed: the `Radio` is
+ * the whole card because the root is the press target, the card belongs to the set because
+ * it names a `value` and not because of where the circle sits inside it, and the border and
+ * fill react to the choice because the demo already holds it — the same `plan` the group
+ * reads.
+ *
+ * The root is a row by default — it is what lines the circle up with its label. A card is
+ * a column, and `style` is the last word (§2 ter), so the card says so there. The circle
+ * is a plain `Radio.Indicator`, absolutely placed in the corner — `end`, never `right`.
+ */
+function PlanCards() {
+  const theme = useXAUITheme()
+  const [plan, setPlan] = useState<(typeof OFFERS)[number]['id']>('quarterly')
+
+  return (
+    <Section
+      title="A set can be a row of cards"
+      note="The card is the Radio — the root is the press target — and it is in the set because it names a value, whatever is nested inside it. The root is a row by default; the card turns it into a column through style, which is the last word. The selected border and fill are the demo's, driven by the same value the group holds."
+    >
+      <Radio.Group
+        value={plan}
+        onValueChange={next => setPlan(next as (typeof OFFERS)[number]['id'])}
+        orientation="horizontal"
+      >
+        {OFFERS.map(offer => {
+          const selected = plan === offer.id
+
+          return (
+            <Radio
+              key={offer.id}
+              value={offer.id}
+              radius="lg"
+              style={{
+                flexDirection: 'column',
+                alignItems: 'center',
+                // Stretch, not the recipe's flex-start: both cards take the tallest's
+                // height, which is what makes them read as one row of two offers.
+                alignSelf: 'stretch',
+                flexGrow: 1,
+                flexBasis: 150,
+                gap: 2,
+                paddingHorizontal: 16,
+                paddingTop: 20,
+                paddingBottom: 16,
+                borderWidth: 1,
+                borderColor: selected ? theme.colors.accent : theme.colors.border,
+                borderRadius: theme.radius.lg,
+                backgroundColor: selected
+                  ? theme.colors.accentSoft
+                  : theme.colors.surface,
+              }}
+            >
+              <Radio.Indicator style={{ position: 'absolute', top: 12, end: 12 }} />
+              <Text
+                style={{
+                  color: theme.colors.foreground,
+                  fontSize: theme.fontSizes['3xl'],
+                  lineHeight: theme.lineHeights['3xl'],
+                  fontWeight: theme.fontWeights.bold,
+                }}
+              >
+                {offer.count}
+              </Text>
+              <Text
+                style={{
+                  color: theme.colors.foreground,
+                  fontSize: theme.fontSizes.md,
+                  fontWeight: theme.fontWeights.medium,
+                }}
+              >
+                {offer.unit}
+              </Text>
+              <Text
+                style={{
+                  color: theme.colors.foreground,
+                  fontSize: theme.fontSizes.md,
+                  fontWeight: theme.fontWeights.semibold,
+                }}
+              >
+                {offer.price}
+              </Text>
+              <View
+                style={{
+                  marginTop: 8,
+                  paddingHorizontal: 10,
+                  paddingVertical: 4,
+                  borderRadius: theme.radius.full,
+                  backgroundColor: selected
+                    ? theme.colors.accent
+                    : theme.colors.backgroundSecondary,
+                }}
+              >
+                <Text
+                  style={{
+                    color: selected
+                      ? theme.colors.accentForeground
+                      : theme.colors.muted,
+                    fontSize: theme.fontSizes.xs,
+                    fontWeight: theme.fontWeights.semibold,
+                  }}
+                >
+                  {offer.tag}
+                </Text>
+              </View>
+            </Radio>
+          )
+        })}
+      </Radio.Group>
+    </Section>
+  )
 }
 
 function Section({

--- a/apps/demo/app/select.tsx
+++ b/apps/demo/app/select.tsx
@@ -190,7 +190,7 @@ function ControlledPicker() {
         onPress={() => setValue('fr')}
         style={{ color: theme.colors.accent, fontSize: theme.fontSizes.sm }}
       >
-        Remettre sur Français, depuis l'extérieur
+        Remettre sur Français, depuis l’extérieur
       </Text>
     </View>
   )

--- a/packages/native/src/components/radio/index.ts
+++ b/packages/native/src/components/radio/index.ts
@@ -1,17 +1,30 @@
+import { RadioGroupRoot } from './radio-group'
 import { RadioIndicator } from './radio-indicator'
 import { RadioLabel } from './radio-label'
 import { RadioRoot } from './radio'
 
+/**
+ * The set is `Radio.Group` rather than a component of its own, because it is not one: it
+ * publishes the context an option was already written to read, and importing a group from
+ * a second module to make three radios exclusive would be a seam with nothing behind it.
+ */
 export const Radio = Object.assign(RadioRoot, {
+  Group: RadioGroupRoot,
   Indicator: RadioIndicator,
   Label: RadioLabel,
 })
 
+/** The same object, for a call site that reads better naming the set. */
+export const RadioGroup = RadioGroupRoot
+
 export { RadioRoot } from './radio'
+export { RadioGroupRoot } from './radio-group'
 export { RadioIndicator } from './radio-indicator'
 export { RadioLabel } from './radio-label'
 export { useRadio } from './radio.context'
+export { useRadioGroup } from './radio-group.context'
 export { radioRecipe } from './radio.recipe'
+export { radioGroupRecipe } from './radio-group.recipe'
 export type {
   RadioContextValue,
   RadioIndicatorProps,
@@ -21,3 +34,9 @@ export type {
   RadioSlot,
   RadioVariant,
 } from './radio.type'
+export type {
+  RadioGroupContextValue,
+  RadioGroupOrientation,
+  RadioGroupProps,
+  RadioGroupSlot,
+} from './radio-group.type'

--- a/packages/native/src/components/radio/radio-group.context.ts
+++ b/packages/native/src/components/radio/radio-group.context.ts
@@ -1,0 +1,39 @@
+import { createContext, useContext } from 'react'
+import type { RadioGroupContextValue } from './radio-group.type'
+
+const RadioGroupContext = createContext<RadioGroupContextValue | null>(null)
+RadioGroupContext.displayName = 'XAUI.Radio.Group.Context'
+
+export const RadioGroupProvider = RadioGroupContext.Provider
+
+/**
+ * R10 — the set an option belongs to, for a third party writing its own row against the
+ * same values `Radio` reads.
+ *
+ * Strict, and named: a hook that asks for the set is asking for the chosen value, and
+ * outside a group there is none to give.
+ */
+export function useRadioGroup(): RadioGroupContextValue {
+  const value = useContext(RadioGroupContext)
+
+  if (value === null) {
+    throw new Error(
+      'XAUI: useRadioGroup must be called inside <Radio.Group>. It reads which option ' +
+        'the set has chosen, and outside a set there is no such thing.'
+    )
+  }
+
+  return value
+}
+
+/**
+ * The same context, read by a `Radio` that may not be in a set at all — a standalone
+ * radio over its own `isSelected` is the component's original shape and stays supported.
+ *
+ * Written by hand rather than through `createSlotContext` for exactly that: this is the
+ * one context in the library whose absence is a valid arrangement rather than a misplaced
+ * slot, so the throwing read and the optional one are two functions instead of one.
+ */
+export function useOptionalRadioGroup(): RadioGroupContextValue | null {
+  return useContext(RadioGroupContext)
+}

--- a/packages/native/src/components/radio/radio-group.recipe.ts
+++ b/packages/native/src/components/radio/radio-group.recipe.ts
@@ -1,0 +1,50 @@
+import { createRecipe } from '../../system/recipe'
+import type { SlotStyles } from '../../system/recipe'
+import type { XAUITheme } from '../../theme/theme.type'
+import type { RadioGroupSlot } from './radio-group.type'
+import type { RadioSize } from './radio.type'
+
+const SLOTS = ['root'] as const
+
+/**
+ * The set's one measurement: how far apart the options sit. It follows the options' own
+ * scale — a 28pt circle needs more air around it than a 20pt one — and it is the same
+ * number in both orientations, because a row and a column of the same options should read
+ * as the same spacing turned sideways.
+ */
+const GAPS: Record<RadioSize, number> = { sm: 2.5, md: 3, lg: 3.5 }
+
+function gapAxis(step: number) {
+  return (theme: XAUITheme): SlotStyles<RadioGroupSlot> => ({
+    root: { gap: theme.spacing(step) },
+  })
+}
+
+/**
+ * The group paints nothing. It has no `variantTokens` and no `paint` for that reason: an
+ * option resolves its own colours, because it can be given a `variant` or a `color` the
+ * set did not choose, and a group that painted would be painting over the row that
+ * disagreed with it.
+ */
+export const radioGroupRecipe = createRecipe({
+  slots: SLOTS,
+
+  variants: {
+    size: {
+      sm: gapAxis(GAPS.sm),
+      md: gapAxis(GAPS.md),
+      lg: gapAxis(GAPS.lg),
+    },
+
+    orientation: {
+      vertical: () => ({ root: { flexDirection: 'column' } }),
+      // Wrapping rather than scrolling: three short labels stay one row on a phone and
+      // become two on a narrow screen, where a row that overflowed would hide an option.
+      horizontal: () => ({
+        root: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center' },
+      }),
+    },
+  },
+
+  defaultVariants: { size: 'md', orientation: 'vertical' },
+})

--- a/packages/native/src/components/radio/radio-group.tsx
+++ b/packages/native/src/components/radio/radio-group.tsx
@@ -1,0 +1,107 @@
+import { forwardRef, useCallback, useMemo } from 'react'
+import { View } from 'react-native'
+import { useControllableState } from '../../hooks/use-controllable-state'
+import { Slot } from '../../system/slot'
+import { useStyleProps } from '../../system/style-props'
+import { useXAUITheme } from '../../theme/theme-hooks'
+import { RadioGroupProvider } from './radio-group.context'
+import { radioGroupRecipe } from './radio-group.recipe'
+import type { RadioGroupProps } from './radio-group.type'
+
+/**
+ * A set of options, and the one that is chosen.
+ *
+ * ```tsx
+ * <Radio.Group value={plan} onValueChange={setPlan}>
+ *   <Radio value="monthly">Tous les mois</Radio>
+ *   <Radio value="yearly">Tous les ans — deux mois offerts</Radio>
+ *   <Radio value="lifetime">À vie</Radio>
+ * </Radio.Group>
+ * ```
+ *
+ * **It is the context the `Radio` was missing**, not a second radio. An option still owns
+ * its circle, its press and its recipe; what it could not know on its own is whether it is
+ * the chosen one, and that is the whole of what this publishes.
+ *
+ * **Exclusivity comes from comparing one value, not from talking to siblings.** The group
+ * holds the chosen `value`; each option compares the `value` it stands for. Nothing walks
+ * the children, so an option nested in a card, a row or a `List.Item` is in the set exactly
+ * as much as a direct child is — and an option with no `value` is simply not in it.
+ *
+ * `variant`, `size`, `radius` and `color` are **defaults handed down**, and an option that
+ * names its own still wins: a set is usually uniform, and the exception is a design rather
+ * than a mistake. `isDisabled` and `isInvalid` are the two that do not work that way — a
+ * disabled set has no enabled option in it, and a set that is wrong is wrong on every row.
+ */
+export const RadioGroupRoot = forwardRef<View, RadioGroupProps>(function RadioGroup(
+  {
+    children,
+    value: controlledValue,
+    defaultValue,
+    onValueChange,
+    orientation,
+    variant,
+    size,
+    radius,
+    color,
+    isDisabled = false,
+    isInvalid = false,
+    asChild = false,
+    accessibilityRole,
+    style,
+    ...props
+  },
+  ref
+) {
+  const theme = useXAUITheme()
+  const [styleProps, rest] = useStyleProps(props)
+
+  const [value, setValue] = useControllableState<string | undefined>({
+    value: controlledValue,
+    defaultValue,
+    onChange: onValueChange as ((next: string | undefined) => void) | undefined,
+  })
+
+  const styles = radioGroupRecipe.resolve({
+    theme,
+    selection: { size, orientation },
+  })
+
+  // `useControllableState` drops a set to the value it already holds, so choosing the
+  // chosen option fires nothing — the `Radio`'s rule, one level up.
+  const select = useCallback((next: string) => setValue(next), [setValue])
+
+  const context = useMemo(
+    () => ({ value, select, variant, size, radius, color, isDisabled, isInvalid }),
+    [value, select, variant, size, radius, color, isDisabled, isInvalid]
+  )
+
+  const rootStyle = [styles.root, styleProps, style]
+
+  return (
+    <RadioGroupProvider value={context}>
+      {asChild ? (
+        <Slot
+          ref={ref}
+          accessibilityRole={accessibilityRole ?? 'radiogroup'}
+          {...rest}
+          style={rootStyle}
+        >
+          {children}
+        </Slot>
+      ) : (
+        <View
+          ref={ref}
+          // Announced once, by the thing that holds the choice. Overridable (R9).
+          accessibilityRole={accessibilityRole ?? 'radiogroup'}
+          {...rest}
+          style={rootStyle}
+        >
+          {children}
+        </View>
+      )}
+    </RadioGroupProvider>
+  )
+})
+
+RadioGroupRoot.displayName = 'XAUI.Radio.Group'

--- a/packages/native/src/components/radio/radio-group.type.ts
+++ b/packages/native/src/components/radio/radio-group.type.ts
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react'
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native'
+import type { AsChildProps } from '../../system/slot'
+import type { ViewStyleProps } from '../../system/style-props'
+import type { RadiusKey } from '../../theme/theme.type'
+import type { RadioSize, RadioVariant } from './radio.type'
+
+/**
+ * Which way the options run. `vertical` is the default because a set of options is read
+ * down a column; `horizontal` wraps, so a row of three short labels stays one row on a
+ * phone and becomes two on a watch rather than overflowing.
+ */
+export type RadioGroupOrientation = 'vertical' | 'horizontal'
+
+export type RadioGroupSlot = 'root'
+
+type RadioGroupOwnProps = {
+  /** The chosen option's `value`. Controlled — leave it out and the group holds its own. */
+  value?: string
+  /** The option chosen at first mount, when uncontrolled. */
+  defaultValue?: string
+  /**
+   * Fired with the newly chosen option's `value`. It never fires with `undefined`: a
+   * press selects and never clears, so a group that has a chosen option keeps one.
+   */
+  onValueChange?: (value: string) => void
+  orientation?: RadioGroupOrientation
+  /** The default for every option in the set. An option's own prop still wins. */
+  variant?: RadioVariant
+  /** The options' scale, and the gap between them. Never width. */
+  size?: RadioSize
+  /** The default corner for every option in the set. */
+  radius?: RadiusKey
+  /** A raw tint (`'#7c3aed'`), never a token (R7), applied to every option. */
+  color?: string
+  /** Dims every option and stops the press. An option cannot opt back in. */
+  isDisabled?: boolean
+  /** Paints every option in `danger` — the set is wrong, not one row of it. */
+  isInvalid?: boolean
+  style?: StyleProp<ViewStyle>
+  children?: ReactNode
+}
+
+/**
+ * R14 — the group's own props, `View`'s, and every `ViewStyle` key neither claims.
+ * `View`'s own props win over the style keys of the same name.
+ */
+export type RadioGroupProps = RadioGroupOwnProps &
+  AsChildProps &
+  Omit<ViewProps, keyof RadioGroupOwnProps> &
+  Omit<ViewStyleProps, keyof RadioGroupOwnProps | keyof ViewProps>
+
+/**
+ * R5 — what an option reads off its set. The appearance keys are **defaults, not resolved
+ * styles**: an option resolves its own recipe because it can be given a `variant` of its
+ * own, and a group that published styles would have to re-resolve them per option anyway.
+ *
+ * The one value no option can compute is `value` — which of them is the chosen one.
+ */
+export type RadioGroupContextValue = {
+  /** The chosen option's value, or `undefined` while none is. */
+  value: string | undefined
+  /** Makes `value` the chosen one. Named `select` because it never clears. */
+  select: (value: string) => void
+  variant: RadioVariant | undefined
+  size: RadioSize | undefined
+  radius: RadiusKey | undefined
+  color: string | undefined
+  isDisabled: boolean
+  isInvalid: boolean
+}

--- a/packages/native/src/components/radio/radio.md
+++ b/packages/native/src/components/radio/radio.md
@@ -11,10 +11,12 @@ import { Radio } from '@xaui/native/radio'
 ## Anatomy
 
 ```tsx
-<Radio>
-  <Radio.Indicator />
-  <Radio.Label />
-</Radio>
+<Radio.Group>
+  <Radio>
+    <Radio.Indicator />
+    <Radio.Label />
+  </Radio>
+</Radio.Group>
 ```
 
 - **`Radio`** — the root, and it is the **row, not the circle**. It is the pressable: it
@@ -22,6 +24,8 @@ import { Radio } from '@xaui/native/radio'
 - **`Radio.Indicator`** — the circle, and the dot inside it. With no children it draws its
   own dot.
 - **`Radio.Label`** — what choosing this option means.
+- **`Radio.Group`** — the set, and the one option in it that is chosen. Optional: a radio
+  over its own `isSelected` works without one.
 
 **It is the [`Checkbox`](../checkbox/checkbox.md) in a circle, with one rule changed: a
 press selects, it never clears.** A set of options has no "none of these" unless one of
@@ -33,31 +37,78 @@ Everything else is the checkbox's, deliberately: the root is the row so the labe
 the option, R3 wraps a text child into the label _and_ supplies the circle, the three
 variants and the four sizes are the same tokens, and no slot carries a margin (R4).
 
-## There is no group
-
-The set lives where its state does:
+## The set
 
 ```tsx
 const [plan, setPlan] = useState('monthly')
 
-<View accessibilityRole="radiogroup" style={{ gap: 12 }}>
-  {PLANS.map(value => (
-    <Radio
-      key={value}
-      isSelected={plan === value}
-      onSelectedChange={() => setPlan(value)}
-    >
-      {LABELS[value]}
-    </Radio>
-  ))}
-</View>
+<Radio.Group value={plan} onValueChange={setPlan}>
+  <Radio value="monthly">Tous les mois</Radio>
+  <Radio value="yearly">Tous les ans — deux mois offerts</Radio>
+  <Radio value="lifetime">À vie</Radio>
+</Radio.Group>
 ```
 
-`RadioGroup` is a **P5 component with a context of its own** — one of the ten the plan
-names as "a layer of slots over an existing group context" — not a prop this component is
-missing. Until it lands, the wrapper carries `accessibilityRole="radiogroup"` and each
-option compares the value it stands for. That is three lines, and they are the three lines
-the group component will replace rather than the ones it would have to undo.
+**`Radio.Group` is the context this component was written to read, not a second radio.** An
+option still owns its circle, its press and its recipe; what it could not know alone is
+whether it is the chosen one, and that is the whole of what the group publishes.
+
+**Exclusivity comes from comparing one value, not from talking to siblings.** The group
+holds the chosen `value`, each option compares the `value` it stands for, and nothing walks
+the children — so an option nested in a `Card`, a `List.Item` or a `Fragment` is in the set
+exactly as much as a direct child is:
+
+```tsx
+<Radio.Group defaultValue="card">
+  <Card>
+    <Radio value="card">Carte bancaire</Radio>
+  </Card>
+  <Card>
+    <Radio value="transfer">Virement</Radio>
+  </Card>
+</Radio.Group>
+```
+
+An option with **no `value`** is not in the set, whatever it is nested in — which is what
+keeps a standalone radio over its own `isSelected` working unchanged inside one.
+
+### What the set hands down
+
+`variant`, `size`, `radius` and `color` are **defaults**, and an option that names its own
+wins: a set is usually uniform, and the row that differs is a design rather than a mistake.
+
+`isDisabled` and `isInvalid` are the two that do not work that way — a disabled set has no
+enabled option in it, and a set that is wrong is wrong on every row. An option can still be
+disabled on its own inside an enabled set; it cannot opt back into a disabled one.
+
+```tsx
+<Radio.Group size="lg" color="#7c3aed" isDisabled>
+  <Radio value="a">Toutes en lg, violettes et éteintes</Radio>
+  <Radio value="b" variant="tertiary">
+    Sauf le contour, qui est à elle
+  </Radio>
+</Radio.Group>
+```
+
+### Orientation
+
+```tsx
+<Radio.Group orientation="horizontal">…</Radio.Group>
+```
+
+The set lays its options out — that is R4, and the reason `Radio.Group` has a recipe at all.
+`vertical` is the default; `horizontal` wraps, so three short labels stay one row on a phone
+and become two on a narrow screen rather than overflowing off it. The gap follows `size`.
+
+### Uncontrolled
+
+```tsx
+<Radio.Group defaultValue="monthly">…</Radio.Group>
+```
+
+`value` present means the caller owns the choice; `defaultValue` leaves it with the group.
+`onValueChange` fires either way, and never with `undefined`: a press selects and never
+clears, so a set that has a chosen option keeps one.
 
 ## Usage
 
@@ -71,9 +122,11 @@ the group component will replace rather than the ones it would have to undo.
 <Radio defaultSelected>Choisie au départ</Radio>
 ```
 
-`isSelected` present means the caller owns the value, which is what a set needs;
-`defaultSelected` is for the standalone case. `onPress` still fires, composed with the
-selection — it is what a wrapper listens to when it wants the press rather than the change.
+`isSelected` present means the caller owns the value; `defaultSelected` is for the
+standalone case. Inside a `Radio.Group` neither is needed — the set is the controlled source
+— and `isSelected` still outranks it, which is what lets one option in a group be driven by
+something the group knows nothing about. `onPress` fires either way, composed with the
+selection: it is what a wrapper listens to when it wants the press rather than the change.
 
 ### Invalid
 
@@ -82,8 +135,8 @@ selection — it is what a wrapper listens to when it wants the press rather tha
 ```
 
 The border, the fill and the label turn `danger`, and the resting fill is dropped: an
-option that is wrong reads as an outline. On a set, put `isInvalid` on every row — the
-error belongs to the question, not to one of its answers.
+option that is wrong reads as an outline. On a set, put it on the **group** — the error
+belongs to the question, not to one of its answers.
 
 ### Disabled
 
@@ -166,7 +219,10 @@ resting fill, and a built-in dot so no icon set is required.
 | The thumb scales 1.5 → 1 on its own                  | The fill and the dot arrive together     | One `SelectionFill`, shared with the `Checkbox`: what differs between the two controls is the mark, not how it arrives. |
 | `Radio.IndicatorBackground` (a glass layer)          | —                                        | A theme-registered blur layer belongs to their Uniwind theming, which is the premise XAUI does not share.               |
 
-Their `RadioGroup` is a component of its own and so is ours, in P5.
+Their `RadioGroup` is a component of its own with a `RadioGroup.Item` inside it; ours is
+`Radio.Group` around plain `Radio`s. One import, one option component, and a radio that
+means the same thing whether or not it is in a set — theirs has two, and the standalone one
+is the one that cannot be grouped.
 
 ## Props
 
@@ -181,13 +237,32 @@ Everything `PressableFeedback` accepts, every `ViewStyle` key it does not alread
 | `size`             | `'sm' \| 'md' \| 'lg'`          | `'md'`        | Circle, dot, gap, label type            |
 | `radius`           | `RadiusKey`                     | `'full'`      | A circle, unless you say otherwise      |
 | `color`            | `string`                        | —             | A hex tint — the colour once chosen     |
-| `isSelected`       | `boolean`                       | —             | Controlled                              |
+| `value`            | `string`                        | —             | What it stands for in a `Radio.Group`   |
+| `isSelected`       | `boolean`                       | —             | Controlled, and it outranks the group   |
 | `defaultSelected`  | `boolean`                       | `false`       | Uncontrolled starting value             |
 | `onSelectedChange` | `(isSelected: boolean) => void` | —             | Fires with `true` only                  |
 | `isInvalid`        | `boolean`                       | `false`       | Danger colours, and the tint is ignored |
 | `isDisabled`       | `boolean`                       | `false`       | Dims the row and stops the press        |
 | `animation`        | `AnimationProp`                 | —             | The press treatment, as everywhere else |
 | `asChild`          | `boolean`                       | `false`       | Merge into the single child             |
+
+### `Radio.Group`
+
+Everything `View` accepts, every `ViewStyle` key it does not already claim (R14), plus:
+
+| Prop            | Type                         | Default      | Notes                                 |
+| --------------- | ---------------------------- | ------------ | ------------------------------------- |
+| `value`         | `string`                     | —            | The chosen option. Controlled         |
+| `defaultValue`  | `string`                     | —            | Uncontrolled starting choice          |
+| `onValueChange` | `(value: string) => void`    | —            | Never fires with `undefined`          |
+| `orientation`   | `'vertical' \| 'horizontal'` | `'vertical'` | `horizontal` wraps                    |
+| `variant`       | `RadioVariant`               | —            | Default for every option              |
+| `size`          | `'sm' \| 'md' \| 'lg'`       | `'md'`       | The options' scale, and the gap       |
+| `radius`        | `RadiusKey`                  | —            | Default for every option              |
+| `color`         | `string`                     | —            | Default for every option              |
+| `isDisabled`    | `boolean`                    | `false`      | Every option, and no row opts back in |
+| `isInvalid`     | `boolean`                    | `false`      | Every option — the question is wrong  |
+| `asChild`       | `boolean`                    | `false`      | Merge into the single child           |
 
 ### `Radio.Indicator`
 
@@ -208,38 +283,47 @@ Everything `Text` accepts, plus the `TextStyle` keys as props (R14).
 `isDisabled` and `isInvalid` — enough to write a description under the label or a price
 beside it. Outside a `<Radio>` it throws by name.
 
+`useRadioGroup()` is exported too, and carries the chosen `value`, `select`, and the
+appearance the set hands down — enough to write an option of your own that is in the set
+without being a `Radio`. Outside a `<Radio.Group>` it throws by name.
+
 ## Accessibility
 
 - `accessibilityRole="radio"` on the root, overridable, with `accessibilityState.checked`
   following the value and `.disabled` following `isDisabled`. A caller's own
   `accessibilityState` is **merged**, not spread over.
 - `aria-invalid` follows `isInvalid`.
-- **Wrap the set** in a `View` with `accessibilityRole="radiogroup"` so a screen reader
-  announces "2 sur 3" rather than three unrelated controls.
+- `accessibilityRole="radiogroup"` on `Radio.Group`, overridable, so a screen reader
+  announces "2 sur 3" rather than three unrelated controls. A set built without the group
+  needs that role on whatever wraps it.
 - The whole row is the touch target, which is what makes a 24pt circle reachable.
 
 ## Migration from `@xaui/native-legacy`
 
-| Legacy                         | v1                                                                    |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `label="…"`                    | `<Radio>…</Radio>` — the text child _is_ the label                    |
-| `labelAlignment="left"`        | write `<Radio.Label>` before `<Radio.Indicator>`                      |
-| `labelAlignment="justify-*"`   | `justifyContent="space-between"` plus a width, in style props         |
-| `isChecked` / `defaultChecked` | `isSelected` / `defaultSelected`                                      |
-| `onValueChange`                | `onSelectedChange` — and it fires with `true` only                    |
-| `themeColor="primary"`         | `color={theme.colors.accent}` — a raw value (R7)                      |
-| `variant="filled"`             | `variant="tertiary"` — a border at rest, the accent once chosen       |
-| `variant="light"`              | gone: a dot with no circle. `<Radio.Indicator>` with your own mark    |
-| `size="sm" \| "md" \| "lg"`    | `size` — the same three                                               |
-| `radius`                       | `radius` — a `RadiusKey` now, and still `full` by default             |
-| `fullWidth`                    | `width="100%"` in style props (R14)                                   |
-| `isDisabled`                   | unchanged, on the root                                                |
-| `labelStyle`                   | `style` on `<Radio.Label>`                                            |
-| `style`                        | `style` on the root                                                   |
-| **`<RadioGroup>` and `value`** | **not yet** — the twelve lines above, or wait for the P5 `RadioGroup` |
+| Legacy                         | v1                                                                 |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `label="…"`                    | `<Radio>…</Radio>` — the text child _is_ the label                 |
+| `labelAlignment="left"`        | write `<Radio.Label>` before `<Radio.Indicator>`                   |
+| `labelAlignment="justify-*"`   | `justifyContent="space-between"` plus a width, in style props      |
+| `isChecked` / `defaultChecked` | `isSelected` / `defaultSelected`                                   |
+| `onValueChange`                | `onSelectedChange` — and it fires with `true` only                 |
+| `themeColor="primary"`         | `color={theme.colors.accent}` — a raw value (R7)                   |
+| `variant="filled"`             | `variant="tertiary"` — a border at rest, the accent once chosen    |
+| `variant="light"`              | gone: a dot with no circle. `<Radio.Indicator>` with your own mark |
+| `size="sm" \| "md" \| "lg"`    | `size` — the same three                                            |
+| `radius`                       | `radius` — a `RadiusKey` now, and still `full` by default          |
+| `fullWidth`                    | `width="100%"` in style props (R14)                                |
+| `isDisabled`                   | unchanged, on the root                                             |
+| `labelStyle`                   | `style` on `<Radio.Label>`                                         |
+| `style`                        | `style` on the root                                                |
+| `<RadioGroup>`                 | `<Radio.Group>` — same `value` / `defaultValue` / `onValueChange`  |
 
-The last row is the one to plan around: the legacy `RadioGroup` carried `value`,
-`defaultValue`, `onValueChange`, `orientation` and the shared `variant` / `size` / `radius`
-/ `themeColor` / `labelAlignment` / `fullWidth` for its options. Until the v1 group lands,
-a set is the `useState` and the `map` shown at the top of this page, and the shared props
-are written on each row — or spread from one object.
+The legacy `RadioGroup` also carried `orientation` — unchanged — and the shared `variant` /
+`size` / `radius` / `themeColor` / `labelAlignment` / `fullWidth` for its options. The first
+three are handed down as before, `themeColor` becomes `color` with a raw value (R7), and the
+last two are gone with the props they mirror: `labelAlignment` is JSX order plus a style
+prop on the row, and `fullWidth` is `width="100%"`.
+
+One difference worth reading twice: the legacy group **rendered** its options from an array
+of items, ours takes them as children. A set of options that comes from data is a `map`, and
+it is the same `map` the rest of this library asks for.

--- a/packages/native/src/components/radio/radio.tsx
+++ b/packages/native/src/components/radio/radio.tsx
@@ -6,6 +6,7 @@ import { PressableFeedback } from '../../system/pressable-feedback'
 import { childrenToString } from '../../system/slot'
 import { useStyleProps } from '../../system/style-props'
 import { useXAUITheme } from '../../theme/theme-hooks'
+import { useOptionalRadioGroup } from './radio-group.context'
 import { RadioIndicator } from './radio-indicator'
 import { RadioLabel } from './radio-label'
 import { RadioProvider } from './radio.context'
@@ -30,10 +31,20 @@ import type { RadioProps } from './radio.type'
  * clears.** A set of options has no "none of these" unless one of them says so, and a
  * radio that could be untapped back to empty would be a checkbox that happens to be round.
  *
- * **There is no group.** The set lives where its state does — `value === 'monthly'` above
- * is the whole of it — and `RadioGroup` is a P5 component with a context of its own, not a
- * prop this one is missing. Wrap the rows in a `View` with `accessibilityRole="radiogroup"`
- * until it lands.
+ * **A set is a `Radio.Group` around options that name a `value`:**
+ *
+ * ```tsx
+ * <Radio.Group value={plan} onValueChange={setPlan}>
+ *   <Radio value="monthly">Tous les mois</Radio>
+ *   <Radio value="yearly">Tous les ans</Radio>
+ * </Radio.Group>
+ * ```
+ *
+ * The group holds the chosen value and hands down `variant`, `size`, `radius` and `color`;
+ * an option that names its own still wins. Nothing walks the children, so an option nested
+ * in a card or a row is in the set exactly as much as a direct child is — and an option
+ * with no `value` is not in it at all, which is what keeps the standalone radio above
+ * working unchanged inside one.
  *
  * Everything else is the `Checkbox`'s: the root is the row, so the label chooses the
  * option; R3 wraps a text child into the label and supplies the circle; the three variants
@@ -46,6 +57,7 @@ export const RadioRoot = forwardRef<View, RadioProps>(function Radio(
     size,
     radius,
     color,
+    value,
     isSelected,
     defaultSelected = false,
     onSelectedChange,
@@ -70,39 +82,62 @@ export const RadioRoot = forwardRef<View, RadioProps>(function Radio(
   const [styleProps, rest] = useStyleProps(props)
   const [isPressed, press] = usePressState({ onPressIn, onPressOut })
 
+  // `null` outside a set, which is a valid arrangement rather than a misplaced slot — a
+  // radio over its own `isSelected` is this component's original shape.
+  const group = useOptionalRadioGroup()
+  // An option joins the set by naming what it stands for. Membership is that and nothing
+  // else: no child is inspected, so nesting one changes nothing.
+  const inGroup = group !== null && value !== undefined
+
   const [selected, setSelected] = useControllableState({
-    value: isSelected,
+    // The set is a controlled source like any other, and `isSelected` still outranks it:
+    // one option in a group can be driven by something the group knows nothing about.
+    value: isSelected ?? (inGroup ? group.value === value : undefined),
     defaultValue: defaultSelected,
     onChange: onSelectedChange,
   })
+
+  // The set's values are defaults, and the option's own win — a uniform set is the common
+  // case, and the row that differs is a design rather than a mistake.
+  const resolvedVariant = variant ?? group?.variant
+  const resolvedSize = size ?? group?.size
+  const resolvedRadius = radius ?? group?.radius
+  const resolvedColor = color ?? group?.color
+  // These two do not work that way: a disabled set has no enabled option in it, and a set
+  // that is wrong is wrong on every row.
+  const disabled = isDisabled || (group?.isDisabled ?? false)
+  const invalid = isInvalid || (group?.isInvalid ?? false)
 
   const handlePress = useCallback(
     (event: GestureResponderEvent) => {
       // `true`, never a toggle — and `useControllableState` drops a set to the value it
       // already holds, so pressing the chosen option fires nothing at all.
       setSelected(true)
-      // Composed, never replaced: a caller's `onPress` is what a group listens to when it
-      // wants the press rather than the change.
+      // Told to the set as well, because the set is what the other options read. Both
+      // callbacks fire: this option's `onSelectedChange` and the group's `onValueChange`.
+      if (inGroup) group.select(value)
+      // Composed, never replaced: a caller's `onPress` is what a wrapper listens to when
+      // it wants the press rather than the change.
       onPress?.(event)
     },
-    [setSelected, onPress]
+    [setSelected, inGroup, group, value, onPress]
   )
 
   const selection = {
-    variant,
-    size,
-    radius,
-    isInvalid: isInvalid ? ('true' as const) : undefined,
+    variant: resolvedVariant,
+    size: resolvedSize,
+    radius: resolvedRadius,
+    isInvalid: invalid ? ('true' as const) : undefined,
   }
-  const states = { pressed: isPressed, disabled: isDisabled }
+  const states = { pressed: isPressed, disabled }
 
   const styles = radioRecipe.resolve({ theme, selection, states })
   // Only when `color` is set, and never cached: a raw tint takes arbitrary values, so
   // letting one into the key would grow the table with the colours users invent. It is
   // suppressed while invalid — an error outranks a brand colour, as on the `Checkbox`.
   const tint =
-    color && !isInvalid
-      ? radioRecipe.tint({ theme, color, selection, states })
+    resolvedColor && !invalid
+      ? radioRecipe.tint({ theme, color: resolvedColor, selection, states })
       : undefined
 
   const context = useMemo(
@@ -114,10 +149,10 @@ export const RadioRoot = forwardRef<View, RadioProps>(function Radio(
       thumbStyle: tint ? [styles.thumb, tint.thumb] : styles.thumb,
       labelStyle: styles.label,
       isSelected: selected,
-      isDisabled,
-      isInvalid,
+      isDisabled: disabled,
+      isInvalid: invalid,
     }),
-    [styles, tint, selected, isDisabled, isInvalid]
+    [styles, tint, selected, disabled, invalid]
   )
 
   // The resolution order of §2 ter, most general to most specific: the cached recipe, the
@@ -150,7 +185,7 @@ export const RadioRoot = forwardRef<View, RadioProps>(function Radio(
       <PressableFeedback
         ref={ref}
         isPressed={isPressed}
-        isDisabled={isDisabled}
+        isDisabled={disabled}
         asChild={asChild}
         animation={animation}
         accessibilityRole={accessibilityRole ?? 'radio'}
@@ -158,10 +193,10 @@ export const RadioRoot = forwardRef<View, RadioProps>(function Radio(
         // the two a screen reader reads this control by. Their keys still win.
         accessibilityState={{
           checked: selected,
-          disabled: isDisabled,
+          disabled,
           ...accessibilityState,
         }}
-        aria-invalid={isInvalid}
+        aria-invalid={invalid}
         {...rest}
         style={rootStyle}
         // After `rest`, and composed rather than replacing.

--- a/packages/native/src/components/radio/radio.type.ts
+++ b/packages/native/src/components/radio/radio.type.ts
@@ -51,7 +51,22 @@ type RadioOwnProps = {
    * Ignored while `isInvalid`, as on the `Checkbox`.
    */
   color?: string
-  /** Controlled. Leave it out and the radio keeps its own state. */
+  /**
+   * What this option stands for inside a [`Radio.Group`](./radio-group.tsx). The group
+   * holds the chosen value; this is the one the option compares it to.
+   *
+   * It is the only thing that puts an option in a set — nothing walks the children — so a
+   * radio nested in a card or a `List.Item` belongs to the set exactly as much as a direct
+   * child does, and one without a `value` is simply not in it, whatever it is nested in.
+   *
+   * Outside a group it means nothing: use `isSelected`.
+   */
+  value?: string
+  /**
+   * Controlled. Leave it out and the radio keeps its own state — or, inside a
+   * `Radio.Group`, takes it from the set. Given here it wins over the set, which is what
+   * lets one option in a group be driven by something else.
+   */
   isSelected?: boolean
   /** The starting value when uncontrolled. @default false */
   defaultSelected?: boolean
@@ -59,11 +74,15 @@ type RadioOwnProps = {
    * Fired when the option becomes the chosen one — **`true` and only `true`**. Pressing a
    * selected radio changes nothing: a set of options has no "none of these" unless one of
    * them says so, which is a `Checkbox`'s job or another option's.
+   *
+   * Inside a `Radio.Group` it still fires, beside the group's `onValueChange` — one is the
+   * option's, the other the set's, and a row that needs to react to being chosen should
+   * not have to read the value it already stands for.
    */
   onSelectedChange?: (isSelected: boolean) => void
-  /** Paints the border, the fill and the label in `danger`. */
+  /** Paints the border, the fill and the label in `danger`. A group's still applies. */
   isInvalid?: boolean
-  /** Dims the row and stops the press. */
+  /** Dims the row and stops the press. A group's still applies. */
   isDisabled?: boolean
   animation?: AnimationProp
   /** R9 — `Pressable`'s function form as much as an object or an array. */


### PR DESCRIPTION
## What

`Radio.Group` — P5.38, and the one item on the list that repairs something already
published rather than adding to it. `Radio` shipped in P3.9 with no group context, which
meant the one thing a radio is for — exclusive selection — was the caller's `useState` and
their `map`.

It lives in `radio/` and is reached as `Radio.Group` (with a `RadioGroup` alias for a call
site that reads better naming the set). No new subpath: it is not a second component, it is
the context the first one was written to read.

```tsx
<Radio.Group value={plan} onValueChange={setPlan}>
  <Radio value="monthly">Tous les mois</Radio>
  <Radio value="yearly">Tous les ans — deux mois offerts</Radio>
</Radio.Group>
```

Two commits come with it and are called out because they are not the feature:

- `fix(demo)` — `react/no-unescaped-entities` was already failing `pnpm lint` on
  `popover.tsx` and `select.tsx` on main, so every PR opened from it starts red.
- `chore(demo)` — a `.claude/launch.json` entry so the web preview (how a screen is
  verified in light and dark) starts without a native toolchain.

## Why

A radio with no group is a checkbox that happens to be round. `radio.md` said as much and
sent the reader to a twelve-line recipe with a `View accessibilityRole="radiogroup"` around
it; this replaces those twelve lines rather than sitting beside them.

## How

- **Membership is a `value`, not a nesting.** The group holds the chosen one, each option
  compares the one it stands for, nothing walks the children. An option inside a `Card` or
  a `List.Item` is in the set exactly as much as a direct child is — and an option with no
  `value` is not in it at all, which is what keeps a standalone `Radio` over its own
  `isSelected` working unchanged inside a group.
- **`isSelected` outranks the set**, so one option can be driven by something the group
  knows nothing about. Both callbacks fire on a press: the option's `onSelectedChange` and
  the set's `onValueChange`. Pressing the chosen option fires neither.
- **`variant` / `size` / `radius` / `color` are defaults**; an option that names its own
  wins. `isDisabled` and `isInvalid` are not defaults — a disabled set has no enabled row
  in it, and a set that is wrong is wrong on every row.
- **The group lays out and paints nothing.** A recipe with one slot: the gap follows `size`,
  `orientation="horizontal"` wraps rather than overflowing. No `variantTokens`, because an
  option resolves its own colours and a group that painted would paint over the row that
  disagreed with it.
- `accessibilityRole="radiogroup"` on the root, overridable. `useRadioGroup()` exported
  (R10). `asChild` through `Slot` (R12).
- `radio.md` rewritten where it said "there is no group"; the demo screen gains four
  sections — the set, handed-down appearance, orientation with the disabled and invalid
  sets, and membership by value.

`pnpm lint && pnpm type-check && pnpm test` green. Demo screen checked in light and dark on
Expo web, including that choosing a third option clears the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)