### PR TITLE
chore(release): move the pre-release line from alpha to beta

### DIFF
--- a/.agents/skills/xaui-flow/SKILL.md
+++ b/.agents/skills/xaui-flow/SKILL.md
@@ -95,7 +95,7 @@ progress is recorded, and it moves in the same commit as the work.
 
 ## 7. Changeset
 
-One per touched package, **always `patch`** while we're on the `alpha` line:
+One per touched package, **always `patch`** while we're on the `beta` line:
 
 ```bash
 pnpm changeset

--- a/.agents/skills/xaui-legacy-migration/SKILL.md
+++ b/.agents/skills/xaui-legacy-migration/SKILL.md
@@ -11,7 +11,7 @@ npm name.
 | Package               | Content                           | Version                                        |
 | --------------------- | --------------------------------- | ---------------------------------------------- |
 | `@xaui/native-legacy` | the 47 current components, frozen | `0.2.8` — same number as the last real release |
-| `@xaui/native`        | the v1 API, from scratch          | `0.9.x-alpha.x` → `1.0.0`                      |
+| `@xaui/native`        | the v1 API, from scratch          | `0.9.x-beta.x` → `1.0.0`                       |
 | `@xaui/hybrid`        | frozen during P0–P4               | unchanged                                      |
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §7.

--- a/.agents/skills/xaui-review/SKILL.md
+++ b/.agents/skills/xaui-review/SKILL.md
@@ -175,7 +175,7 @@ pnpm lint && pnpm type-check && pnpm test
 - [ ] All three green — paste the real result, never "should pass".
 - [ ] Demo screen renders in light **and** dark.
 - [ ] Legacy equivalent carries `@deprecated` pointing at the replacement.
-- [ ] A changeset exists (`patch` — we are on the `alpha` line) for every touched package.
+- [ ] A changeset exists (`patch` — we are on the `beta` line) for every touched package.
 
 ## The one blocking review of the project
 

--- a/.changeset/beta-line.md
+++ b/.changeset/beta-line.md
@@ -1,0 +1,16 @@
+---
+'@xaui/native': patch
+'@xaui/hybrid': patch
+---
+
+Move the pre-release line from `alpha` to `beta`.
+
+`.changeset/pre.json` now carries the tag `beta`, so both packages are versioned
+`0.9.x-beta.x` and every publish lands on the `beta` dist-tag: `pnpm add @xaui/native@beta`
+is the opt-in from here on. The `alpha` dist-tag is frozen on the last `0.9.1-alpha.x`
+publish and no longer moves, and `latest` is untouched — it still points at
+`@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14` until `1.0.0`.
+
+Only the `tag` field changed. `initialVersions` and the list of consumed changesets are
+kept as they were, which is what a `pre exit` + `pre enter beta` would have thrown away —
+the next `changeset version` would then have replayed every entry into the changelogs.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "alpha",
+  "tag": "beta",
   "initialVersions": {
     "demo": "1.0.71",
     "docs": "0.1.47",

--- a/.claude/skills/xaui-flow/SKILL.md
+++ b/.claude/skills/xaui-flow/SKILL.md
@@ -95,7 +95,7 @@ progress is recorded, and it moves in the same commit as the work.
 
 ## 7. Changeset
 
-One per touched package, **always `patch`** while we're on the `alpha` line:
+One per touched package, **always `patch`** while we're on the `beta` line:
 
 ```bash
 pnpm changeset

--- a/.claude/skills/xaui-legacy-migration/SKILL.md
+++ b/.claude/skills/xaui-legacy-migration/SKILL.md
@@ -11,7 +11,7 @@ npm name.
 | Package               | Content                           | Version                                        |
 | --------------------- | --------------------------------- | ---------------------------------------------- |
 | `@xaui/native-legacy` | the 47 current components, frozen | `0.2.8` — same number as the last real release |
-| `@xaui/native`        | the v1 API, from scratch          | `0.9.x-alpha.x` → `1.0.0`                      |
+| `@xaui/native`        | the v1 API, from scratch          | `0.9.x-beta.x` → `1.0.0`                       |
 | `@xaui/hybrid`        | frozen during P0–P4               | unchanged                                      |
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §7.

--- a/.claude/skills/xaui-review/SKILL.md
+++ b/.claude/skills/xaui-review/SKILL.md
@@ -175,7 +175,7 @@ pnpm lint && pnpm type-check && pnpm test
 - [ ] All three green — paste the real result, never "should pass".
 - [ ] Demo screen renders in light **and** dark.
 - [ ] Legacy equivalent carries `@deprecated` pointing at the replacement.
-- [ ] A changeset exists (`patch` — we are on the `alpha` line) for every touched package.
+- [ ] A changeset exists (`patch` — we are on the `beta` line) for every touched package.
 
 ## The one blocking review of the project
 

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -40,7 +40,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P2.1   | The reference `Button`                                                           | done    |
 | P2.2   | Perf baseline — 200 buttons, re-renders and allocations                          | done    |
 | P2.3   | API review — blocking, nothing starts in P3 before it                            | done    |
-| P2.4   | Publish `@xaui/native` on the `alpha` tag                                        | ci      |
+| P2.4   | Publish `@xaui/native` on the pre-release tag                                    | ci      |
 | P2.5   | Fix the ripple — it renders nothing (P2-API-REVIEW §D)                           | done    |
 | P2.5b  | `PressableFeedback` composes its overlays — no `feedbackVariant`                 | done    |
 | P2.6   | Style as props (R14) — `system/style-props/`, then the `Button`                  | done    |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -1092,7 +1092,7 @@ L'ancien tree ne devient **pas** un sous-chemin de `@xaui/native`. Il est republ
 | --------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@xaui/native-legacy` | les 47 composants actuels, figés | `0.2.11` — le dernier numéro que le package a réellement porté avant sa publication (le `0.2.8` visé à l'origine a été dépassé par les trois patchs de P0 : core-shim, icônes inlinées) |
 | `@xaui/native`        | l'API v1, repart de zéro         | `1.0.0`                                                                                                                                                                                 |
-| `@xaui/hybrid`        | gelé pendant P0–P4               | `0.9.x-alpha.x` — thème seulement, publié sur le tag `alpha` ; `latest` reste sur `0.0.14`                                                                                              |
+| `@xaui/hybrid`        | gelé pendant P0–P4               | `0.9.x-beta.x` — thème seulement, publié sur le tag `beta` ; `latest` reste sur `0.0.14`                                                                                                |
 
 C'est plus propre que le sous-chemin sur trois points concrets :
 
@@ -1184,20 +1184,20 @@ startContent={<I/>} / endContent={<I/>}     → <X.Icon/> placé dans l'ordre vo
 
 ### Versions
 
-| Package               | Version         | Contenu                                                                                                                                                                                            |
-| --------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@xaui/native-legacy` | `0.2.11`        | publié une fois, figé — et figé pour de bon : le package est dans `ignore` (`.changeset/config.json`), donc changesets ne le versionne plus. Un correctif `0.2.x` demande de le sortir de la liste |
-| `@xaui/native`        | `0.9.x-alpha.x` | le noyau arrive composant par composant, API instable et annoncée comme telle                                                                                                                      |
-| `@xaui/native`        | `1.0.0`         | noyau de 15 composants + doc complète                                                                                                                                                              |
-| `@xaui/native`        | `1.x`           | les 32 composants restants                                                                                                                                                                         |
-| `@xaui/native`        | `2.0.0`         | plus rien à voir avec legacy — `native-legacy` est déprécié bien avant                                                                                                                             |
+| Package               | Version        | Contenu                                                                                                                                                                                            |
+| --------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@xaui/native-legacy` | `0.2.11`       | publié une fois, figé — et figé pour de bon : le package est dans `ignore` (`.changeset/config.json`), donc changesets ne le versionne plus. Un correctif `0.2.x` demande de le sortir de la liste |
+| `@xaui/native`        | `0.9.x-beta.x` | le noyau arrive composant par composant, API instable et annoncée comme telle                                                                                                                      |
+| `@xaui/native`        | `1.0.0`        | noyau de 15 composants + doc complète                                                                                                                                                              |
+| `@xaui/native`        | `1.x`          | les 32 composants restants                                                                                                                                                                         |
+| `@xaui/native`        | `2.0.0`        | plus rien à voir avec legacy — `native-legacy` est déprécié bien avant                                                                                                                             |
 
-Les préversions `0.9.x-alpha` remplacent les `0.4.x – 0.9.x` du modèle précédent : comme `@xaui/native` repart de zéro, publier des mineures qui ne contiennent que deux ou trois composants donnerait un package inutilisable sous un numéro qui promet le contraire. Un tag `alpha` dit la vérité.
+Les préversions `0.9.x` remplacent les `0.4.x – 0.9.x` du modèle précédent : comme `@xaui/native` repart de zéro, publier des mineures qui ne contiennent que deux ou trois composants donnerait un package inutilisable sous un numéro qui promet le contraire. Un tag de préversion dit la vérité. La ligne a démarré sur `alpha` et est passée sur `beta` une fois le noyau v1 et sa documentation en place ; le basculement est une simple édition de `tag` dans `.changeset/pre.json`, jamais un `pre exit` suivi d'un `pre enter` — celui-ci réinitialise `initialVersions` et la liste des changesets déjà consommés, et le `changeset version` suivant rejouerait tout le changelog.
 
-Concrètement, le dépôt est en **pre mode changesets** (`.changeset/pre.json`, tag `alpha`) : `changeset publish` pousse `native` et `hybrid` sous le dist-tag `alpha`, et `latest` reste sur les dernières releases qui portent réellement des composants — `@xaui/native@0.2.8` et `@xaui/hybrid@0.0.14`. Un `npm i @xaui/native` continue donc de renvoyer `0.2.8` ; l'opt-in est `@xaui/native@alpha`. Trois conséquences à garder en tête :
+Concrètement, le dépôt est en **pre mode changesets** (`.changeset/pre.json`, tag `beta`) : `changeset publish` pousse `native` et `hybrid` sous le dist-tag `beta`, et `latest` reste sur les dernières releases de la ligne précédente — `@xaui/native@0.2.8` et `@xaui/hybrid@0.0.14`. Un `npm i @xaui/native` continue donc de renvoyer `0.2.8` ; l'opt-in est `@xaui/native@beta`. Le dist-tag `alpha` est figé sur le dernier publish `0.9.1-alpha.x` et ne bouge plus. Trois conséquences à garder en tête :
 
-- **Le pre mode est global au dépôt, et il contamine les dépendants.** Il n'y a même pas besoin d'un changeset sur `@xaui/native-legacy` : comme il déclare `@xaui/native` en peer dep, la release `0.9.1-alpha.0` l'a bumpé en `0.2.12-alpha.0` au passage. C'est pour ça que legacy est dans `ignore` (`.changeset/config.json`) — sinon chaque alpha de `native` lui collerait un numéro d'alpha alors qu'il est figé. `demo` et `docs` y sont aussi, parce que changesets exige que tout dépendant d'un package ignoré le soit également.
-- **Le tag d'un premier publish ne se négocie pas en pre mode.** `getReleaseTag` (`@changesets/cli`) donne le tag pre à tout package dont `publishedState !== "only-pre"`, ce qui inclut `"never"` : un package jamais publié sort donc taggé `alpha`, sans tag `latest` du tout. Et il n'y a pas d'échappatoire propre — `changeset publish --tag` est refusé en pre mode, et `changeset pre exit` ne suffit pas (le `preState` est passé au publish quel que soit son mode ; seul le `changeset version` suivant supprime `pre.json`, en graduant `native` et `hybrid` sur `latest` au passage). La sortie de secours est en aval : publier sous `alpha`, puis `npm dist-tag add <pkg>@<version> latest`. C'est ce qui a été fait pour `@xaui/native-legacy@0.2.11`.
+- **Le pre mode est global au dépôt, et il contamine les dépendants.** Il n'y a même pas besoin d'un changeset sur `@xaui/native-legacy` : comme il déclare `@xaui/native` en peer dep, la release `0.9.1-alpha.0` l'a bumpé en `0.2.12-alpha.0` au passage. C'est pour ça que legacy est dans `ignore` (`.changeset/config.json`) — sinon chaque préversion de `native` lui collerait un numéro de préversion alors qu'il est figé. `demo` et `docs` y sont aussi, parce que changesets exige que tout dépendant d'un package ignoré le soit également.
+- **Le tag d'un premier publish ne se négocie pas en pre mode.** `getReleaseTag` (`@changesets/cli`) donne le tag pre à tout package dont `publishedState !== "only-pre"`, ce qui inclut `"never"` : un package jamais publié sort donc taggé `beta`, sans tag `latest` du tout. Et il n'y a pas d'échappatoire propre — `changeset publish --tag` est refusé en pre mode, et `changeset pre exit` ne suffit pas (le `preState` est passé au publish quel que soit son mode ; seul le `changeset version` suivant supprime `pre.json`, en graduant `native` et `hybrid` sur `latest` au passage). La sortie de secours est en aval : publier sous le tag pre, puis `npm dist-tag add <pkg>@<version> latest`. C'est ce qui a été fait pour `@xaui/native-legacy@0.2.11`.
 - **`changeset pre exit` avant `1.0.0`**, sinon la version stable n'atteindrait jamais le tag `latest`.
 
 ---
@@ -1402,7 +1402,7 @@ Identique pour P2, P3 et P5. C'est **la** tâche répétée 47 fois ; l'écrire 
    → Un chiffre écrit dans le plan. C'est le seuil que les 46 autres devront tenir, et la seule preuve que le cache fait ce qu'on prétend. **Mesuré — voir §9 bis.**
 3. **Revue d'API — bloquante.**
    → Corriger le pattern ici coûte 1 ; après le noyau, 15. Rien ne démarre en P3 avant cette revue. **Faite — `P2-API-REVIEW.md` : neuf constats, six corrigés, trois datés. Verdict : le pattern tient, P3 peut démarrer.**
-4. **Publier `@xaui/native` sur le tag `alpha`** (la ligne `0.9.x-alpha.x` est déjà ouverte, cf. §Versions).
+4. **Publier `@xaui/native` sur le tag de préversion** (la ligne `0.9.x` est déjà ouverte, cf. §Versions).
    → La démo consomme le package publié, pas le workspace. **Le dépôt est prêt — voir §9 ter.**
 
 ---
@@ -1438,8 +1438,8 @@ PR « Version Packages » ; merger celle-là publie. `changeset version`, `versi
 `release` ne se lancent jamais à la main (§Release).
 
 Les changesets de P2 sont posés : le `Button`, le correctif `asChild`, et les correctifs de
-la revue d'API. En pre mode `alpha`, ils donnent `@xaui/native@0.9.2-alpha.0` sur le
-dist-tag `alpha`. `latest` ne bouge pas.
+la revue d'API. En pre mode `beta`, ils donnent un `@xaui/native@0.9.x-beta.x` sur le
+dist-tag `beta`. `latest` ne bouge pas.
 
 **La barrière avant la publication.** `pnpm pack:check` répond maintenant à deux questions
 sur le tarball plutôt qu'une :
@@ -1455,7 +1455,7 @@ sur le tarball plutôt qu'une :
 
 **Ce qui reste, une fois la version sur npm** — dans cet ordre, et pas avant :
 
-1. `apps/demo` passe de `workspace:*` à `@xaui/native@alpha`. C'est le critère d'acceptation
+1. `apps/demo` passe de `workspace:*` à `@xaui/native@beta`. C'est le critère d'acceptation
    de P2.4 : la démo doit consommer ce que les gens installent, pas l'arbre de travail.
    **Attention au risque du §10** : `@xaui/native-legacy` déclare `@xaui/native` en peer, et
    la démo dépend des deux. Un range qui ne se résout pas sur la même version mettrait deux

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Commits follow commitizen. **No Claude co-author line.** Commit progressively �
 per coherent unit as the work lands, not one at the end.
 
 Before the PR: create a changeset per touched package (`pnpm changeset`, always **patch**,
-we are on the `alpha` line — see §Release), commit the `.changeset/*.md`, run `pnpm lint &&
+we are on the `beta` line — see §Release), commit the `.changeset/*.md`, run `pnpm lint &&
 pnpm type-check && pnpm test`, and run the `xaui-review` skill on the diff.
 
 ```bash
@@ -157,29 +157,36 @@ Changesets, fully automated. **Never run `pnpm changeset version`, `pnpm version
 or `pnpm release` locally** — merging to `main` opens or updates a "Version Packages" PR,
 and merging that one publishes.
 
-### The `alpha` line
+### The `beta` line
 
-The repo is in changesets **pre mode** with the tag `alpha` (`.changeset/pre.json`), so
-`@xaui/native` and `@xaui/hybrid` are versioned `0.9.x-alpha.x` and published on the
-`alpha` dist-tag. `latest` keeps pointing at `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`
-— the last releases that carry components — because v1's `src/` is still the theme layer
-alone. `pnpm add @xaui/native@alpha` is how you get it.
+The repo is in changesets **pre mode** with the tag `beta` (`.changeset/pre.json`), so
+`@xaui/native` and `@xaui/hybrid` are versioned `0.9.x-beta.x` and published on the
+`beta` dist-tag. `latest` keeps pointing at `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`
+— the last releases of the previous line — because v1 is not `1.0.0` yet.
+`pnpm add @xaui/native@beta` is how you get it.
+
+The line was `alpha` until the v1 core was documented end to end; the switch was a single
+edit of `tag` in `.changeset/pre.json`, which keeps `initialVersions` and the consumed
+`changesets` list intact. Never do it with `pre exit` + `pre enter`: that resets both, and
+the next `changeset version` would replay every changeset into the changelogs. The `alpha`
+dist-tag is frozen on the last `0.9.1-alpha.x` publish and no longer moves — nothing
+republishes it, so `@xaui/native@alpha` is now a historical pin.
 
 Three consequences, all of them load-bearing:
 
 - **Never `changeset pre exit`** unless the task says to. It graduates both packages onto
-  `latest`, which today means handing every `npm i @xaui/native` a package with no
-  components. It is required exactly once, right before `1.0.0`.
+  `latest`, which today means handing every `npm i @xaui/native` an unfinished v1. It is
+  required exactly once, right before `1.0.0`.
 - **Pre mode is repo-wide and reaches dependents.** No changeset on a package is needed for
-  it to catch an alpha number: `@xaui/native-legacy` peer-depends on `@xaui/native`, so
-  `0.9.1-alpha.0` bumped it to `0.2.12-alpha.0` on its own. That is why
+  it to catch a pre-release number: `@xaui/native-legacy` peer-depends on `@xaui/native`,
+  so `0.9.1-alpha.0` bumped it to `0.2.12-alpha.0` on its own. That is why
   `@xaui/native-legacy` sits in `ignore` (`.changeset/config.json`) — it is frozen at
   `0.2.11` and must stay there. `demo` and `docs` are in that list too, because changesets
   requires every dependent of an ignored package to be ignored as well. A genuine `0.2.x`
   fix on legacy means taking it out of `ignore` for that release.
 - **The tag on a first publish cannot be chosen in pre mode.** `getReleaseTag` gives the
   pre tag to any package whose `publishedState` is not `"only-pre"`, and `"never"` is not
-  `"only-pre"` — so a never-published package goes out tagged `alpha` with no `latest` tag
+  `"only-pre"` — so a never-published package goes out tagged `beta` with no `latest` tag
   at all. There is no clean way out: `changeset publish --tag` is refused in pre mode, and
   `changeset pre exit` does not help (publish reads `preState` whatever its mode; only the
   next `changeset version` deletes `pre.json`, and it graduates `native` and `hybrid` onto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,14 @@ Two pointers that save a lookup:
 - Task status: `.project-specs/ROADMAP.md`
 - The plan the work follows: `.project-specs/XAUI-V1-PLAN.md`
 
-**`@xaui/native` and `@xaui/hybrid` are on the `alpha` line.** The repo sits in changesets
-pre mode (`.changeset/pre.json`, tag `alpha`), so every version those two packages get is
-named `0.9.x-alpha.x` and every publish lands on the `alpha` dist-tag. `latest` stays where
-it is — `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`, the last releases that carry
-components — until the v1 core is real. Never run `changeset pre exit` unless asked: it
-would graduate both packages onto `latest` with a theme layer and no components. AGENTS.md
-§Release and plan §Versions have the rest.
+**`@xaui/native` and `@xaui/hybrid` are on the `beta` line.** The repo sits in changesets
+pre mode (`.changeset/pre.json`, tag `beta`), so every version those two packages get is
+named `0.9.x-beta.x` and every publish lands on the `beta` dist-tag. The `alpha` dist-tag
+is frozen on the last `0.9.1-alpha.x` publish and no longer moves. `latest` stays where it
+is — `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14`, the last releases that carry the old
+components — until the v1 core is complete. Never run `changeset pre exit` unless asked: it
+would graduate both packages onto `latest` before v1 is done. AGENTS.md §Release and plan
+§Versions have the rest.
 
 Skills live in `.agents/skills/<name>/SKILL.md`, copied into `.claude/skills/`. Start any
 non-trivial task with `xaui-flow`; run `xaui-review` on the diff before every PR.

--- a/apps/docs/app/docs/components/[componentId]/page.tsx
+++ b/apps/docs/app/docs/components/[componentId]/page.tsx
@@ -79,7 +79,7 @@ export default async function ComponentPage({ params }: ComponentPageProps) {
       <header className="space-y-5 border-b pb-8">
         <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
           <span className="rounded-full bg-violet-100 px-2.5 py-1 text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-            Alpha
+            Beta
           </span>
           <span className="rounded-full bg-muted px-2.5 py-1 text-muted-foreground">
             {component.category}

--- a/apps/docs/app/docs/faq/page.tsx
+++ b/apps/docs/app/docs/faq/page.tsx
@@ -69,12 +69,13 @@ export default function FaqPage() {
           </p>
         </Question>
 
-        <Question id="alpha-tag" question="Why install from the alpha tag?">
+        <Question id="beta-tag" question="Why install from the beta tag?">
           <p>
-            The current package publishes on the <code>alpha</code> dist-tag, so{' '}
-            <code>pnpm add @xaui/native@alpha</code> is what gets you the{' '}
+            The current package publishes on the <code>beta</code> dist-tag, so{' '}
+            <code>pnpm add @xaui/native@beta</code> is what gets you the{' '}
             {components.length} components documented here. Plain <code>latest</code>{' '}
-            still points at the previous line.
+            still points at the previous line, and the <code>alpha</code> tag is
+            frozen on the last pre-beta publish.
           </p>
         </Question>
 

--- a/apps/docs/app/docs/getting-started/page.tsx
+++ b/apps/docs/app/docs/getting-started/page.tsx
@@ -21,7 +21,7 @@ export default function GettingStartedPage() {
       </header>
 
       <Step number="1" title="Install the package">
-        <CodeBlock language="bash" code="pnpm add @xaui/native@alpha" />
+        <CodeBlock language="bash" code="pnpm add @xaui/native@beta" />
         <p className="text-sm text-muted-foreground">
           The native peer dependencies are listed in the{' '}
           <Link className="underline" href="/docs/installation">

--- a/apps/docs/app/docs/installation/page.tsx
+++ b/apps/docs/app/docs/installation/page.tsx
@@ -23,7 +23,7 @@ export default function InstallationPage() {
       <DocSection title="Expo (recommended)">
         <CodeBlock
           language="bash"
-          code={`pnpm add @xaui/native@alpha libphonenumber-js
+          code={`pnpm add @xaui/native@beta libphonenumber-js
 pnpm exec expo install react-native-reanimated react-native-worklets \\
   react-native-gesture-handler react-native-svg react-native-safe-area-context`}
         />
@@ -37,7 +37,7 @@ pnpm exec expo install react-native-reanimated react-native-worklets \\
       <DocSection title="React Native Community CLI">
         <CodeBlock
           language="bash"
-          code={`pnpm add @xaui/native@alpha libphonenumber-js \\
+          code={`pnpm add @xaui/native@beta libphonenumber-js \\
   react-native-reanimated react-native-worklets react-native-gesture-handler \\
   react-native-svg react-native-safe-area-context
 cd ios && pod install && cd ..`}

--- a/apps/docs/app/docs/introduction/page.tsx
+++ b/apps/docs/app/docs/introduction/page.tsx
@@ -34,7 +34,7 @@ export default function IntroductionPage() {
     <div className="space-y-14 pb-16">
       <header className="space-y-6">
         <div className="inline-flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1.5 text-xs font-medium">
-          <Sparkles className="size-3.5" /> @xaui/native · alpha
+          <Sparkles className="size-3.5" /> @xaui/native · beta
         </div>
         <div className="max-w-3xl space-y-4">
           <h1 className="text-4xl font-bold tracking-tight md:text-6xl">

--- a/apps/docs/app/docs/migration/page.tsx
+++ b/apps/docs/app/docs/migration/page.tsx
@@ -40,7 +40,7 @@ export default function MigrationPage() {
         </h2>
         <CodeBlock
           language="bash"
-          code="pnpm add @xaui/native@alpha --save-exact @xaui/native-legacy@0.2.11"
+          code="pnpm add @xaui/native@beta --save-exact @xaui/native-legacy@0.2.11"
         />
         <p className="text-muted-foreground">
           Pin <code>@xaui/native-legacy</code> to an exact version. It is frozen and

--- a/apps/docs/app/docs/releases/[version]/page.tsx
+++ b/apps/docs/app/docs/releases/[version]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { Markdown } from '@/components/docs/markdown'
-import { getRelease, getReleases } from '@/lib/releases'
+import { CHANNEL_LABELS, getRelease, getReleases } from '@/lib/releases'
 
 type ReleasePageProps = {
   params: Promise<{ version: string }>
@@ -54,7 +54,7 @@ export default async function ReleasePage({ params }: ReleasePageProps) {
             {release.version}
           </h1>
           <span className="rounded-full bg-violet-100 px-2.5 py-1 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-            {release.channel === 'alpha' ? 'Alpha' : 'Stable'}
+            {CHANNEL_LABELS[release.channel]}
           </span>
         </div>
         <p className="text-sm text-muted-foreground">

--- a/apps/docs/app/docs/releases/page.tsx
+++ b/apps/docs/app/docs/releases/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowUpRight } from 'lucide-react'
 import { Markdown } from '@/components/docs/markdown'
-import { getLatestRelease, getReleases } from '@/lib/releases'
+import { CHANNEL_LABELS, getLatestRelease, getReleases } from '@/lib/releases'
 
 export const metadata: Metadata = {
   title: 'Releases — XAUI Native',
@@ -20,7 +20,7 @@ export default function ReleasesPage() {
         <h1 className="text-3xl font-bold tracking-tight md:text-4xl">Releases</h1>
         <p className="max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
           The notes for <code>@xaui/native</code>, as the changesets wrote them at
-          publish time. These land on the <code>alpha</code> dist-tag;{' '}
+          publish time. These land on the <code>beta</code> dist-tag;{' '}
           <code>latest</code> still points at the previous line.
         </p>
       </header>
@@ -29,7 +29,7 @@ export default function ReleasesPage() {
         <div className="flex flex-wrap items-center gap-2">
           <h2 className="text-2xl font-bold tracking-tight">{latest.version}</h2>
           <span className="rounded-full bg-violet-100 px-2.5 py-1 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-            {latest.channel === 'alpha' ? 'Alpha' : 'Stable'}
+            {CHANNEL_LABELS[latest.channel]}
           </span>
           <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
             Latest

--- a/apps/docs/lib/data/components.ts
+++ b/apps/docs/lib/data/components.ts
@@ -22,14 +22,14 @@ export type Component = {
   markdownPath: string
   demoId: string
   exports: string[]
-  status: 'alpha'
+  status: 'beta'
 }
 
 export const components: Component[] = catalog.map(component => ({
   ...component,
   name: component.title,
   category: component.category as ComponentCategory,
-  status: 'alpha',
+  status: 'beta',
 }))
 
 export const categories = Array.from(

--- a/apps/docs/lib/releases.ts
+++ b/apps/docs/lib/releases.ts
@@ -1,12 +1,27 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+/** The npm dist-tag a version went out on, read back from the version string. */
+export type Channel = 'alpha' | 'beta' | 'stable'
+
+export const CHANNEL_LABELS: Record<Channel, string> = {
+  alpha: 'Alpha',
+  beta: 'Beta',
+  stable: 'Stable',
+}
+
 export type Release = {
   version: string
-  channel: 'alpha' | 'stable'
+  channel: Channel
   summary: string
   markdown: string
   href: string
+}
+
+function getChannel(version: string): Channel {
+  if (version.includes('-alpha')) return 'alpha'
+  if (version.includes('-beta')) return 'beta'
+  return 'stable'
 }
 
 /**
@@ -57,7 +72,7 @@ export function getReleases(): Release[] {
 
     return {
       version,
-      channel: version.includes('-alpha') ? 'alpha' : 'stable',
+      channel: getChannel(version),
       summary: getSummary(markdown),
       markdown,
       href: `/docs/releases/${version}`,

--- a/apps/docs/public/docs/changelog.md
+++ b/apps/docs/public/docs/changelog.md
@@ -1,5 +1,14 @@
 # @xaui/native
 
+## 0.9.1-alpha.94
+
+### Patch Changes
+
+- de3781b: Allow the built-in TimePicker and DateTimePicker indicators to render without custom icon props.
+- 22ea8e6: Remove `TimeField`. A time typed into a box is `MaskField` with `mask="time"`, which
+  carries the same mask engine behind one API instead of two, so the field had nothing of
+  its own left. `TimePicker` — the dial — is untouched.
+
 ## 0.9.1-alpha.93
 
 ### Patch Changes

--- a/apps/docs/public/skills/xaui/SKILL.md
+++ b/apps/docs/public/skills/xaui/SKILL.md
@@ -10,7 +10,7 @@ description: Write React Native UI with @xaui/native — composition-first compo
 ## Install
 
 ```bash
-pnpm add @xaui/native@alpha
+pnpm add @xaui/native@beta
 pnpm exec expo install react-native-reanimated react-native-worklets \
   react-native-gesture-handler react-native-svg react-native-safe-area-context
 ```

--- a/tooling/component-docs/generate.mjs
+++ b/tooling/component-docs/generate.mjs
@@ -417,7 +417,7 @@ const skill = [
   '## Install',
   '',
   '```bash',
-  'pnpm add @xaui/native@alpha',
+  'pnpm add @xaui/native@beta',
   'pnpm exec expo install react-native-reanimated react-native-worklets \\',
   '  react-native-gesture-handler react-native-svg react-native-safe-area-context',
   '```',


### PR DESCRIPTION
## What

`@xaui/native` and `@xaui/hybrid` move from the `alpha` pre-release line to the `beta` one, and every place the repository names that line follows.

- `.changeset/pre.json` — `tag` is now `beta`. Nothing else in that file changed.
- A `patch` changeset for both packages, so the next release lands `0.9.x-beta.x` on the `beta` dist-tag.
- **Docs site** — install commands (`pnpm add @xaui/native@beta`) on installation, getting started and migration; the introduction badge; the FAQ entry (`#alpha-tag` → `#beta-tag`); the releases page copy; the component-page status badge and `Component['status']`.
- `lib/releases.ts` — `channel` becomes `'alpha' | 'beta' | 'stable'` with a `CHANNEL_LABELS` map, so the 94 published `-alpha.x` releases keep reading "Alpha" in the history while new ones read "Beta".
- `tooling/component-docs/generate.mjs` — the install line in the generated agent skill, with `public/skills/xaui/SKILL.md` regenerated (and the pending `public/docs/changelog.md` sync that came with the run).
- **Instructions and specs** — `CLAUDE.md`, `AGENTS.md` §Release, the `xaui-flow` / `xaui-review` / `xaui-legacy-migration` skills in both `.agents/skills/` and `.claude/skills/`, and `XAUI-V1-PLAN.md` §Versions.

## Why

The v1 core and its documentation are in place, so `alpha` no longer describes the package honestly. `latest` is untouched — it still points at `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14` until `1.0.0`. The `alpha` dist-tag is left frozen on the last `0.9.1-alpha.x` publish: nothing republishes it, so existing `@xaui/native@alpha` installs keep resolving to a real version rather than breaking.

## How

The switch is a one-field edit of `tag` in `.changeset/pre.json`, deliberately **not** `changeset pre exit` + `changeset pre enter beta`. That pair resets `initialVersions` to the current `0.9.1-alpha.94` and empties the consumed-changesets list, and the next `changeset version` would replay all 113 entries into both changelogs. Editing the tag keeps both, and the pre-release counter simply carries on: the next publish is `0.9.1-beta.95`. AGENTS.md §Release now records that.

Historical statements stay historical — the ROADMAP rows for the alpha publishes, the old changeset files, and the phase table in `xaui-flow` still say what actually shipped.

## Gates

```
pnpm lint         ✓ 6/6 (1 pre-existing warning in apps/demo/app/segment.tsx)
pnpm type-check   ✓ 5/5
pnpm test         ✓ 8/8
pnpm format:check ✓
```

`apps/docs` builds clean — 94 release pages prerendered, the newest still `0.9.1-alpha.94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)