### PR TITLE
chore: rename planned InputTrigger to DummyField

### DIFF
--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -131,7 +131,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.29 | `Carousel` | done |
 | P5.30 | `Pager` | todo |
 | P5.31 | `RefreshControl` | todo |
-| P5.32 | `InputTrigger` | todo |
+| P5.32 | `DummyField` — renamed from legacy `InputTrigger`, not the `Trigger` slot vocabulary | todo |
 | P5.33 | `FeatureDiscovery` | todo |
 | P5.34 | `BarChart` — grouped or stacked, drawn on `react-native-svg` | done |
 | P5.34b | `AreaChart` — net new, the `LineChart` with the ground under it filled | done |


### PR DESCRIPTION
## What
Renames the still-`todo` P5.32 roadmap entry from `InputTrigger` to `DummyField`.

## Why
`InputTrigger` clashes with the v1 `Trigger` slot vocabulary (`Select.Trigger`, `Popover.Trigger`, `Menu.Trigger`) even though it isn't a trigger for a compound component — it's a non-editable, pressable stand-in styled like a text field. `DummyField` follows the existing `Field` suffix (`TextField`, `MaskField`) and describes what it actually is.

## How
Status column/title text change only, no code touched yet (component doesn't exist in v1).