### PR TITLE
fix(pager): one colour at two opacities, not two colours

### DIFF
--- a/.changeset/pager-indicator-contrast.md
+++ b/.changeset/pager-indicator-contrast.md
@@ -1,0 +1,32 @@
+---
+'@xaui/native': patch
+---
+
+`Pager` — the indicator is one colour at two opacities
+
+The dots were a **pair** of tokens: the current one from the variant, the rest from the
+neutral `default` fill, which is what `Carousel` does. A pair has to be chosen to contrast
+with itself, and it cannot be — measured in the DOM, `tertiary` put `surface` against
+`default`, which is `#ffffff` on `#e4e4e7` in light and two near-identical greys in dark. The
+one variant that exists for a pager over an image was the one whose indicator could not be
+read, in both colour modes.
+
+Every dot now takes the variant's one colour, the current one at full strength and the rest at
+`DOT_REST_OPACITY` (0.3, exported). That cannot collapse whatever the variant, whichever the
+colour mode, and for any raw `color` a caller invents — and it is what iOS's own page control
+does. 30% rather than 50%, because the dots are seven points across and at half strength a
+small mark reads as the current one seen through something rather than as a mark behind it.
+
+Three consequences:
+
+- `secondary` is now `foreground` rather than `defaultForeground` — the page's own ink, for an
+  indicator that has to read as chrome.
+- A pager over a **photograph** is `color="#ffffff"` rather than `tertiary`: a photograph is a
+  photograph in both colour modes, and `surface` flips with the theme. The doc said `tertiary`
+  was the answer; it was not.
+- `PagerDotInk` and the context's `dotInk` are gone, along with the flatten that built them —
+  there is no pair for a worklet to interpolate between, so the recipe's `dot` is a plain
+  style and the travel is an `opacity`.
+
+Also adds a full-screen `Pager` verification to the demo, which is the case a section inside a
+`ScrollView` cannot show, and the one that surfaced this.

--- a/apps/demo/app/_layout.tsx
+++ b/apps/demo/app/_layout.tsx
@@ -134,6 +134,10 @@ export default function RootLayout() {
                 options={{ title: 'MorphButton (v1)' }}
               />
               <Stack.Screen name="pager" options={{ title: 'Pager (v1)' }} />
+              <Stack.Screen
+                name="pager-full"
+                options={{ title: 'Pager plein écran (v1)' }}
+              />
               <Stack.Screen name="popover" options={{ title: 'Popover (v1)' }} />
               <Stack.Screen
                 name="pressable-feedback"

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -54,6 +54,7 @@ const SCREENS = [
   { href: '/menu', label: 'Menu' },
   { href: '/morph-button', label: 'MorphButton' },
   { href: '/pager', label: 'Pager' },
+  { href: '/pager-full', label: 'Pager (plein écran)' },
   { href: '/popover', label: 'Popover' },
   { href: '/pressable-feedback', label: 'PressableFeedback' },
   { href: '/progress-bar', label: 'ProgressBar' },

--- a/apps/demo/app/pager-full.tsx
+++ b/apps/demo/app/pager-full.tsx
@@ -1,0 +1,114 @@
+import { View, Text } from 'react-native'
+import { Button } from '@xaui/native/button'
+import { Pager, usePager } from '@xaui/native/pager'
+import { useXAUITheme } from '@xaui/native/theme'
+
+const SCREENS = [
+  {
+    title: 'Plein écran',
+    body: "Un Pager n'a pas de hauteur propre : flex={1} le fait remplir ce qu'on lui donne.",
+  },
+  {
+    title: 'Une page est la piste',
+    body: "Mesurée, sur les deux axes — donc ici c'est l'écran, sans qu'aucune propriété ne le dise.",
+  },
+  {
+    title: 'Les points par-dessus',
+    body: "position absolute + bottom + start + end : ils sont dans le flux par défaut, et sur les pages c'est un jeu de style props.",
+  },
+]
+
+/**
+ * The full-screen verification for the `Pager` — the case a section inside a `ScrollView`
+ * cannot show, because a page that fills the screen needs a parent that does.
+ *
+ * `flex={1}` on the root is the whole answer, and it is the reason the recipe gives the root
+ * no size of its own: a `flex: 1` in there would have expanded to a zero flex-basis and
+ * overridden an explicit `height`, so a caller reaching for one would have been silently
+ * ignored. Here it is the caller who says which of the two they want.
+ */
+export default function PagerFullScreen() {
+  const theme = useXAUITheme()
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      <Pager flex={1} variant="tertiary">
+        <Pager.Content>
+          {SCREENS.map((screen, index) => (
+            <Pager.Page key={screen.title}>
+              <Page index={index} title={screen.title} body={screen.body} />
+            </Pager.Page>
+          ))}
+        </Pager.Content>
+
+        {/* Over the pages rather than under them: a full-screen pager has no room below its
+            own content, so the dots sit on it. */}
+        <Pager.Indicator position="absolute" bottom={32} start={0} end={0} />
+      </Pager>
+    </View>
+  )
+}
+
+const TONES = ['accent', 'foreground', 'danger'] as const
+
+function Page({
+  index,
+  title,
+  body,
+}: {
+  index: number
+  title: string
+  body: string
+}) {
+  const theme = useXAUITheme()
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: theme.colors[TONES[index % TONES.length]],
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        paddingHorizontal: 32,
+      }}
+    >
+      <Text
+        style={{
+          color: theme.colors.accentForeground,
+          fontSize: theme.fontSizes['2xl'],
+          fontWeight: theme.fontWeights.bold,
+          textAlign: 'center',
+        }}
+      >
+        {title}
+      </Text>
+      <Text
+        style={{
+          color: theme.colors.accentForeground,
+          fontSize: theme.fontSizes.md,
+          textAlign: 'center',
+        }}
+      >
+        {body}
+      </Text>
+      <Skip />
+    </View>
+  )
+}
+
+/** A control inside a page, written against the context — it costs no state of its own. */
+function Skip() {
+  const { goTo, count, index } = usePager()
+  const isLast = index === count - 1
+
+  return (
+    <Button
+      variant="tertiary"
+      marginTop={8}
+      onPress={() => goTo(isLast ? 0 : count - 1)}
+    >
+      {isLast ? 'Revenir au début' : 'Passer'}
+    </Button>
+  )
+}

--- a/apps/demo/app/pager.tsx
+++ b/apps/demo/app/pager.tsx
@@ -109,7 +109,7 @@ export default function PagerScreen() {
 
       <Section
         title="Les trois variantes"
-        note="Elles nomment la couleur du point courant, seule chose que ce composant peint. Les points derrière gardent un remplissage neutre : une teinte pâle de l'accent sous les pages lirait comme un contrôle à moitié chargé."
+        note="Elles nomment la couleur de l'indicateur, et chaque point la prend : le courant à pleine force, les autres à 30 %. Une paire de couleurs devrait contraster avec elle-même et n'y arrive pas — tertiary posait surface sur default, soit blanc sur presque-blanc en clair et deux gris identiques en sombre."
       >
         {VARIANTS.map(variant => (
           <View key={variant} style={{ gap: 8 }}>
@@ -122,11 +122,20 @@ export default function PagerScreen() {
               <Pager.Content>
                 {STEPS.map(step => (
                   <Pager.Page key={step.title}>
-                    <Panel title={step.title} body={variant} />
+                    {/* `tertiary` is the raised ground — white on a light theme — so it is
+                        shown on a coloured page, which is where it is for. */}
+                    <Panel
+                      title={step.title}
+                      body={variant}
+                      tone={variant === 'tertiary' ? 'accent' : 'default'}
+                    />
                   </Pager.Page>
                 ))}
               </Pager.Content>
-              <Pager.Indicator paddingVertical={10} />
+              {/* Over the page rather than under it, so every variant's dots are compared
+                  against the ground they are meant to sit on — a `tertiary` indicator on the
+                  black page below would be a dark dot on a dark page in dark mode. */}
+              <Pager.Indicator position="absolute" bottom={10} start={0} end={0} />
             </Pager>
           </View>
         ))}

--- a/packages/native/src/components/pager/index.ts
+++ b/packages/native/src/components/pager/index.ts
@@ -15,11 +15,10 @@ export { PagerContent } from './pager-content'
 export { PagerDot, PagerIndicator } from './pager-indicator'
 export { PagerPage } from './pager-page'
 export { usePager } from './pager.context'
-export { pagerRecipe } from './pager.recipe'
+export { DOT_REST_OPACITY, pagerRecipe } from './pager.recipe'
 export type {
   PagerContentProps,
   PagerContextValue,
-  PagerDotInk,
   PagerDotProps,
   PagerOrientation,
   PagerProps,

--- a/packages/native/src/components/pager/pager-indicator.tsx
+++ b/packages/native/src/components/pager/pager-indicator.tsx
@@ -1,12 +1,10 @@
 import { forwardRef } from 'react'
 import { Pressable, View } from 'react-native'
-import Animated, {
-  interpolateColor,
-  useAnimatedStyle,
-} from 'react-native-reanimated'
+import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated'
 import { useStyleProps } from '../../system/style-props'
 import { progressFromOffset } from '../../utils/carousel'
 import { usePager } from './pager.context'
+import { DOT_REST_OPACITY } from './pager.recipe'
 import type { PagerDotProps, PagerViewSlotProps } from './pager.type'
 
 /** A dot is the right size to look at and the wrong size to hit. */
@@ -74,7 +72,6 @@ export const PagerDot = forwardRef<View, PagerDotProps>(function PagerDot(
 ) {
   const {
     dotStyle,
-    dotInk,
     offset,
     step,
     count,
@@ -83,19 +80,17 @@ export const PagerDot = forwardRef<View, PagerDotProps>(function PagerDot(
     goTo,
   } = usePager()
   const [styleProps, rest] = useStyleProps(props)
-  const { rest: restColor, active } = dotInk
 
   const travel = useAnimatedStyle(() => {
+    'worklet'
     const distance = Math.abs(progressFromOffset(offset.get(), step, count) - index)
     // Linear between two dots and nothing beyond them: `1 − distance` clamped at zero hands
-    // the colour over at exactly the rate the neighbour takes it, so the two never both read
-    // as current and never both read as behind.
+    // the strength over at exactly the rate the neighbour takes it, so the two never both
+    // read as current and never both read as behind.
     const nearness = Math.max(0, 1 - distance)
 
-    return {
-      backgroundColor: interpolateColor(nearness, [0, 1], [restColor, active]),
-    }
-  })
+    return { opacity: interpolate(nearness, [0, 1], [DOT_REST_OPACITY, 1]) }
+  }, [offset, step, count, index])
 
   return (
     <AnimatedPressable

--- a/packages/native/src/components/pager/pager.md
+++ b/packages/native/src/components/pager/pager.md
@@ -88,27 +88,43 @@ of photographs want opposite things inside a page, and the caller is the one who
 this is.
 
 Three variants, none of them an intent — a pager reports nothing, it is a way of arranging
-what does. They name which colour the **current** dot takes:
+what does. They name **the indicator's colour**, and every dot takes it:
 
 - `primary` — the accent. The onboarding flow's answer.
-- `secondary` — the neutral foreground, for a pager on a plain page.
-- `tertiary` — the raised surface, which on a light theme is white: the pager over a
-  photograph, where an accent dot disappears into whatever is behind it.
+- `secondary` — the page's own ink, for an indicator that has to read as chrome.
+- `tertiary` — the raised ground, white on a light theme.
 
 `ghost` is absent rather than forgotten. A dot with no fill is not a dot, which is why
 `InputOTP` has no `ghost` either — a box that is not a box is not a box.
 
-The dots behind the current one keep a **neutral** fill rather than a faint version of it: a
-pale tint of the accent under the pages reads as a control that has half failed to load. A
-raw `color` therefore reaches the current dot only, which is the one it should move.
+A pager over a **photograph** wants `color="#ffffff"` rather than `tertiary`: a photograph is
+a photograph in both colour modes, and `surface` flips with the theme.
 
-Both ends of the travel are the recipe's, so `variant` is how the **pair** moves — and a
-style prop is not: `<Pager.Dot backgroundColor="…" />` lands after the interpolated colour
-and replaces it outright, which stops the dot travelling at all. A caller who needs a pair
-the three variants do not offer composes their own dot against `usePager().offset`, which is
-what the context publishes it for.
+### One colour at two opacities, not two colours
 
-## The dot changes colour, it does not stretch
+The current dot is at full strength and the rest sit at 30%. `DOT_REST_OPACITY` is exported,
+and the travel between the two is interpolated from the live scroll offset.
+
+This is the correction of the component's first shape, and it is worth stating why rather than
+just what. The dots started as a **pair** of tokens — the current one from the variant, the
+rest from the neutral `default` fill, which is what `Carousel` does. A pair has to be chosen
+to contrast with itself, and it cannot be: `tertiary` put `surface` against `default`, which
+measures `#ffffff` on `#e4e4e7` in light and two near-identical greys in dark. The one variant
+that exists for a pager over an image was the one whose indicator could not be read, in both
+colour modes.
+
+One colour at two opacities cannot collapse like that — whatever the variant, whichever the
+colour mode, and for any raw `color` a caller invents. It is also what iOS's own page control
+does. 30% rather than 50%: the dots are seven points across, and at half strength a small mark
+reads as the current one seen through something rather than as a mark behind it.
+
+A style prop is still not the way to recolour one dot: `<Pager.Dot backgroundColor="…" />`
+lands after the recipe, so it paints that dot and leaves the opacity travel alone — which is
+usually not what someone reaching for it meant. A caller who needs something the variants and
+`color` do not offer composes their own dot against `usePager().offset`, which is what the
+context publishes it for.
+
+## The dot fades, it does not stretch
 
 That is the difference from `Carousel.Dot`, and it is deliberate rather than a
 simplification. A page control is a fixed row of marks saying how many screens there are and
@@ -116,7 +132,7 @@ which one you are on, and a mark that grows makes the row's arithmetic move unde
 who is counting it. The carousel's pill is a _progress_ indicator over a series; this is a
 position among screens.
 
-It **follows the drag rather than the settle**: the colour is interpolated from the live
+It **follows the drag rather than the settle**: the opacity is interpolated from the live
 scroll offset on the UI thread, so it travels while the finger is still down. Reading the
 settled index instead would make it jump once per gesture, after the fact.
 

--- a/packages/native/src/components/pager/pager.recipe.ts
+++ b/packages/native/src/components/pager/pager.recipe.ts
@@ -3,24 +3,45 @@ import type { SlotStyles, VariantTokens } from '../../system/recipe'
 import type { Size, XAUITheme } from '../../theme/theme.type'
 import type { PagerSlot, PagerVariant } from './pager.type'
 
-const SLOTS = ['root', 'content', 'page', 'indicator', 'dot', 'dotActive'] as const
+const SLOTS = ['root', 'content', 'page', 'indicator', 'dot'] as const
 
 /**
  * The tokens paint the **dots**, and nothing else — the pages are the caller's content and
  * this component never touches them.
  *
- * Only `bgSelected` is named, because only the current dot is a colour decision: the ones
- * behind it keep the neutral fill `base` gives them, which is the ground the current one
- * travels over. `bgSelected` is also the role a raw `color` re-tints, which is why the
- * colour that matters is the one carrying that name.
+ * One role, not two. Every dot takes `bgSelected` and the unfilled ones are the same colour
+ * at `DOT_REST_OPACITY`, so there is no second token that has to be chosen to contrast with
+ * the first. It is also the role a raw `color` re-tints, which is why a tinted pager tints
+ * its whole indicator rather than half of it.
  */
 const VARIANT_TOKENS: Record<PagerVariant, VariantTokens> = {
   primary: { bgSelected: 'accent' },
-  secondary: { bgSelected: 'defaultForeground' },
-  // The raised ground rather than the page's, which on a light theme is white: this is the
-  // pager over a photograph, where an accent dot disappears into whatever is behind it.
+  // The page's own ink, for an indicator that has to read as chrome rather than as accent.
+  secondary: { bgSelected: 'foreground' },
+  // The raised ground — white on a light theme. A pager over a *photograph* wants
+  // `color="#ffffff"` instead: a photograph is a photograph in both colour modes, and this
+  // token flips with the theme.
   tertiary: { bgSelected: 'surface' },
 }
+
+/**
+ * How far behind the current dot the others sit.
+ *
+ * **Opacity, not a second colour**, and this is the load-bearing decision in the file. A
+ * neutral fill for the unfilled dots — the `Carousel`'s answer, which this copied first — has
+ * to contrast with whatever the current one happens to be, and it cannot: `tertiary` puts
+ * `surface` against `default`, which is `#ffffff` on `#e4e4e7` in light and two
+ * near-identical greys in dark. The variant that exists for a pager over an image was the one
+ * whose indicator could not be read.
+ *
+ * One colour at two opacities cannot collapse like that, whatever the variant, whichever the
+ * colour mode, and for any raw `color` a caller invents. It is also what iOS's own page
+ * control does.
+ *
+ * 0.3 rather than 0.5: the dots are seven points across, and at half strength a small mark
+ * reads as the current one seen through something rather than as a mark behind it.
+ */
+export const DOT_REST_OPACITY = 0.3
 
 type SizeStep = {
   /** A dot's diameter. */
@@ -67,7 +88,7 @@ function orientationAxis(direction: 'row' | 'column') {
 export const pagerRecipe = createRecipe({
   slots: SLOTS,
 
-  base: theme => ({
+  base: () => ({
     /**
      * **The root has no size of its own**, and that is deliberate rather than missing.
      *
@@ -87,23 +108,17 @@ export const pagerRecipe = createRecipe({
     // named, so it arrives as an inline style instead of from here.
     page: { overflow: 'hidden' },
     indicator: { alignItems: 'center', justifyContent: 'center' },
-    /**
-     * A neutral fill rather than a faint version of the current one: a pale tint of the
-     * accent under the pages reads as a control that has half failed to load. A raw `color`
-     * reaches the current dot, which is the one it should move.
-     */
-    dot: { backgroundColor: theme.colors.default },
   }),
 
   variantTokens: VARIANT_TOKENS,
 
   /**
-   * The current dot, **read as a value and never applied as a style**: the colour is
-   * interpolated on the UI thread, and `interpolateColor` needs a string rather than a
-   * `StyleSheet` id. The root flattens this slot into `dotInk`, so the recipe still owns it.
+   * Every dot takes the same colour. What separates the current one from the rest is its
+   * opacity, animated on the UI thread — so this is a plain style rather than a value the
+   * root has to flatten and hand to a worklet.
    */
   paint: (_theme, colors) => ({
-    dotActive: { backgroundColor: colors.bgSelected },
+    dot: { backgroundColor: colors.bgSelected },
   }),
 
   variants: {

--- a/packages/native/src/components/pager/pager.tsx
+++ b/packages/native/src/components/pager/pager.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useCallback, useMemo, useState } from 'react'
-import { StyleSheet, View } from 'react-native'
-import type { ViewStyle } from 'react-native'
+import { View } from 'react-native'
 import type Animated from 'react-native-reanimated'
 import { useAnimatedRef, useSharedValue } from 'react-native-reanimated'
 import { useControllableState } from '../../hooks/use-controllable-state'
@@ -115,28 +114,14 @@ export const PagerRoot = forwardRef<View, PagerProps>(function Pager(
     [orientation, setIndex, step, trackRef]
   )
 
-  const context = useMemo(() => {
-    const active = StyleSheet.flatten<ViewStyle>([styles.dotActive, tint?.dotActive])
-    const at = StyleSheet.flatten<ViewStyle>([styles.dot])
-
-    return {
+  const context = useMemo(
+    () => ({
       contentStyle: styles.content,
       pageStyle: styles.page,
       indicatorStyle: styles.indicator,
-      dotStyle: styles.dot,
-      // Values rather than styles: the colour is interpolated on the UI thread, and
-      // `interpolateColor` needs strings. The fallbacks are the tokens the recipe named, for
-      // the platform colours `ColorValue` also covers.
-      dotInk: {
-        rest:
-          typeof at.backgroundColor === 'string'
-            ? at.backgroundColor
-            : theme.colors.default,
-        active:
-          typeof active.backgroundColor === 'string'
-            ? active.backgroundColor
-            : theme.colors.accent,
-      },
+      // One colour for every dot; the current one is told apart by its opacity, which the dot
+      // animates itself. Nothing here has to be flattened into a value for a worklet.
+      dotStyle: tint ? [styles.dot, tint.dot] : styles.dot,
       orientation,
       index,
       count,
@@ -149,23 +134,23 @@ export const PagerRoot = forwardRef<View, PagerProps>(function Pager(
       onSettle: setIndex,
       trackRef,
       isDisabled,
-    }
-  }, [
-    styles,
-    tint,
-    theme,
-    orientation,
-    index,
-    count,
-    track,
-    setTrack,
-    step,
-    offset,
-    goTo,
-    setIndex,
-    trackRef,
-    isDisabled,
-  ])
+    }),
+    [
+      styles,
+      tint,
+      orientation,
+      index,
+      count,
+      track,
+      setTrack,
+      step,
+      offset,
+      goTo,
+      setIndex,
+      trackRef,
+      isDisabled,
+    ]
+  )
 
   // The resolution order of §2 ter: the cached recipe, the uncached tint, the style props,
   // then `style` — the last word.

--- a/packages/native/src/components/pager/pager.type.ts
+++ b/packages/native/src/components/pager/pager.type.ts
@@ -82,12 +82,6 @@ export type PagerDotProps = PagerViewSlotProps & {
   index: number
 }
 
-/** The two colours a dot travels between, read as values because a worklet interpolates them. */
-export type PagerDotInk = {
-  rest: string
-  active: string
-}
-
 /** How big the track measured — a page is exactly this, on both axes. */
 export type PagerTrackSize = {
   width: number
@@ -99,8 +93,12 @@ export type PagerContextValue = {
   contentStyle: StyleProp<ViewStyle>
   pageStyle: StyleProp<ViewStyle>
   indicatorStyle: StyleProp<ViewStyle>
+  /**
+   * One colour for every dot. What tells the current one from the rest is its opacity, which
+   * the dot animates itself — so there is no second colour in here to keep in contrast with
+   * the first, and no pair that can collapse into one.
+   */
   dotStyle: StyleProp<ViewStyle>
-  dotInk: PagerDotInk
   orientation: PagerOrientation
   /** The settled page. */
   index: number


### PR DESCRIPTION
## What

The `Pager`'s indicator is now **one colour at two opacities** instead of two colours. Plus a
full-screen `Pager` verification in the demo, which is what surfaced it.

## Why

The dots were a **pair** of tokens: the current one from the variant, the rest from the
neutral `default` fill — which is what `Carousel` does, and which this copied. A pair has to
be chosen to contrast with itself, and it cannot be. Measured in the DOM:

| variant | current | rest | |
| --- | --- | --- | --- |
| `primary` (light) | `rgb(147,51,234)` | `rgb(228,228,231)` | fine |
| `secondary` (light) | `rgb(24,24,27)` | `rgb(228,228,231)` | fine |
| **`tertiary` (light)** | **`rgb(255,255,255)`** | **`rgb(228,228,231)`** | **white on near-white** |
| `primary` (dark) | `rgb(192,132,252)` | `rgb(39,39,42)` | fine |
| **`tertiary` (dark)** | **`surface` ≈ `rgb(39,39,42)`** | **`rgb(39,39,42)`** | **two identical greys** |

The one variant that exists for a pager over an image was the one whose indicator could not be
read — in both colour modes.

## How

Every dot takes the variant's one colour. The current one is at full strength and the rest sit
at `DOT_REST_OPACITY` (0.3, exported), and the travel between them is the same interpolation
from the live scroll offset, on `opacity` instead of `backgroundColor`.

One colour at two opacities cannot collapse: not for any variant, not in either colour mode,
and not for any raw `color` a caller invents. It is also what iOS's own page control does. 30%
rather than 50% — the dots are seven points across, and at half strength a small mark reads as
the current one seen through something rather than as a mark behind it.

Three consequences worth calling out:

- **`secondary` is now `foreground`** rather than `defaultForeground` — the page's own ink, for
  an indicator that has to read as chrome.
- **A pager over a photograph is `color="#ffffff"`, not `tertiary`.** A photograph is a
  photograph in both colour modes, and `surface` flips with the theme. The doc claimed
  `tertiary` was the answer for that case; it was not, and it now says so.
- **`PagerDotInk` and the context's `dotInk` are gone**, along with the flatten that built
  them. There is no pair for a worklet to interpolate between, so the recipe's `dot` is a plain
  style — which also removes the two token fallbacks the flatten needed for the platform
  colours `ColorValue` covers.

The doc's paragraph arguing *for* a neutral rest fill is replaced by one explaining why that
shape was wrong, since it is the kind of decision someone will otherwise re-make.

## Full-screen verification

`/pager-full` in the demo: a `Pager` with `flex={1}` filling the screen, full-bleed pages and
the dots overlaid. It is the case a section inside a `ScrollView` cannot show — a page that
fills the screen needs a parent that does — and it is the answer to "can a `Pager` be full
page": `flex={1}`, which is exactly why the recipe gives the root no size of its own.

## Verification

`pnpm lint && pnpm type-check && pnpm test` — green (54 test files on `@xaui/native`, 93 on
`@xaui/native-legacy`).

Measured in the DOM after the change, every variant, both modes: one `backgroundColor` per row
with the current dot at `1.00` and the rest at `0.30`. Screenshotted in light and dark — all
three variants now read, including `tertiary`.

Full page confirmed by geometry rather than by eye: viewport 430×932, track 430×868 (the screen
less the header), `scrollWidth` 1290 = 3 × 430, three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
