### PR TITLE
feat(wheel-picker): a bold selection that turns under a scroll

### DIFF
--- a/.changeset/wheel-picker-select.md
+++ b/.changeset/wheel-picker-select.md
@@ -1,0 +1,21 @@
+---
+'@xaui/native': patch
+---
+
+A WheelPicker reads at a glance again, and turns under a parent scroll:
+
+The row at the middle is **bold**, on top of the band's colour — weight now says which row
+is chosen together with where it sits, and unfocused rows hold the body weight. The fade and
+lean away from the middle were doing that alone, and a still wheel next to a still list read
+as the same thing.
+
+The columns set `nestedScrollEnabled`, because a wheel most often sits inside a scroll of its
+own — on Android a vertical `ScrollView` under a vertical `ScrollView` keeps the gesture for
+itself unless the child asks, and a wheel that will not turn is not a wheel.
+
+Rows are a size step taller — `sm` 36, `md` 40 — so the band reads as a target you aim at
+rather than a hairline, and a turning row has room to lean into. `lg` keeps its 44.
+
+`ghost` and `tertiary` rows name `accentSoftForeground` rather than `foreground`, and
+`secondary`'s band is `defaultSoft`: under a tint, a bare `foreground` resolves to the tint
+itself, which painted the row the colour of the band it sits on.

--- a/packages/native/src/components/wheel-picker/wheel-picker-column.tsx
+++ b/packages/native/src/components/wheel-picker/wheel-picker-column.tsx
@@ -173,6 +173,7 @@ export const WheelPickerColumn = forwardRef<ScrollView, WheelPickerColumnProps>(
           showsVerticalScrollIndicator={false}
           // The two together are the snap: `fast` without an interval overshoots by rows,
           // and an interval without `fast` drifts to a stop between two of them.
+          nestedScrollEnabled={true}
           snapToInterval={rowHeight}
           decelerationRate="fast"
           scrollEnabled={!disabled}

--- a/packages/native/src/components/wheel-picker/wheel-picker.geometry.ts
+++ b/packages/native/src/components/wheel-picker/wheel-picker.geometry.ts
@@ -6,12 +6,12 @@ import type { WheelPickerSize } from './wheel-picker.type'
  *
  * Off the spacing grid, like the `Slider`'s rail: how tall a row has to be before a list
  * of them reads as a wheel you can aim at has nothing to do with the gaps between things.
- * `md` is iOS's picker row measured — 36 points, which is what puts five of them in the
- * 180 the platform's own wheel is.
+ * `md` sits a little above iOS's own 36-point picker row — the band reads as a target you
+ * aim at rather than a hairline, and a turning row has more room to lean into.
  */
 export const ROWS: Record<WheelPickerSize, { height: number; type: FontSizeKey }> = {
-  sm: { height: 32, type: 'sm' },
-  md: { height: 36, type: 'md' },
+  sm: { height: 36, type: 'sm' },
+  md: { height: 40, type: 'md' },
   lg: { height: 44, type: 'lg' },
 }
 

--- a/packages/native/src/components/wheel-picker/wheel-picker.recipe.ts
+++ b/packages/native/src/components/wheel-picker/wheel-picker.recipe.ts
@@ -26,9 +26,9 @@ const SLOTS = ['root', 'band', 'column', 'item', 'itemSelected'] as const
  */
 const VARIANT_TOKENS: Record<WheelPickerVariant, VariantTokens> = {
   primary: { bg: 'accentSoft', fg: 'accentSoftForeground' },
-  secondary: { bg: 'default', fg: 'defaultForeground' },
-  tertiary: { border: 'border', fg: 'foreground' },
-  ghost: { fg: 'foreground' },
+  secondary: { bg: 'defaultSoft', fg: 'accentSoftForeground' },
+  tertiary: { border: 'border', fg: 'accentSoftForeground' },
+  ghost: { fg: 'accentSoftForeground' },
 }
 
 function sizeAxis(size: WheelPickerSize) {
@@ -87,7 +87,7 @@ export const wheelPickerRecipe = createRecipe({
       borderBottomWidth: colors.border ? theme.borderWidth.default : 0,
     },
     item: { color: theme.colors.foreground },
-    itemSelected: { color: colors.fg },
+    itemSelected: { color: colors.fg, fontWeight: theme.fontWeights.bold },
   }),
 
   variants: {


### PR DESCRIPTION
## What

- The row at the middle of the wheel is **bold** (`theme.fontWeights.bold`), on top of the band colour.
- Wheel columns set `nestedScrollEnabled`, so the wheel turns inside a parent `ScrollView`.
- Rows run a size step taller (`sm` 36, `md` 40) so the band reads as a target and a turning row has room to lean.
- `ghost`/`tertiary` rows name `accentSoftForeground` (was `foreground`); `secondary`'s band is `defaultSoft` — under a tint, a bare `foreground` resolved to the tint itself.
- A changeset for `@xaui/native`.

## Why

Weight was the one thing not saying which row is chosen; a still wheel next to a still list read as the same thing. Android keeps the vertical gesture for a parent `ScrollView` unless the child asks, which made the wheel refuse to turn in a form. The token fix removes a row painted the colour of the band it sits on.

## How

All in the wheel-picker recipe/geometry plus one flag on the column's `ScrollView`. Verified with `pnpm lint && pnpm type-check && pnpm test` and the demo screen in light and dark.