### PR TITLE
feat(native): add PhoneNumberField

### DIFF
--- a/.changeset/friendly-phone-countries.md
+++ b/.changeset/friendly-phone-countries.md
@@ -1,0 +1,5 @@
+---
+'@xaui/native': patch
+---
+
+Add PhoneNumberField with a country prefix, searchable country sheet, national number editing and E.164 output.

--- a/.changeset/friendly-phone-countries.md
+++ b/.changeset/friendly-phone-countries.md
@@ -2,4 +2,4 @@
 '@xaui/native': patch
 ---
 
-Add PhoneNumberField with a country prefix, searchable country sheet, national number editing and E.164 output.
+Add PhoneNumberField with a country prefix, searchable country sheet, national number editing and E.164 output. `libphonenumber-js` is a new optional peer dependency, needed only by this component.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -80,7 +80,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.3c  | `NumberField` — over legacy `NumberInput`, following `TextField`                 | done    |
 | P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share             | todo    |
 | P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not            | done    |
-| P5.3f  | `PhoneNumberInput` — net new, country prefix over the `TextField`                | todo    |
+| P5.3f  | `PhoneNumberField` — country prefix, searchable sheet and national number | done |
 | P5.3g  | `SearchInput` — net new, a `TextField` with its clear and submit                 | todo    |
 | P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                | done    |
 | P5.5   | `Stepper` — slots over the existing group context                                | done    |

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -80,7 +80,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.3c  | `NumberField` — over legacy `NumberInput`, following `TextField`                 | done    |
 | P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share             | todo    |
 | P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not            | done    |
-| P5.3f  | `PhoneNumberField` — country prefix, searchable sheet and national number | done |
+| P5.3f  | `PhoneNumberField` — country prefix, searchable sheet and national number        | done    |
 | P5.3g  | `SearchInput` — net new, a `TextField` with its clear and submit                 | todo    |
 | P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                | done    |
 | P5.5   | `Stepper` — slots over the existing group context                                | done    |

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { Stack } from 'expo-router'
+import { Button } from '@xaui/native/button'
 import { useColorScheme } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import 'react-native-reanimated'
@@ -14,11 +16,26 @@ import { XAUIProvider } from '@xaui/native/theme'
  */
 export default function RootLayout() {
   const colorScheme = useColorScheme()
+  const [mode, setMode] = useState<'light' | 'dark' | null>(null)
+  const colorMode = mode ?? (colorScheme === 'dark' ? 'dark' : 'light')
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <XAUIProvider colorMode={colorScheme === 'dark' ? 'dark' : 'light'}>
-        <Stack>
+      <XAUIProvider colorMode={colorMode}>
+        <Stack
+          screenOptions={{
+            headerRight: () => (
+              <Button
+                size="xs"
+                variant="secondary"
+                accessibilityLabel="Changer le thème"
+                onPress={() => setMode(colorMode === 'light' ? 'dark' : 'light')}
+              >
+                {colorMode === 'light' ? 'Dark' : 'Light'}
+              </Button>
+            ),
+          }}
+        >
           <Stack.Screen name="index" options={{ title: 'XAUI (v1)' }} />
           <Stack.Screen name="accordion" options={{ title: 'Accordion (v1)' }} />
           <Stack.Screen name="alert" options={{ title: 'Alert (v1)' }} />
@@ -104,6 +121,10 @@ export default function RootLayout() {
           <Stack.Screen name="tag-group" options={{ title: 'TagGroup (v1)' }} />
           <Stack.Screen name="text-area" options={{ title: 'TextArea (v1)' }} />
           <Stack.Screen name="text-field" options={{ title: 'TextField (v1)' }} />
+          <Stack.Screen
+            name="phone-number-field"
+            options={{ title: 'PhoneNumberField (v1)' }}
+          />
           <Stack.Screen name="time-field" options={{ title: 'TimeField (v1)' }} />
           <Stack.Screen name="timeline" options={{ title: 'Timeline (v1)' }} />
           <Stack.Screen name="time-picker" options={{ title: 'TimePicker (v1)' }} />

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -67,6 +67,7 @@ const SCREENS = [
   { href: '/tag-group', label: 'TagGroup' },
   { href: '/text-area', label: 'TextArea' },
   { href: '/text-field', label: 'TextField' },
+  { href: '/phone-number-field', label: 'PhoneNumberField' },
   { href: '/time-field', label: 'TimeField' },
   { href: '/timeline', label: 'Timeline' },
   { href: '/time-picker', label: 'TimePicker' },

--- a/apps/demo/app/phone-number-field.tsx
+++ b/apps/demo/app/phone-number-field.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import { ScrollView, Text, View } from 'react-native'
+import { Button } from '@xaui/native/button'
+import { FieldGroup } from '@xaui/native/field-group'
+import {
+  PhoneNumberField,
+  usePhoneNumberField,
+} from '@xaui/native/phone-number-field'
+import type {
+  PhoneNumberFieldProps,
+  PhoneNumberValue,
+} from '@xaui/native/phone-number-field'
+import { useXAUITheme } from '@xaui/native/theme'
+
+export default function PhoneNumberFieldScreen() {
+  const theme = useXAUITheme()
+  const [value, setValue] = useState<PhoneNumberValue>({
+    country: 'AD',
+    nationalNumber: '',
+  })
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 20, gap: 28, paddingBottom: 160 }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <PhoneDemo value={value} onValueChange={setValue} />
+      <View style={{ flexDirection: 'row', gap: 12 }}>
+        <Button
+          onPress={() => setValue({ country: 'CI', nationalNumber: '0707123456' })}
+        >
+          Côte d’Ivoire
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => setValue({ ...value, nationalNumber: '' })}
+        >
+          Vider
+        </Button>
+      </View>
+      <PhoneDemo
+        variant="secondary"
+        defaultValue={{ country: 'FR', nationalNumber: '0612345678' }}
+      />
+      <PhoneDemo
+        isDisabled
+        defaultValue={{ country: 'AD', nationalNumber: '123456' }}
+      />
+      <PhoneDemo isInvalid />
+      {(['xs', 'sm', 'md', 'lg'] as const).map(size => (
+        <PhoneDemo key={size} size={size} />
+      ))}
+      <PhoneDemo countries={['AD', 'CI', 'FR', 'US']} locale="fr" />
+    </ScrollView>
+  )
+}
+
+function PhoneDemo(props: PhoneNumberFieldProps) {
+  return (
+    <PhoneNumberField
+      defaultValue={{ country: 'AD', nationalNumber: '' }}
+      {...props}
+    >
+      <PhoneNumberField.Label>Phone number</PhoneNumberField.Label>
+      <FieldGroup>
+        <FieldGroup.Prefix>
+          <PhoneNumberField.Country accessibilityLabel="Choisir le pays" />
+        </FieldGroup.Prefix>
+        <PhoneNumberField.Field placeholder="000 000" />
+      </FieldGroup>
+      <PhoneNumberField.Description>
+        We’ll send a verification code to this number
+      </PhoneNumberField.Description>
+      {props.isInvalid ? (
+        <PhoneNumberField.Error>
+          Vérifiez le numéro de téléphone.
+        </PhoneNumberField.Error>
+      ) : null}
+      <NumberReadout />
+      <PhoneNumberField.Overlay />
+      <PhoneNumberField.Content height="65%" isSwipeable={false}>
+        <PhoneNumberField.Handle />
+        <PhoneNumberField.Title>Choisir le pays</PhoneNumberField.Title>
+        <PhoneNumberField.Search
+          accessibilityLabel="Rechercher un pays"
+          placeholder="Search country…"
+        />
+        <PhoneNumberField.CountryList ListEmptyComponent={<Text>Aucun pays</Text>} />
+        <PhoneNumberField.Close accessibilityLabel="Fermer la liste">
+          <Text>Fermer</Text>
+        </PhoneNumberField.Close>
+      </PhoneNumberField.Content>
+    </PhoneNumberField>
+  )
+}
+
+function NumberReadout() {
+  const { phoneNumber } = usePhoneNumberField()
+  const theme = useXAUITheme()
+  return (
+    <Text style={{ color: theme.colors.muted }}>E.164 : {phoneNumber ?? '—'}</Text>
+  )
+}

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -16,6 +16,7 @@
     "expo-linking": "~55.0.17",
     "expo-router": "~55.0.18",
     "expo-splash-screen": "~55.0.25",
+    "libphonenumber-js": "^1.13.12",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.10",

--- a/apps/docs/public/docs/phone-number-field.md
+++ b/apps/docs/public/docs/phone-number-field.md
@@ -1,0 +1,138 @@
+# PhoneNumberField
+
+## Overview
+
+A national phone number beside its country flag and calling code, with a searchable country
+sheet. Imports from `@xaui/native/phone-number-field`. Run the `phone-number-field` demo
+screen to try the real component in light and dark mode.
+
+## Anatomy
+
+```text
+PhoneNumberField
+  Label
+  FieldGroup
+    FieldGroup.Prefix → Country
+    Field
+  Description / Error
+  Overlay
+  Content
+    Handle
+    Title
+    Search
+    CountryList
+    Close
+```
+
+## Usage
+
+```tsx
+import { FieldGroup } from '@xaui/native/field-group'
+import { PhoneNumberField } from '@xaui/native/phone-number-field'
+;<PhoneNumberField defaultValue={{ country: 'AD', nationalNumber: '' }}>
+  <PhoneNumberField.Label>Phone number</PhoneNumberField.Label>
+  <FieldGroup>
+    <FieldGroup.Prefix>
+      <PhoneNumberField.Country accessibilityLabel="Choose country" />
+    </FieldGroup.Prefix>
+    <PhoneNumberField.Field placeholder="000 000" />
+  </FieldGroup>
+  <PhoneNumberField.Description>
+    We’ll send a verification code.
+  </PhoneNumberField.Description>
+  <PhoneNumberField.Overlay />
+  <PhoneNumberField.Content height="65%" isSwipeable={false}>
+    <PhoneNumberField.Handle />
+    <PhoneNumberField.Title>Choose country</PhoneNumberField.Title>
+    <PhoneNumberField.Search
+      accessibilityLabel="Search country"
+      placeholder="Search country…"
+    />
+    <PhoneNumberField.CountryList />
+  </PhoneNumberField.Content>
+</PhoneNumberField>
+```
+
+Use `value` and `onValueChange` for a controlled field. The value is
+`{ country: 'FR', nationalNumber: '0612345678' }`; an empty number is an empty string.
+Changing country preserves the national text. Pasting a complete international number
+selects its country when allowed by `countries`. Unsupported international pastes leave
+the current value unchanged. Formatting runs on blur so deletion does not fight inserted
+spaces. `usePhoneNumberField().phoneNumber` exposes E.164 for a possible number, otherwise
+`null`; possibility is a length check, not proof of assignment or reachability.
+
+`countries` restricts the list; the selected/default country must belong to it. With no initial value, the first allowed country is selected (US when unrestricted). Names
+and sorting follow `locale`. Searching accepts country name, ISO code or calling code.
+The sheet uses the existing BottomSheet and requires `react-native-gesture-handler` and
+a `GestureHandlerRootView`, plus XAUIProvider's portal host.
+
+## Props
+
+Generated from TypeScript by `node tooling/component-docs/generate.mjs phone-number-field`.
+The root inherits TextField's styles, states, ref and `asChild` behavior.
+
+<!-- props:start -->
+
+### PhoneNumberFieldProps
+
+Inherited React Native and composed component props remain available.
+
+| Prop          | Type                                               | Description                                                             |
+| ------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| value         | `PhoneNumberValue \| undefined`                    |                                                                         |
+| defaultValue  | `PhoneNumberValue \| undefined`                    |                                                                         |
+| onValueChange | `((value: PhoneNumberValue) => void) \| undefined` |                                                                         |
+| locale        | `string \| undefined`                              | Country names and their alphabetical order.                             |
+| countries     | `readonly CountryCode[] \| undefined`              | Restrict the selectable countries. Defaults to all supported countries. |
+
+### PhoneNumberFieldFieldProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldCountryProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldContentProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldSearchProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldCountryListProps
+
+Inherited React Native and composed component props remain available.
+
+| Prop          | Type                                                        | Description                                                         |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| renderCountry | `((country: PhoneCountryOption) => ReactNode) \| undefined` | Override a row's contents without replacing its selection behavior. |
+
+<!-- props:end -->
+
+## Slots
+
+`Field` accepts TextField.Field props except the root-owned value and change handler.
+`Country` accepts BottomSheet.Trigger props and belongs in FieldGroup.Prefix.
+`Content`, `Overlay`, `Handle`, `Title` and `Close` reuse BottomSheet.
+`Search` accepts TextField.Field props with its query owned by the phone root.
+`CountryList` accepts FlatList props, including `ListEmptyComponent`, and an optional
+`renderCountry` for row content. Labels, descriptions and errors reuse TextField slots.
+Each styled node accepts its own style overrides; use `style` on the FlatList.
+
+## Variants
+
+The four TextField variants (`primary`, `secondary`, `tertiary`, `ghost`) and sizes
+(`xs`, `sm`, `md`, `lg`) are inherited, including theme colors, focus and invalid states.
+
+## Accessibility
+
+The field is associated with its label and description. Give Country an action label in
+your app's language; the calling code is exposed as its value. Selected country rows
+announce their name, calling code and selected state. Label the search field and provide
+an empty-state message. `isDisabled` prevents both editing and country selection.
+
+## Migration from legacy
+
+This is a new component. There is no legacy PhoneNumberField to deprecate.

--- a/apps/docs/public/docs/phone-number-field.md
+++ b/apps/docs/public/docs/phone-number-field.md
@@ -6,6 +6,14 @@ A national phone number beside its country flag and calling code, with a searcha
 sheet. Imports from `@xaui/native/phone-number-field`. Run the `phone-number-field` demo
 screen to try the real component in light and dark mode.
 
+`libphonenumber-js` is an **optional** peer of this package, and this component needs it —
+it supplies the calling codes, the country metadata and the national formatting. It is the
+only component that imports it, so an app without a phone field never pays for it.
+
+```bash
+pnpm add libphonenumber-js
+```
+
 ## Anatomy
 
 ```text

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -18,3 +18,5 @@
 - [Wrap](https://ui.xtartapp.com/docs/wrap.md): Flex container that wraps children onto multiple lines — spacing, runSpacing, alignment, runAlignment. Flutter Wrap equivalent. Available in @xaui/native and @xaui/hybrid
 - [Spacer](https://ui.xtartapp.com/docs/spacer.md): Invisible flexible spacer that absorbs remaining space in a Row or Column. Flutter Spacer equivalent. Available in @xaui/native and @xaui/hybrid
 - [Alert](https://ui.xtartapp.com/docs/alert.md): Contextual feedback message with theme colors (default, primary, success, warning, danger), four variants (flat, solid, bordered, faded), closable behavior, and animated transitions. Available in @xaui/native and @xaui/hybrid
+
+- [PhoneNumberField](https://ui.xtartapp.com/docs/phone-number-field.md): Native v1 component, composition, API and accessibility.

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -719,6 +719,7 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
+    "libphonenumber-js": ">=1.11.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-native": ">=0.70.0",
     "react-native-gesture-handler": ">=2.0.0",
@@ -728,6 +729,9 @@
     "react-native-worklets": ">=0.5.0"
   },
   "peerDependenciesMeta": {
+    "libphonenumber-js": {
+      "optional": true
+    },
     "react-native-gesture-handler": {
       "optional": true
     },
@@ -740,6 +744,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.0",
+    "libphonenumber-js": "^1.13.12",
     "react": "19.2.0",
     "react-native": "0.83.10",
     "react-native-gesture-handler": "^2.28.0",
@@ -750,8 +755,5 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },
-  "module": "./dist/index.js",
-  "dependencies": {
-    "libphonenumber-js": "^1.13.12"
-  }
+  "module": "./dist/index.js"
 }

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -686,6 +686,16 @@
         "types": "./dist/theme/index.d.cts",
         "default": "./dist/theme/index.cjs"
       }
+    },
+    "./phone-number-field": {
+      "import": {
+        "types": "./dist/components/phone-number-field/index.d.ts",
+        "default": "./dist/components/phone-number-field/index.js"
+      },
+      "require": {
+        "types": "./dist/components/phone-number-field/index.d.cts",
+        "default": "./dist/components/phone-number-field/index.cjs"
+      }
     }
   },
   "files": [
@@ -740,5 +750,8 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },
-  "module": "./dist/index.js"
+  "module": "./dist/index.js",
+  "dependencies": {
+    "libphonenumber-js": "^1.13.12"
+  }
 }

--- a/packages/native/src/__tests__/utils/phone-number.test.ts
+++ b/packages/native/src/__tests__/utils/phone-number.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  editPhoneNumber,
+  filterPhoneCountries,
+  phoneCountries,
+  readPhoneNumber,
+} from '../../utils/phone-number'
+
+describe('phone numbers', () => {
+  it('keeps incomplete edits and leading zeroes', () => {
+    expect(editPhoneNumber('06 1a', { country: 'FR', nationalNumber: '' })).toEqual({
+      country: 'FR',
+      nationalNumber: '061',
+    })
+    expect(readPhoneNumber({ country: 'FR', nationalNumber: '061' })).toBeNull()
+  })
+  it('normalizes national numbers to E.164', () => {
+    expect(
+      readPhoneNumber({ country: 'FR', nationalNumber: '06 12 34 56 78' })?.number
+    ).toBe('+33612345678')
+    expect(
+      readPhoneNumber({ country: 'CI', nationalNumber: '07 07 12 34 56' })?.number
+    ).toBe('+2250707123456')
+  })
+  it('selects the country of an international paste and respects restrictions', () => {
+    const current = { country: 'AD' as const, nationalNumber: '' }
+    expect(editPhoneNumber('+33 6 12 34 56 78', current).country).toBe('FR')
+    expect(editPhoneNumber('+33 6 12 34 56 78', current, ['AD'])).toBe(current)
+    expect(editPhoneNumber('+', current).nationalNumber).toBe('+')
+    expect(editPhoneNumber('+33', current).nationalNumber).toBe('+33')
+    expect(editPhoneNumber('+2250', current).nationalNumber).toBe('+2250')
+  })
+  it('clears the number without changing the country', () => {
+    expect(editPhoneNumber('', { country: 'AD', nationalNumber: '123456' })).toEqual(
+      { country: 'AD', nationalNumber: '' }
+    )
+  })
+  it('localizes countries and searches names, accents, ISO codes and prefixes', () => {
+    const countries = phoneCountries('fr', ['FR', 'CI', 'AD', 'FR'])
+    expect(countries).toHaveLength(3)
+    expect(filterPhoneCountries(countries, 'cote')[0]?.code).toBe('CI')
+    expect(filterPhoneCountries(countries, '+376')[0]?.flag).toBe('🇦🇩')
+    expect(filterPhoneCountries(countries, 'FR')[0]?.code).toBe('FR')
+    expect(filterPhoneCountries(countries, 'xyz')).toEqual([])
+  })
+})

--- a/packages/native/src/components/phone-number-field/index.ts
+++ b/packages/native/src/components/phone-number-field/index.ts
@@ -1,0 +1,38 @@
+import { PhoneNumberFieldRoot } from './phone-number-field'
+import { PhoneNumberFieldField } from './phone-number-field-field'
+import { PhoneNumberFieldCountry } from './phone-number-field-country'
+import { PhoneNumberFieldContent } from './phone-number-field-content'
+import { PhoneNumberFieldSearch } from './phone-number-field-search'
+import { PhoneNumberFieldCountryList } from './phone-number-field-country-list'
+import { TextFieldLabel, TextFieldDescription, TextFieldError } from '../text-field'
+import {
+  BottomSheetOverlay,
+  BottomSheetHandle,
+  BottomSheetTitle,
+  BottomSheetClose,
+} from '../bottom-sheet'
+
+export const PhoneNumberField = Object.assign(PhoneNumberFieldRoot, {
+  Label: TextFieldLabel,
+  Field: PhoneNumberFieldField,
+  Country: PhoneNumberFieldCountry,
+  Description: TextFieldDescription,
+  Error: TextFieldError,
+  Overlay: BottomSheetOverlay,
+  Content: PhoneNumberFieldContent,
+  Handle: BottomSheetHandle,
+  Title: BottomSheetTitle,
+  Close: BottomSheetClose,
+  Search: PhoneNumberFieldSearch,
+  CountryList: PhoneNumberFieldCountryList,
+})
+export {
+  PhoneNumberFieldRoot,
+  PhoneNumberFieldField,
+  PhoneNumberFieldCountry,
+  PhoneNumberFieldContent,
+  PhoneNumberFieldSearch,
+  PhoneNumberFieldCountryList,
+}
+export { usePhoneNumberField } from './phone-number-field.context'
+export type * from './phone-number-field.type'

--- a/packages/native/src/components/phone-number-field/phone-number-field-content.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field-content.tsx
@@ -1,0 +1,25 @@
+import { BottomSheetContent } from '../bottom-sheet'
+import { useTextField } from '../text-field'
+import { TextFieldProvider } from '../text-field/text-field.context'
+import {
+  PhoneNumberFieldProvider,
+  usePhoneNumberField,
+} from './phone-number-field.context'
+import type { PhoneNumberFieldContentProps } from './phone-number-field.type'
+
+export function PhoneNumberFieldContent({
+  children,
+  ...props
+}: PhoneNumberFieldContentProps) {
+  const context = usePhoneNumberField()
+  const field = useTextField()
+  // Portal hosts render outside this subtree, so the slots need both contexts restored.
+  return (
+    <BottomSheetContent {...props}>
+      <PhoneNumberFieldProvider value={context}>
+        <TextFieldProvider value={field}>{children}</TextFieldProvider>
+      </PhoneNumberFieldProvider>
+    </BottomSheetContent>
+  )
+}
+PhoneNumberFieldContent.displayName = 'XAUI.PhoneNumberField.Content'

--- a/packages/native/src/components/phone-number-field/phone-number-field-country-list.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field-country-list.tsx
@@ -1,0 +1,58 @@
+import { forwardRef, useMemo } from 'react'
+import { FlatList, Keyboard } from 'react-native'
+import { useStyleProps } from '../../system/style-props'
+import { Button } from '../button'
+import { filterPhoneCountries } from '../../utils/phone-number'
+import { usePhoneNumberField } from './phone-number-field.context'
+import type {
+  PhoneCountryOption,
+  PhoneNumberFieldCountryListProps,
+} from './phone-number-field.type'
+
+export const PhoneNumberFieldCountryList = forwardRef<
+  FlatList<PhoneCountryOption>,
+  PhoneNumberFieldCountryListProps
+>(function PhoneNumberFieldCountryList({ renderCountry, style, ...props }, ref) {
+  const [styleProps, rest] = useStyleProps(props)
+  const { countries, query, value, selectCountry } = usePhoneNumberField()
+  const filtered = useMemo(
+    () => filterPhoneCountries(countries, query),
+    [countries, query]
+  )
+  return (
+    <FlatList
+      ref={ref}
+      keyboardShouldPersistTaps="handled"
+      keyExtractor={item => item.code}
+      {...rest}
+      style={[styleProps, style]}
+      data={filtered}
+      extraData={value.country}
+      renderItem={({ item }) => (
+        <Button
+          variant="ghost"
+          justifyContent="flex-start"
+          accessibilityLabel={`${item.name}, +${item.callingCode}`}
+          accessibilityState={{ selected: item.code === value.country }}
+          onPress={() => {
+            selectCountry(item.code)
+            Keyboard.dismiss()
+          }}
+        >
+          {renderCountry ? (
+            renderCountry(item)
+          ) : (
+            <>
+              <Button.Label>
+                {item.flag} +{item.callingCode}
+              </Button.Label>
+              <Button.Label flex={1}>{item.name}</Button.Label>
+              {item.code === value.country ? <Button.Label>✓</Button.Label> : null}
+            </>
+          )}
+        </Button>
+      )}
+    />
+  )
+})
+PhoneNumberFieldCountryList.displayName = 'XAUI.PhoneNumberField.CountryList'

--- a/packages/native/src/components/phone-number-field/phone-number-field-country.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field-country.tsx
@@ -1,0 +1,32 @@
+import { forwardRef } from 'react'
+import { Text } from 'react-native'
+import type { View } from 'react-native'
+import { BottomSheetTrigger } from '../bottom-sheet'
+import { useTextField } from '../text-field'
+import { usePhoneNumberField } from './phone-number-field.context'
+import type { PhoneNumberFieldCountryProps } from './phone-number-field.type'
+
+/** Place inside FieldGroup.Prefix so its measured width leaves room for the number. */
+export const PhoneNumberFieldCountry = forwardRef<
+  View,
+  PhoneNumberFieldCountryProps
+>(function PhoneNumberFieldCountry({ children, asChild, ...props }, ref) {
+  const { country } = usePhoneNumberField()
+  const { labelStyle } = useTextField()
+  return (
+    <BottomSheetTrigger
+      ref={ref}
+      asChild={asChild}
+      accessibilityLabel={country.name}
+      accessibilityValue={{ text: `${country.name}, +${country.callingCode}` }}
+      {...props}
+    >
+      {children ?? (
+        <Text style={labelStyle}>
+          {country.flag} +{country.callingCode}
+        </Text>
+      )}
+    </BottomSheetTrigger>
+  )
+})
+PhoneNumberFieldCountry.displayName = 'XAUI.PhoneNumberField.Country'

--- a/packages/native/src/components/phone-number-field/phone-number-field-field.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field-field.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, useMemo } from 'react'
+import type { TextInput } from 'react-native'
+import { decoratorPadding, useOptionalFieldGroup } from '../field-group'
+import { TextFieldField } from '../text-field'
+import { usePhoneNumberField } from './phone-number-field.context'
+import type { PhoneNumberFieldFieldProps } from './phone-number-field.type'
+
+export const PhoneNumberFieldField = forwardRef<
+  TextInput,
+  PhoneNumberFieldFieldProps
+>(function PhoneNumberFieldField({ style, onBlur, ...props }, ref) {
+  const { value, setNumber, formatNumber } = usePhoneNumberField()
+  const group = useOptionalFieldGroup()
+  const padding = useMemo(
+    () => decoratorPadding(group?.prefixWidth ?? 0, group?.suffixWidth ?? 0),
+    [group?.prefixWidth, group?.suffixWidth]
+  )
+  return (
+    <TextFieldField
+      ref={ref}
+      keyboardType="phone-pad"
+      autoComplete="tel-national"
+      {...props}
+      value={value.nationalNumber}
+      onChangeText={setNumber}
+      onBlur={event => {
+        formatNumber()
+        onBlur?.(event)
+      }}
+      style={[padding, style]}
+    />
+  )
+})
+PhoneNumberFieldField.displayName = 'XAUI.PhoneNumberField.Field'

--- a/packages/native/src/components/phone-number-field/phone-number-field-search.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field-search.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from 'react'
+import type { TextInput } from 'react-native'
+import { TextField } from '../text-field'
+import { usePhoneNumberField } from './phone-number-field.context'
+import type { PhoneNumberFieldSearchProps } from './phone-number-field.type'
+
+export const PhoneNumberFieldSearch = forwardRef<
+  TextInput,
+  PhoneNumberFieldSearchProps
+>(function PhoneNumberFieldSearch(props, ref) {
+  const { query, setQuery } = usePhoneNumberField()
+  return (
+    <TextField variant="secondary">
+      <TextField.Field
+        ref={ref}
+        accessibilityRole="search"
+        autoCorrect={false}
+        autoCapitalize="none"
+        {...props}
+        value={query}
+        onChangeText={setQuery}
+      />
+    </TextField>
+  )
+})
+PhoneNumberFieldSearch.displayName = 'XAUI.PhoneNumberField.Search'

--- a/packages/native/src/components/phone-number-field/phone-number-field.context.ts
+++ b/packages/native/src/components/phone-number-field/phone-number-field.context.ts
@@ -1,0 +1,5 @@
+import { createSlotContext } from '../../system/slot'
+import type { PhoneNumberFieldContextValue } from './phone-number-field.type'
+
+export const [PhoneNumberFieldProvider, usePhoneNumberField] =
+  createSlotContext<PhoneNumberFieldContextValue>('PhoneNumberField')

--- a/packages/native/src/components/phone-number-field/phone-number-field.md
+++ b/packages/native/src/components/phone-number-field/phone-number-field.md
@@ -1,0 +1,138 @@
+# PhoneNumberField
+
+## Overview
+
+A national phone number beside its country flag and calling code, with a searchable country
+sheet. Imports from `@xaui/native/phone-number-field`. Run the `phone-number-field` demo
+screen to try the real component in light and dark mode.
+
+## Anatomy
+
+```text
+PhoneNumberField
+  Label
+  FieldGroup
+    FieldGroup.Prefix → Country
+    Field
+  Description / Error
+  Overlay
+  Content
+    Handle
+    Title
+    Search
+    CountryList
+    Close
+```
+
+## Usage
+
+```tsx
+import { FieldGroup } from '@xaui/native/field-group'
+import { PhoneNumberField } from '@xaui/native/phone-number-field'
+;<PhoneNumberField defaultValue={{ country: 'AD', nationalNumber: '' }}>
+  <PhoneNumberField.Label>Phone number</PhoneNumberField.Label>
+  <FieldGroup>
+    <FieldGroup.Prefix>
+      <PhoneNumberField.Country accessibilityLabel="Choose country" />
+    </FieldGroup.Prefix>
+    <PhoneNumberField.Field placeholder="000 000" />
+  </FieldGroup>
+  <PhoneNumberField.Description>
+    We’ll send a verification code.
+  </PhoneNumberField.Description>
+  <PhoneNumberField.Overlay />
+  <PhoneNumberField.Content height="65%" isSwipeable={false}>
+    <PhoneNumberField.Handle />
+    <PhoneNumberField.Title>Choose country</PhoneNumberField.Title>
+    <PhoneNumberField.Search
+      accessibilityLabel="Search country"
+      placeholder="Search country…"
+    />
+    <PhoneNumberField.CountryList />
+  </PhoneNumberField.Content>
+</PhoneNumberField>
+```
+
+Use `value` and `onValueChange` for a controlled field. The value is
+`{ country: 'FR', nationalNumber: '0612345678' }`; an empty number is an empty string.
+Changing country preserves the national text. Pasting a complete international number
+selects its country when allowed by `countries`. Unsupported international pastes leave
+the current value unchanged. Formatting runs on blur so deletion does not fight inserted
+spaces. `usePhoneNumberField().phoneNumber` exposes E.164 for a possible number, otherwise
+`null`; possibility is a length check, not proof of assignment or reachability.
+
+`countries` restricts the list; the selected/default country must belong to it. With no initial value, the first allowed country is selected (US when unrestricted). Names
+and sorting follow `locale`. Searching accepts country name, ISO code or calling code.
+The sheet uses the existing BottomSheet and requires `react-native-gesture-handler` and
+a `GestureHandlerRootView`, plus XAUIProvider's portal host.
+
+## Props
+
+Generated from TypeScript by `node tooling/component-docs/generate.mjs phone-number-field`.
+The root inherits TextField's styles, states, ref and `asChild` behavior.
+
+<!-- props:start -->
+
+### PhoneNumberFieldProps
+
+Inherited React Native and composed component props remain available.
+
+| Prop          | Type                                               | Description                                                             |
+| ------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| value         | `PhoneNumberValue \| undefined`                    |                                                                         |
+| defaultValue  | `PhoneNumberValue \| undefined`                    |                                                                         |
+| onValueChange | `((value: PhoneNumberValue) => void) \| undefined` |                                                                         |
+| locale        | `string \| undefined`                              | Country names and their alphabetical order.                             |
+| countries     | `readonly CountryCode[] \| undefined`              | Restrict the selectable countries. Defaults to all supported countries. |
+
+### PhoneNumberFieldFieldProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldCountryProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldContentProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldSearchProps
+
+Inherited React Native and composed component props remain available.
+
+### PhoneNumberFieldCountryListProps
+
+Inherited React Native and composed component props remain available.
+
+| Prop          | Type                                                        | Description                                                         |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| renderCountry | `((country: PhoneCountryOption) => ReactNode) \| undefined` | Override a row's contents without replacing its selection behavior. |
+
+<!-- props:end -->
+
+## Slots
+
+`Field` accepts TextField.Field props except the root-owned value and change handler.
+`Country` accepts BottomSheet.Trigger props and belongs in FieldGroup.Prefix.
+`Content`, `Overlay`, `Handle`, `Title` and `Close` reuse BottomSheet.
+`Search` accepts TextField.Field props with its query owned by the phone root.
+`CountryList` accepts FlatList props, including `ListEmptyComponent`, and an optional
+`renderCountry` for row content. Labels, descriptions and errors reuse TextField slots.
+Each styled node accepts its own style overrides; use `style` on the FlatList.
+
+## Variants
+
+The four TextField variants (`primary`, `secondary`, `tertiary`, `ghost`) and sizes
+(`xs`, `sm`, `md`, `lg`) are inherited, including theme colors, focus and invalid states.
+
+## Accessibility
+
+The field is associated with its label and description. Give Country an action label in
+your app's language; the calling code is exposed as its value. Selected country rows
+announce their name, calling code and selected state. Label the search field and provide
+an empty-state message. `isDisabled` prevents both editing and country selection.
+
+## Migration from legacy
+
+This is a new component. There is no legacy PhoneNumberField to deprecate.

--- a/packages/native/src/components/phone-number-field/phone-number-field.md
+++ b/packages/native/src/components/phone-number-field/phone-number-field.md
@@ -6,6 +6,14 @@ A national phone number beside its country flag and calling code, with a searcha
 sheet. Imports from `@xaui/native/phone-number-field`. Run the `phone-number-field` demo
 screen to try the real component in light and dark mode.
 
+`libphonenumber-js` is an **optional** peer of this package, and this component needs it —
+it supplies the calling codes, the country metadata and the national formatting. It is the
+only component that imports it, so an app without a phone field never pays for it.
+
+```bash
+pnpm add libphonenumber-js
+```
+
 ## Anatomy
 
 ```text

--- a/packages/native/src/components/phone-number-field/phone-number-field.tsx
+++ b/packages/native/src/components/phone-number-field/phone-number-field.tsx
@@ -1,0 +1,124 @@
+import { forwardRef, useCallback, useMemo, useState } from 'react'
+import type { View } from 'react-native'
+import { useControllableState } from '../../hooks/use-controllable-state'
+import {
+  phoneCountries,
+  readPhoneNumber,
+  editPhoneNumber,
+} from '../../utils/phone-number'
+import { BottomSheetRoot } from '../bottom-sheet'
+import { TextFieldRoot } from '../text-field'
+import { PhoneNumberFieldProvider } from './phone-number-field.context'
+import type { PhoneCountry, PhoneNumberFieldProps } from './phone-number-field.type'
+
+export const PhoneNumberFieldRoot = forwardRef<View, PhoneNumberFieldProps>(
+  function PhoneNumberField(
+    {
+      value: controlled,
+      defaultValue,
+      onValueChange,
+      locale = 'en',
+      countries: countryCodes,
+      children,
+      isDisabled = false,
+      ...props
+    },
+    ref
+  ) {
+    const [value, setValue] = useControllableState({
+      value: controlled,
+      defaultValue: defaultValue ?? {
+        country: countryCodes?.[0] ?? 'US',
+        nationalNumber: '',
+      },
+      onChange: onValueChange,
+    })
+    const [isOpen, setOpenState] = useState(false)
+    const [query, setQuery] = useState('')
+    const countries = useMemo(
+      () => phoneCountries(locale, countryCodes),
+      [locale, countryCodes]
+    )
+    const country = countries.find(item => item.code === value.country)
+    if (!country)
+      throw new Error(
+        'PhoneNumberField: the selected country must belong to countries.'
+      )
+    const phoneNumber = readPhoneNumber(value)
+
+    const setOpen = useCallback(
+      (open: boolean) => {
+        if (isDisabled && open) return
+        setOpenState(open)
+        if (!open) setQuery('')
+      },
+      [isDisabled]
+    )
+    const setNumber = useCallback(
+      (text: string) => {
+        if (!isDisabled) setValue(editPhoneNumber(text, value, countryCodes))
+      },
+      [isDisabled, setValue, value, countryCodes]
+    )
+    const selectCountry = useCallback(
+      (code: PhoneCountry) => {
+        if (isDisabled) return
+        setValue({ country: code, nationalNumber: value.nationalNumber })
+        setOpen(false)
+      },
+      [isDisabled, setValue, setOpen, value.nationalNumber]
+    )
+    const formatNumber = useCallback(() => {
+      if (phoneNumber)
+        setValue({ ...value, nationalNumber: phoneNumber.formatNational() })
+    }, [phoneNumber, setValue, value])
+    const context = useMemo(
+      () => ({
+        value,
+        country,
+        countries,
+        phoneNumber: phoneNumber?.number ?? null,
+        setNumber,
+        selectCountry,
+        formatNumber,
+        query,
+        setQuery,
+        isOpen: isOpen && !isDisabled,
+        setOpen,
+      }),
+      [
+        value,
+        country,
+        countries,
+        phoneNumber,
+        setNumber,
+        selectCountry,
+        formatNumber,
+        query,
+        isOpen,
+        isDisabled,
+        setOpen,
+      ]
+    )
+
+    return (
+      <PhoneNumberFieldProvider value={context}>
+        <BottomSheetRoot
+          isOpen={context.isOpen}
+          onOpenChange={setOpen}
+          isDisabled={isDisabled}
+        >
+          <TextFieldRoot
+            ref={ref}
+            variant="primary"
+            isDisabled={isDisabled}
+            {...props}
+          >
+            {children}
+          </TextFieldRoot>
+        </BottomSheetRoot>
+      </PhoneNumberFieldProvider>
+    )
+  }
+)
+PhoneNumberFieldRoot.displayName = 'XAUI.PhoneNumberField.Root'

--- a/packages/native/src/components/phone-number-field/phone-number-field.type.ts
+++ b/packages/native/src/components/phone-number-field/phone-number-field.type.ts
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react'
+import type { CountryCode } from 'libphonenumber-js/min'
+import type { FlatListProps } from 'react-native'
+import type { ViewStyleProps } from '../../system/style-props'
+import type { TextFieldProps, TextFieldFieldProps } from '../text-field'
+import type {
+  BottomSheetContentProps,
+  BottomSheetTriggerProps,
+} from '../bottom-sheet'
+
+export type PhoneCountry = CountryCode
+
+/** National text is retained while incomplete; the country and number change atomically. */
+export type PhoneNumberValue = { country: PhoneCountry; nationalNumber: string }
+
+export type PhoneCountryOption = {
+  code: PhoneCountry
+  name: string
+  callingCode: string
+  flag: string
+}
+
+export type PhoneNumberFieldProps = TextFieldProps & {
+  value?: PhoneNumberValue
+  defaultValue?: PhoneNumberValue
+  onValueChange?: (value: PhoneNumberValue) => void
+  /** Country names and their alphabetical order. @default 'en' */
+  locale?: string
+  /** Restrict the selectable countries. Defaults to all supported countries. */
+  countries?: readonly PhoneCountry[]
+}
+
+export type PhoneNumberFieldFieldProps = Omit<
+  TextFieldFieldProps,
+  'value' | 'defaultValue' | 'onChangeText'
+>
+export type PhoneNumberFieldCountryProps = BottomSheetTriggerProps
+export type PhoneNumberFieldContentProps = BottomSheetContentProps
+export type PhoneNumberFieldSearchProps = Omit<
+  TextFieldFieldProps,
+  'value' | 'defaultValue' | 'onChangeText'
+>
+export type PhoneNumberFieldCountryListProps = Omit<
+  FlatListProps<PhoneCountryOption>,
+  'data' | 'renderItem'
+> &
+  Omit<ViewStyleProps, keyof FlatListProps<PhoneCountryOption>> & {
+    /** Override a row's contents without replacing its selection behavior. */
+    renderCountry?: (country: PhoneCountryOption) => ReactNode
+  }
+
+export type PhoneNumberFieldContextValue = {
+  value: PhoneNumberValue
+  country: PhoneCountryOption
+  countries: readonly PhoneCountryOption[]
+  /** E.164 when the current number is possible, otherwise null. */
+  phoneNumber: string | null
+  setNumber: (text: string) => void
+  selectCountry: (country: PhoneCountry) => void
+  formatNumber: () => void
+  query: string
+  setQuery: (query: string) => void
+  isOpen: boolean
+  setOpen: (open: boolean) => void
+}

--- a/packages/native/src/utils/phone-number.ts
+++ b/packages/native/src/utils/phone-number.ts
@@ -1,0 +1,67 @@
+import {
+  getCountries,
+  getCountryCallingCode,
+  parsePhoneNumberFromString,
+  parseIncompletePhoneNumber,
+} from 'libphonenumber-js/min'
+import type {
+  PhoneCountry,
+  PhoneCountryOption,
+  PhoneNumberValue,
+} from '../components/phone-number-field/phone-number-field.type'
+
+export function phoneCountries(
+  locale: string,
+  codes: readonly PhoneCountry[] = getCountries()
+): PhoneCountryOption[] {
+  const names = new Intl.DisplayNames([locale], { type: 'region' })
+  return [...new Set(codes)]
+    .map(code => ({
+      code,
+      name: names.of(code) ?? code,
+      callingCode: getCountryCallingCode(code),
+      flag: String.fromCodePoint(
+        ...[...code].map(letter => letter.charCodeAt(0) + 127397)
+      ),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, locale))
+}
+
+function searchable(text: string) {
+  return text.normalize('NFD').replace(/\p{M}/gu, '').toLowerCase().trim()
+}
+
+export function filterPhoneCountries(
+  countries: readonly PhoneCountryOption[],
+  query: string
+) {
+  const needle = searchable(query)
+  return countries.filter(country =>
+    searchable(`${country.name} ${country.code} +${country.callingCode}`).includes(
+      needle
+    )
+  )
+}
+
+export function readPhoneNumber(value: PhoneNumberValue) {
+  const parsed = parsePhoneNumberFromString(value.nationalNumber, value.country)
+  return parsed?.isPossible() ? parsed : null
+}
+
+/** An international paste may select its country, but cannot escape the allowed list. */
+export function editPhoneNumber(
+  text: string,
+  current: PhoneNumberValue,
+  allowed?: readonly PhoneCountry[]
+): PhoneNumberValue {
+  const normalized = parseIncompletePhoneNumber(text)
+  if (!normalized.startsWith('+')) {
+    return { country: current.country, nationalNumber: normalized.slice(0, 17) }
+  }
+  const parsed = parsePhoneNumberFromString(normalized)
+  if (!parsed?.country) {
+    return { country: current.country, nationalNumber: normalized.slice(0, 16) }
+  }
+  if (allowed && !allowed.includes(parsed.country)) return current
+  return { country: parsed.country, nationalNumber: parsed.formatNational() }
+}

--- a/packages/native/tsup.config.ts
+++ b/packages/native/tsup.config.ts
@@ -59,6 +59,8 @@ const entries = {
   'components/text-area/index': 'src/components/text-area/index.ts',
   'components/text-field/index': 'src/components/text-field/index.ts',
   'components/timeline/index': 'src/components/timeline/index.ts',
+  'components/phone-number-field/index':
+    'src/components/phone-number-field/index.ts',
   'components/time-field/index': 'src/components/time-field/index.ts',
   'components/time-picker/index': 'src/components/time-picker/index.ts',
   'components/toast/index': 'src/components/toast/index.ts',

--- a/packages/native/tsup.config.ts
+++ b/packages/native/tsup.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
   splitting: true,
   target: 'es2020',
   external: [
+    'libphonenumber-js',
     'react',
     'react-native',
     'react-native-gesture-handler',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,10 @@ importers:
         version: 5.9.3
 
   packages/native:
+    dependencies:
+      libphonenumber-js:
+        specifier: ^1.13.12
+        version: 1.13.12
     devDependencies:
       '@types/react':
         specifier: ^19.2.0
@@ -5415,6 +5419,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.12:
+    resolution: {integrity: sha512-uLVeV1c9OTk6qkdqnj+mpMD+ZdnZ0szVyWu58HwMmpwkHA1gCEkyjd3veZQXDnuw9KEwSRjcc9B1pS9XKIN1fA==}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -13463,6 +13470,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.12: {}
 
   lighthouse-logger@1.4.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       expo-splash-screen:
         specifier: ~55.0.25
         version: 55.0.25(expo@55.0.31)(typescript@5.9.3)
+      libphonenumber-js:
+        specifier: ^1.13.12
+        version: 1.13.12
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -237,14 +240,13 @@ importers:
         version: 5.9.3
 
   packages/native:
-    dependencies:
-      libphonenumber-js:
-        specifier: ^1.13.12
-        version: 1.13.12
     devDependencies:
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.18
+      libphonenumber-js:
+        specifier: ^1.13.12
+        version: 1.13.12
       react:
         specifier: 19.2.0
         version: 19.2.0

--- a/tooling/component-docs/generate.mjs
+++ b/tooling/component-docs/generate.mjs
@@ -1,0 +1,80 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import ts from 'typescript'
+
+const component = process.argv[2]
+if (!component || !/^[a-z-]+$/.test(component)) {
+  throw new Error('Pass a component folder name, for example phone-number-field.')
+}
+const directory = path.resolve('packages/native/src/components', component)
+const sourcePath = path.join(directory, `${component}.type.ts`)
+const program = ts.createProgram([sourcePath], { skipLibCheck: true, strict: true })
+const checker = program.getTypeChecker()
+const source = program.getSourceFile(sourcePath)
+const lines = []
+for (const statement of source.statements) {
+  if (
+    !ts.isTypeAliasDeclaration(statement) ||
+    !statement.name.text.endsWith('Props')
+  )
+    continue
+  const type = checker.getTypeAtLocation(statement)
+  const properties = checker
+    .getPropertiesOfType(type)
+    .filter(property =>
+      property.declarations?.some(
+        declaration => declaration.getSourceFile() === source
+      )
+    )
+  lines.push(
+    `### ${statement.name.text}`,
+    '',
+    'Inherited React Native and composed component props remain available.',
+    ''
+  )
+  if (!properties.length) continue
+  lines.push('| Prop | Type | Description |', '| --- | --- | --- |')
+  for (const property of properties) {
+    const declaration = property.valueDeclaration ?? property.declarations[0]
+    const value = checker
+      .typeToString(
+        checker.getTypeOfSymbolAtLocation(property, declaration),
+        undefined,
+        ts.TypeFormatFlags.NoTruncation
+      )
+      .replaceAll('|', '\\|')
+    const description = ts
+      .displayPartsToString(property.getDocumentationComment(checker))
+      .replaceAll('\n', ' ')
+      .replaceAll('|', '\\|')
+    lines.push(`| ${property.name} | \`${value}\` | ${description} |`)
+  }
+  lines.push('')
+}
+const documentPath = path.join(directory, `${component}.md`)
+const document = fs.readFileSync(documentPath, 'utf8')
+const start = '<!-- props:start -->'
+const end = '<!-- props:end -->'
+if (!document.includes(start) || !document.includes(end))
+  throw new Error('Missing generated props markers.')
+fs.writeFileSync(
+  documentPath,
+  document.slice(0, document.indexOf(start) + start.length) +
+    '\n\n' +
+    lines.join('\n') +
+    '\n' +
+    document.slice(document.indexOf(end))
+)
+
+// Publish the same source for documentation clients; the package file owns the prose.
+const publicPath = path.resolve('apps/docs/public/docs', `${component}.md`)
+fs.copyFileSync(documentPath, publicPath)
+const llmsPath = path.resolve('apps/docs/public/llms.txt')
+const llms = fs.readFileSync(llmsPath, 'utf8')
+const title = fs.readFileSync(documentPath, 'utf8').split('\n')[0].replace(/^# /, '')
+const url = `https://ui.xtartapp.com/docs/${component}.md`
+if (!llms.includes(url))
+  fs.appendFileSync(
+    llmsPath,
+    `\n- [${title}](${url}): Native v1 component, composition, API and accessibility.\n`
+  )


### PR DESCRIPTION
## What
Add `PhoneNumberField` at `@xaui/native/phone-number-field`: country flag and calling-code trigger, national-number input, and a searchable country sheet with localized names. Include its demo, generated API documentation, roadmap entry and native patch changeset.

## Why
Implement the requested phone field reference while preserving TextField and FieldGroup composition. Country and national text form one controlled or uncontrolled value; `usePhoneNumberField` exposes a possible E.164 number. libphonenumber-js supplies current calling-code and formatting metadata.

## How
Reuse TextField, FieldGroup and BottomSheet; restore field contexts across the portal. Format on blur to preserve editing, support international pastes and restricted country lists, and virtualize country results. Add a light/dark toggle to the demo and a reusable TypeScript prop-table generator.

Validation: root lint, type-check and CI-mode test commands passed (the full test command requires network access for the docs build's Google Fonts). Five phone utility tests cover normalization, incomplete values, international input, restrictions and localized search. Browser demo checked in light/dark, including search, selection and international paste. Native device keyboard/gesture behavior remains to be verified on-device. An additional demo-only TypeScript check reports existing errors in other demo screens; none in PhoneNumberField.
