### PR TITLE
fix(docs): make native previews scrollable

### DIFF
--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -177,3 +177,4 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | D3  | `turbo.json` `test` outputs are wrong — every run warns                   | todo   |
 | D4  | `apps/docs/public/docs/` still documents the dropped legacy `view/` names | todo   |
 | D5  | `@xaui/native` types came from one dts worker that OOM'd — now `tsc`      | done   |
+| D6  | Constrain web preview screens so their React Native `ScrollView` scrolls  | done   |

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -139,7 +139,13 @@
 .native-preview-screen * {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  scrollbar-width: thin;
   text-rendering: geometricPrecision;
+}
+
+.native-preview-screen *::-webkit-scrollbar {
+  height: 4px;
+  width: 4px;
 }
 
 .native-preview-screen {

--- a/apps/docs/components/preview/native-preview-client.tsx
+++ b/apps/docs/components/preview/native-preview-client.tsx
@@ -102,8 +102,11 @@ export function NativePreviewClient({
             }
           >
             <div className="native-preview-screen" ref={screen}>
+              {/* GestureHandlerRootView's flex only bounds the demo when its HTML parent
+                  participates in flex layout. That bound is what makes ScrollView scroll. */}
               <div
                 style={{
+                  display: 'flex',
                   width: DEVICE.width,
                   height: DEVICE.height,
                   transform: `scale(${scale})`,

--- a/apps/docs/public/docs/changelog.md
+++ b/apps/docs/public/docs/changelog.md
@@ -1,5 +1,21 @@
 # @xaui/native
 
+## 0.9.1-beta.95
+
+### Patch Changes
+
+- 15b01ea: Move the pre-release line from `alpha` to `beta`.
+
+  `.changeset/pre.json` now carries the tag `beta`, so both packages are versioned
+  `0.9.x-beta.x` and every publish lands on the `beta` dist-tag: `pnpm add @xaui/native@beta`
+  is the opt-in from here on. The `alpha` dist-tag is frozen on the last `0.9.1-alpha.x`
+  publish and no longer moves, and `latest` is untouched — it still points at
+  `@xaui/native@0.2.8` and `@xaui/hybrid@0.0.14` until `1.0.0`.
+
+  Only the `tag` field changed. `initialVersions` and the list of consumed changesets are
+  kept as they were, which is what a `pre exit` + `pre enter beta` would have thrown away —
+  the next `changeset version` would then have replayed every entry into the changelogs.
+
 ## 0.9.1-alpha.94
 
 ### Patch Changes


### PR DESCRIPTION
## What

- Constrain the scaled native preview canvas so React Native Web ScrollViews own their overflow.
- Use a thin scrollbar in previews, with a 4px WebKit fallback.
- Synchronize the public beta release notes used by the site header and releases page.

## Why

The GestureHandler root expanded to the full demo content height, so ScrollViews had no constrained viewport and could not scroll. The generated public changelog also remained one release behind the native package.

## How

The HTML canvas now participates in flex layout, bounding the demo at the emulated device height. Browser verification measured an 844px viewport over 3938px of scrollable content and confirmed scrollTop changes with wheel input.

Validated with:
- pnpm lint
- pnpm type-check
- pnpm --filter docs test
- pnpm --filter docs build
- manual Chrome verification in light mode