### PR TITLE
chore: retire HeroUI and Flutter references

### DIFF
--- a/.agents/skills/xaui-component/SKILL.md
+++ b/.agents/skills/xaui-component/SKILL.md
@@ -290,7 +290,7 @@ decisions taken elsewhere in the same document or in CLAUDE.md. This skill wins:
 
 ## Pitfalls
 
-- Re-resolving the recipe inside a slot — that's HeroUI's model and it only works with a
+- Re-resolving the recipe inside a slot — that's the reference implementation's model and it only works with a
   class-cache engine. Resolve once at the root (R5).
 - Putting a token-dependent value in `.style.ts`. It belongs to the recipe.
 - Adding a prop instead of using `style`. R7 closes that door on purpose.

--- a/.agents/skills/xaui-system/SKILL.md
+++ b/.agents/skills/xaui-system/SKILL.md
@@ -11,7 +11,7 @@ if a helper becomes useful outside, it **moves** to `system/`, it is not re-expo
 `utils/`.
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §3 (style engine), §1 ter (what to take
-from HeroUI), §2 (folder layout), §9/P1 (acceptance criteria).
+from the reference implementation), §2 (folder layout), §9/P1 (acceptance criteria).
 
 ## `system/recipe/` — the style engine
 
@@ -90,7 +90,7 @@ different `color` adds **no entry** to the cache.
 ## `system/slot/`
 
 - `create-slot-context.ts` — strict context with a named error when a slot hook is used
-  outside its parent (`Error.captureStackTrace`, like HeroUI).
+  outside its parent (`Error.captureStackTrace`, like the reference implementation).
 - `children-to-string.ts` — recursive stringification (R3). **Do not inspect the first
   child**: try to stringify the whole tree; if it contains any React element, return
   `null` and pass children through; otherwise wrap the concatenated string in the default
@@ -131,7 +131,7 @@ Acceptance: the existing tests pass unmodified.
 
 ## `system/icon/`
 
-The gap HeroUI never closed: an icon is a third-party component, slot context doesn't reach
+The gap the reference implementation never closed: an icon is a third-party component, slot context doesn't reach
 it, so their users compute the colour by hand. XAUI's `Icon` reads the parent slot context
 for **size and colour**.
 

--- a/.changeset/accordion-v1.md
+++ b/.changeset/accordion-v1.md
@@ -4,12 +4,12 @@
 
 `Accordion` — Item · Trigger · Indicator · Content
 
-P5.11, over the legacy `ExpansionPanel`. HeroUI Native calls it `accordion` and so does
+P5.11, over the legacy `ExpansionPanel`. The reference implementation calls it `accordion` and so does
 this, which is also what the roadmap row now says.
 
 **The height is never measured.** The panel is mounted or it is not, and Reanimated's
 layout transition animates the row between the two — `LinearTransition.springify()` on
-HeroUI's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
+The reference implementation's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
 deliberately: a height is a longer distance than a rotation, and at the chevron's
 stiffness the same damping makes a long panel take almost half a second to settle.
 
@@ -22,7 +22,7 @@ still animating.
 **The variant table is the `Card`'s, token for token.** An accordion in `default` _is_ a
 card with rows in it, and two containers that look alike but are declared apart drift —
 the drift showing up as an accordion sitting on a card with a fill one step off it.
-`ghost` is the default and is HeroUI's own: rows separated by hairlines, on whatever page
+`ghost` is the default and is the reference implementation's own: rows separated by hairlines, on whatever page
 they sit on.
 
 **The separators are the root's, drawn between its children.** A row that drew its own

--- a/.changeset/alert-v1.md
+++ b/.changeset/alert-v1.md
@@ -8,11 +8,11 @@ A message the interface has to make sure is read. Compound root plus five slots:
 `Alert.Icon`, `Alert.Content`, `Alert.Title`, `Alert.Description` and `Alert.Close`, laid
 out as a row of three columns spaced by the root's `gap` alone.
 
-Nine variants: the `Card`'s `surface` for the neutral level — HeroUI's alert root, token
+Nine variants: the `Card`'s `surface` for the neutral level — the reference implementation's alert root, token
 for token, shadow included — and the `Chip`'s status ladder for the rest, each family in
 its full and soft slice.
 
-Visually aligned with `heroui-native`: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
+Visually aligned with the reference implementation: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
 title above a 14/20 description and an 18pt icon at `md`. The icon's optical offset is
 derived from the title's leading rather than hard-coded, so it stays right at all four
 sizes.

--- a/.changeset/avatar-v1.md
+++ b/.changeset/avatar-v1.md
@@ -8,27 +8,27 @@ The eleventh entry of the core. **The fallback is not a state, it is the layer u
 `Avatar.Image` is absolutely positioned over `Avatar.Fallback`, and an `Image` with nothing
 decoded yet draws nothing — so the initials show while the photo loads and **stay if the URL
 is wrong**, with no load-state machine, no `onError` to remember, and nothing to get out of
-sync. HeroUI runs a status enum for this; a stacking order says the same thing and cannot
+sync. The reference implementation runs a status enum for this; a stacking order says the same thing and cannot
 disagree with itself. JSX order between the two slots is therefore free.
 
 `variant` is the `Chip`'s eleven names, meaning here what they mean there — an avatar is a
 token _about_ a person or a thing, which is the category the `Chip` established. The three
 status families are present because an avatar reports as often as it identifies: a red frame
 for the account that failed to sync, a green one for the person who is online. It is
-HeroUI's `variant × color` matrix said once.
+The reference implementation's `variant × color` matrix said once.
 
 `size` sets both sides, because an avatar is a square before it is a circle — 32, 40, 48, 64,
-HeroUI's three steps plus the one our ladder adds below them. The glyph inside the fallback
+The reference implementation's three steps plus the one our ladder adds below them. The glyph inside the fallback
 runs ahead of the initials at the top of the scale, because two letters fill a circle that
 one person-icon has to sit inside with air around it.
 
-`radius` defaults to `full`, where HeroUI fixes one large radius for all three sizes — which
+`radius` defaults to `full`, where the reference implementation fixes one large radius for all three sizes — which
 makes their small avatars round and their large ones squircles.
 
 **No default glyph.** XAUI publishes no icon set, so the mark is always the caller's. What
 `Avatar.Fallback` does instead is publish the frame's resolved size and colour to
 `IconContext`, so an `Icon` written inside it needs no props at all.
 
-The photo fades in over 200ms on `onLoad` — HeroUI's timing — driven by a shared value
+The photo fades in over 200ms on `onLoad` — the reference implementation's timing — driven by a shared value
 rather than a mount animation, because the node has to be mounted from the first render or
 it never fetches. `animation={false}` skips it and mounts no worklet.

--- a/.changeset/bottom-sheet-v1.md
+++ b/.changeset/bottom-sheet-v1.md
@@ -5,7 +5,7 @@
 `BottomSheet` — Trigger · Overlay · Content · Handle · Title · Description · Close
 
 **Built on this library's own peers rather than on `@gorhom/bottom-sheet`**, which is what
-HeroUI wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
+The reference implementation wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
 value; taking a dependency for that would put a second animation library in every app that
 installs one component. What it costs is their snap points and their scroll integration —
 both worth having, and both worth their own change rather than a dependency.

--- a/.changeset/card.md
+++ b/.changeset/card.md
@@ -16,7 +16,7 @@ the radius and the type of the two text slots, and never a height: a card is as 
 what it holds. `isPressable` turns the surface into a `PressableFeedback` with a press
 wash, `accessibilityRole="button"` and the shared scale.
 
-The rendering is HeroUI's card measured — `md` is 16pt of padding, a 24pt radius, an
+The rendering is the reference implementation's card measured — `md` is 16pt of padding, a 24pt radius, an
 18/28 title in `medium` over a 16/24 description, no border on a filled surface — reached
 through our own vocabulary rather than through their utility classes, and with the gaps the
 component owns instead of leaving to the call site.
@@ -33,7 +33,7 @@ exported so a third party's layer is not a second-class citizen.
 The clip lives on the layer rather than on the root: `overflow: 'hidden'` cuts the node's
 own shadow on iOS, so clipping the card would cost a `default` one the elevation its variant
 just gave it. `radius` therefore moves both slots together — a corner that moved only the
-root would round the card and leave its photo square. HeroUI reaches the same feature
+root would round the card and leave its photo square. The reference implementation reaches the same feature
 through a `background` **prop** and clips on both nodes, losing the shadow.
 
 **The light `surfaceSecondary` moves up half a step**, `#f4f4f5` → `#ececee`. It sat so

--- a/.changeset/checkbox-v1.md
+++ b/.changeset/checkbox-v1.md
@@ -6,7 +6,7 @@ feat(checkbox): the v1 `Checkbox` — a box, a mark and the label that toggles i
 
 The eighth entry of the core. **The root is the row, not the box**: it is the pressable, so
 tapping the label ticks the checkbox — which is the whole reason `Checkbox.Label` is a slot
-here rather than a `Text` you put beside the component and wire up yourself. HeroUI needs a
+here rather than a `Text` you put beside the component and wire up yourself. The reference implementation needs a
 second component (`ControlField`) for that; the plan's slots for this one are Indicator ·
 Label, and this is why.
 
@@ -26,7 +26,7 @@ Three of the `Input`'s four levels, on the same `field*` tokens — `ghost` is a
 a box with no border and no fill is nothing at all — plus the four sizes, `radius`,
 `isInvalid` (which drops the resting fill and outranks the tint) and `isDisabled`.
 
-`isIndeterminate` is ours and not HeroUI's: the legacy checkbox had it, a "select all" is
+`isIndeterminate` is ours and not the reference implementation's: the legacy checkbox had it, a "select all" is
 what it is for, and `accessibilityState.checked: 'mixed'` is something only the component
 can say. A press resolves it to selected rather than toggling into it.
 

--- a/.changeset/chip-v1.md
+++ b/.changeset/chip-v1.md
@@ -8,11 +8,11 @@ A compact token — a status, a tag, a filter, a person. Compound root plus five
 `Chip.Label`, `Chip.Icon`, `Chip.Dot`, `Chip.Avatar` and `Chip.Close`, spaced by the root
 alone, so JSX order is screen order and there is no `startContent` / `endContent`.
 
-Eleven flat variants replace HeroUI's `variant × color` matrix: the `Button`'s five-step
+Eleven flat variants replace the reference implementation's `variant × color` matrix: the `Button`'s five-step
 emphasis ladder plus the three status families it deliberately refused — a chip reports an
 outcome, so `success`, `warning` and `danger` each land here with their soft slice.
 
-Visually aligned with `heroui-native`: 12pt of horizontal padding, a 14/20 label and a 28pt
+Visually aligned with the reference implementation: 12pt of horizontal padding, a 14/20 label and a 28pt
 `md`, with the height fixed rather than derived from vertical padding so a chip carrying an
 avatar still lines up with the one beside it.
 

--- a/.changeset/close-button-v1.md
+++ b/.changeset/close-button-v1.md
@@ -25,7 +25,7 @@ component that has one. `secondary` is the neutral disc and the default, for the
 decoration, and the disc is what makes it a target. `ghost` is the bare cross for a
 component already providing one.
 
-Four sizes on a 24 / 28 / 32 / 40 box, `md` being HeroUI's measured and the `Dialog`'s. The
+Four sizes on a 24 / 28 / 32 / 40 box, `md` being the reference implementation's measured and the `Dialog`'s. The
 bar is a ratio of the box rather than a table — a bar rotated a quarter turn spans
 `length / √2` per axis, so it is twice as long as the cross looks — which makes it one cross
 at four sizes instead of four drawings of one. **The stroke does not scale**: it is the

--- a/.changeset/dialog-close-cross.md
+++ b/.changeset/dialog-close-cross.md
@@ -2,10 +2,10 @@
 '@xaui/native': patch
 ---
 
-`Dialog.Close` draws a cross when it is empty, like HeroUI's.
+`Dialog.Close` draws a cross when it is empty, like the reference implementation's.
 
 It was a bare pressable that rendered whatever it was given and nothing when it was given
-nothing, so `<Dialog.Close />` — the first line of HeroUI's own anatomy — put an invisible
+nothing, so `<Dialog.Close />` — the first line of the reference implementation's own anatomy — put an invisible
 32 points in the corner. It now reads `system/close-button`, which draws the cross from two
 rotated bars, and the dialog's recipe resolves the box and the bar the way `Chip.Close`
 already did.

--- a/.changeset/dialog-v1.md
+++ b/.changeset/dialog-v1.md
@@ -27,5 +27,5 @@ reaches the overlay under it and closes the dialog.
 No `variant`: the question a dialog asks is in its words, not in its fill.
 
 It also unblocks the `presentation` prop that `Select.Content` and `Menu.Content` are
-written around but cannot offer — HeroUI has both, and `dialog` was half of what was
+written around but cannot offer — the reference implementation has both, and `dialog` was half of what was
 missing.

--- a/.changeset/divider-v1.md
+++ b/.changeset/divider-v1.md
@@ -32,6 +32,6 @@ lines and two, instead of eight.
 `Animated.View` that collapses a section takes the thickness and the ink from the recipe and
 the height from a shared value.
 
-`size` is the thickness — `xs` is HeroUI's `thin`, one device pixel, and `lg` is their
+`size` is the thickness — `xs` is the reference implementation's `thin`, one device pixel, and `lg` is their
 `thick`, six points. **It defaults to `xs`**, the one place in the library that does not
 default to `md`: a rule you notice is a rule that is too thick.

--- a/.changeset/field-radius-align.md
+++ b/.changeset/field-radius-align.md
@@ -2,11 +2,11 @@
 '@xaui/native': patch
 ---
 
-The `field` radius aligns on HeroUI's — 21 points becomes 12
+The `field` radius aligns on the reference implementation's — 21 points becomes 12
 
 `buildRadius` derived it as `base * 1.75`, which on the default base of 12 put a 48-tall
 field at 21 — 87% of its geometric maximum, so it read as a gélule rather than as a rounded
-box. HeroUI reaches 12 for the same control from the other side of the scale: their
+box. The reference implementation reaches 12 for the same control from the other side of the scale: their
 `--radius-field` is an alias of their `--radius-xl`, and their base is 8 where ours is 12.
 
 It coincides with `lg` at the default base and stays its own key, because that is what lets

--- a/.changeset/input-group.md
+++ b/.changeset/input-group.md
@@ -23,7 +23,7 @@ underneath, and the content leaves the accessibility tree. It is off by default,
 suffix is most often a control and one that swallowed its own taps would be a reveal toggle
 you cannot press. A disabled `Input` takes the touches from both decorators all the same.
 
-`InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one HeroUI's
+`InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one the reference implementation's
 component does not: a glyph one step above the field's type, in the theme's
 `fieldPlaceholder`, so a form does not carry a hard-coded `#888` on every field.
 

--- a/.changeset/input-otp-v1.md
+++ b/.changeset/input-otp-v1.md
@@ -30,7 +30,7 @@ Three corrections after seeing it on a device.
 **The box takes the `lg` radius, 12 points, not `field`.** A field is wide, so 21 on a
 48-tall one reads as a rounded rectangle; a code box is very nearly square — 44 by 48 at
 `md`, 36 by 40 at `sm` — where the geometric maximum is 22, so the same 21 is a pill in all
-but name and is clamped to one outright at the small end. Twelve is where HeroUI lands for
+but name and is clamped to one outright at the small end. Twelve is where the reference implementation lands for
 the same box from the other direction: their `field` radius is their `xl`, and their scale's
 base is 8 where ours is 12.
 

--- a/.changeset/input-textarea.md
+++ b/.changeset/input-textarea.md
@@ -10,7 +10,7 @@ recipe, the same resolved context, the same four variants, the same `size`, `rad
 and `.Error` are literally the `Input`'s slots, re-exported rather than wrapped.
 
 Only `TextArea.Field` differs, by three things: `multiline`, the text pinned to the top, and
-a height counted in lines. That is HeroUI's answer too — their `TextArea` is twenty lines
+a height counted in lines. That is the reference implementation's answer too — their `TextArea` is twenty lines
 rendering their `Input` with the same three defaults.
 
 `rows` (default `3`) and `maxRows` are **raw values** (R6), like `color`: they resolve

--- a/.changeset/input-v1.md
+++ b/.changeset/input-v1.md
@@ -12,7 +12,7 @@ makes the three lines slots of one component rather than three components a form
 keep in step — and why `TextInputProps` are on the field rather than on the root.
 
 The first real use of the theme's `field*` family, derived in P0 and unread since. Four
-variants, the library's emphasis levels narrowed like the `Card`'s, splitting HeroUI's
+variants, the library's emphasis levels narrowed like the `Card`'s, splitting the reference implementation's
 two-name `primary | secondary` by saying what each of their ends already is: `primary` is
 their field fill plus the theme's `field` shadow, `secondary` their neutral fill and the
 default here, `tertiary` the border alone, `ghost` neither.
@@ -24,7 +24,7 @@ accent. `isInvalid` outranks it, so a field that is both reads as wrong rather t
 against the box's own padding, so the JSX is identical either way and nothing is
 reparented; the field pays for the room and the box grows by the same amount.
 
-Visually aligned with `heroui-native`: a 48pt minimum, 12pt of horizontal padding, a 16/24
+Visually aligned with the reference implementation: a 48pt minimum, 12pt of horizontal padding, a 16/24
 label above the field and a 14/20 line below it at `md`. The height is a **minimum** rather
 than fixed — the one place this component departs from the `Button`'s rule, because a
 `multiline` field holds the user's own text and has to grow.

--- a/.changeset/khaki-lions-argue.md
+++ b/.changeset/khaki-lions-argue.md
@@ -4,7 +4,7 @@
 
 `Typography` and `TextSpan` — the first entry of the v1 core
 
-Ten roles, aligned with HeroUI Native's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
+Ten roles, aligned with the reference implementation's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
 `code`. Each role fixes size, line height, weight and family **together**, which is why
 there is no `size` prop and no `weight` prop — the combinations they allowed (a heading in
 a light weight, a caption in a display size) become unwritable rather than discouraged.

--- a/.changeset/list-group-v1.md
+++ b/.changeset/list-group-v1.md
@@ -31,6 +31,6 @@ unset prop can still reach the group's.
 Nothing is walked and nothing is counted: the group publishes two gaps and a type scale, the
 sections are ordinary children, and one can be built out of something that is not a list.
 
-For the record, since the name is theirs: HeroUI's `ListGroup` **is our `List`** — a Surface
+For the record, since the name is theirs: The reference implementation's `ListGroup` **is our `List`** — a Surface
 container with Item · ItemPrefix · ItemContent · ItemTitle · ItemDescription · ItemSuffix,
 slot for slot. What ships here under that name is the thing neither of us had.

--- a/.changeset/list-v1.md
+++ b/.changeset/list-v1.md
@@ -5,7 +5,7 @@
 `List` — rows on a ground.
 
 `List.Item` and `List.ItemButton` with `ItemPrefix`, `ItemContent`, `ItemTitle`,
-`ItemDescription` and `ItemSuffix`, on the anatomy `heroui-native`'s `ListGroup` uses.
+`ItemDescription` and `ItemSuffix`, on the anatomy the reference implementation's `ListGroup` uses.
 
 **It is the `Accordion` with rows that do not open**, and it reads the same ladder, insets
 its separators the same way and lifts the same one variant. Two containers that look alike
@@ -26,7 +26,7 @@ quieter menu with none of the affordances. A row that toggles carries the contro
 toggles it — a `Switch` in its suffix — which says out loud what it does and is reachable as
 the control it actually is.
 
-**`ItemSuffix` draws nothing of its own.** HeroUI's puts a chevron there by default; the
+**`ItemSuffix` draws nothing of its own.** The reference implementation's puts a chevron there by default; the
 trailing end of a settings row is a switch at least as often, and a slot that guesses makes
 you pass a child in order to render nothing.
 

--- a/.changeset/menu-v1.md
+++ b/.changeset/menu-v1.md
@@ -47,7 +47,7 @@ text in it.
 
 `flex: 1` is `flexBasis: 0`. The measuring pass asks the panel how wide it wants to be, so
 there is no definite width for a zero basis to grow into: the row's content size is nothing,
-the title collapses, and the panel holds that width. HeroUI writes `flex: 1` on the same
+the title collapses, and the panel holds that width. The reference implementation writes `flex: 1` on the same
 node and gets away with it because their measuring pass hands the panel a definite width —
 ours asks a question a zero basis cannot answer.
 
@@ -59,5 +59,5 @@ now says so where anyone writing the next anchored panel will read it.
 thirteen: a menu row is a title with an indicator beside it and sometimes a sentence under
 it, where a popover is prose alone.
 
-`SubMenu` is not here. HeroUI ships it as its own component and it needs a second anchored
+`SubMenu` is not here. The reference implementation ships it as its own component and it needs a second anchored
 panel whose trigger is a row of the first, which is worth its own change.

--- a/.changeset/popover-v1.md
+++ b/.changeset/popover-v1.md
@@ -63,7 +63,7 @@ full-width panel the moment it holds a sentence, and a popover is an aside rathe
 sheet. Thirteen ems of the body size, about twenty-six characters a line — narrow on
 purpose. A popover is read at a glance, and a glance is two or three short lines rather
 than a paragraph; past that it stops being an aside and starts being a sheet with a tail.
-It is where HeroUI's own panels land too, measured off their placement demos. A multiple of
+It is where the reference implementation's own panels land too, measured off their placement demos. A multiple of
 the type rather than a number of points, so a theme that scales its type scales the panel
 with it.
 
@@ -74,7 +74,7 @@ The main axis was in the first half and not the second, so a panel beside a trig
 room for it went off the screen entirely — `start` and `end` were unusable and nothing said
 so until one was opened.
 
-The panel may now overlap its own trigger. That is the right trade, and the one HeroUI's
+The panel may now overlap its own trigger. That is the right trade, and the one the reference implementation's
 `useRelativePosition` makes too: a panel covering the button that opened it is legible, and
 a panel past the edge of the screen is not.
 

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -37,7 +37,7 @@
     "eager-marks-float",
     "eighty-rails-run",
     "field-decorator-android-z",
-    "field-radius-heroui",
+    "field-radius-align",
     "fresh-clocks-smile",
     "fresh-fabs-focus",
     "friendly-phone-countries",

--- a/.changeset/press-feedback-values.md
+++ b/.changeset/press-feedback-values.md
@@ -3,7 +3,7 @@
 ---
 
 Fix the press scale, which lurched on wide controls, and align the touch feedback with
-HeroUI's values.
+The reference implementation's values.
 
 **The scale was a flat `0.975` for every control.** What the eye reads is the displacement,
 not the ratio: that same ratio moves a 360pt row nine points and a 96pt chip two. It is now

--- a/.changeset/retire-reference-attribution.md
+++ b/.changeset/retire-reference-attribution.md
@@ -1,0 +1,9 @@
+---
+'@xaui/native': patch
+---
+
+Reword the third-party library attribution in doc comments and component docs
+
+Every design note that named the upstream library it was measured against now says
+"the reference implementation" instead. No API, token, value or behaviour changes —
+only the prose in JSDoc, component `.md` pages and generated docs.

--- a/.changeset/select-v1.md
+++ b/.changeset/select-v1.md
@@ -9,7 +9,7 @@ Its trigger is the `TextField`'s twin — the same `field*` tokens, the same fou
 the same heights — so a select and a text input in one form read as one control rather
 than as two libraries meeting.
 
-The visual values and the motion are HeroUI Native's, not the legacy component's. The
+The visual values and the motion are the reference implementation's, not the legacy component's. The
 chevron turns 0 to −180° on their spring (damping 140, stiffness 1000, mass 4): heavily
 damped against a very high stiffness, so it arrives in a fifth of a second without
 overshooting, because an oscillating chevron reads as a bug rather than as motion. The
@@ -39,11 +39,11 @@ rather than rendering.
 chevron and the gap between them, and at that height the value gets nothing. The
 `TextField` keeps its `xs` because a field only has to hold text.
 
-The panel's corner is `2xl`, not `3xl`. HeroUI's is their `--radius-3xl` on a base of 8,
+The panel's corner is `2xl`, not `3xl`. The reference implementation's is their `--radius-3xl` on a base of 8,
 which is 24 points; our base is 12, so the same 24 is `2xl`. Reading their key rather than
 their number put a 36-point corner on it and made it read as a pill.
 
-Two narrowings against HeroUI, both deliberate. `placement` is `top` or `bottom` only: a
+Two narrowings against the reference implementation, both deliberate. `placement` is `top` or `bottom` only: a
 list as wide as its own field hanging off the side of it reads as a menu, and `start` and
 `end` belong to `Popover`. And there is no `presentation` prop — the bottom-sheet and
 dialog presentations need `BottomSheet` and `Dialog`, which do not exist yet.

--- a/.changeset/skeleton-v1.md
+++ b/.changeset/skeleton-v1.md
@@ -21,11 +21,11 @@ families and no `primary`**, because a skeleton reports nothing and a placeholde
 accent announces the brand where there is nothing yet to announce; **no `tertiary` and no
 `ghost`**, because a skeleton with a border and no fill is an empty box.
 
-HeroUI reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
+The reference implementation reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
 lets a theme move the skeleton by moving `default`, rather than by discovering that a
 percentage of a text colour is where the placeholder grey came from.
 
-**No shimmer**, where HeroUI's default is one: a shimmer is a gradient sweeping across the
+**No shimmer**, where the reference implementation's default is one: a shimmer is a gradient sweeping across the
 block, a gradient needs `react-native-svg`, and that is an optional peer a component in the
 core cannot require. One animation, so `animation` is a boolean rather than a name to
 choose between — the block breathes between full opacity and a half, a second each way.

--- a/.changeset/slider-v1.md
+++ b/.changeset/slider-v1.md
@@ -37,7 +37,7 @@ four points thick is a line rather than a control.
 
 ### A rail with a knob on it, not a capsule with a core
 
-The legacy proportions rather than HeroUI's: 6 to 10 points of rail under a 16 to 24 point
+The legacy proportions rather than the reference implementation's: 6 to 10 points of rail under a 16 to 24 point
 disc. The knob overhangs the rail by half their difference on each side, and the rail
 reserves that overhang as a margin — without it the knob spills into whatever sits above
 and below, and the layout has no idea the control is thicker than its rail.

--- a/.changeset/spinner-v1.md
+++ b/.changeset/spinner-v1.md
@@ -17,13 +17,13 @@ resolves to `accentForeground` — white. A spinner has no surface, so `primary`
 named: deleting is a `danger` wait. **No `ghost`**, because a spinner with no ink is not a
 spinner, and **no `-soft` slices**, because a soft slice is a fill softened.
 
-HeroUI fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
+The reference implementation fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
 therefore `react-native-svg` — an **optional peer**, which a component in the
 fifteen-component core cannot require. Two circles of one ink at two opacities read as the
 same figure, cost two views, and pull in nothing. The track is what does the work: a
 rotating three-quarter ring on its own reads as broken rather than as busy.
 
-`size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, HeroUI's
+`size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, the reference implementation's
 three steps plus the one our ladder adds between the first two. The stroke thickens once,
 at `lg`.
 

--- a/.changeset/toast-collapsed-stack.md
+++ b/.changeset/toast-collapsed-stack.md
@@ -2,10 +2,10 @@
 '@xaui/native': patch
 ---
 
-The toast stack collapses, like HeroUI's.
+The toast stack collapses, like the reference implementation's.
 
 It was a flex column with a gap: every card fully visible, one under the next, so six
-toasts took six card heights down the screen. HeroUI's is a pile — one card in front, the
+toasts took six card heights down the screen. The reference implementation's is a pile — one card in front, the
 rest scaled down and pushed toward the edge behind it, only their shoulders showing.
 
 Every card is now anchored to the same edge and its depth is entirely in its transform:

--- a/.changeset/toast-swipe.md
+++ b/.changeset/toast-swipe.md
@@ -2,7 +2,7 @@
 '@xaui/native': patch
 ---
 
-The front toast can be thrown away with a swipe, like HeroUI's.
+The front toast can be thrown away with a swipe, like the reference implementation's.
 
 Away from its edge — up on a top stack, down on a bottom one — past 50 points or 500 points
 a second, their thresholds, either alone being enough. Dragged the wrong way it resists
@@ -14,7 +14,7 @@ Only the front card. The ones behind show a seven-point shoulder, which is a tar
 any reasonable minimum, and dragging the second card out from under the first reads as a
 glitch rather than as a dismissal. `isSwipeable={false}` on the host turns it off.
 
-Note that this dismisses **one** card and the pile empties a swipe at a time — HeroUI's
+Note that this dismisses **one** card and the pile empties a swipe at a time — the reference implementation's
 gesture calls `hide(id)`, not a clear-all, and their provider has no such thing.
 
 The gesture runs on `react-native-gesture-handler`, already an optional peer, reached only

--- a/.changeset/toast-v1.md
+++ b/.changeset/toast-v1.md
@@ -33,4 +33,4 @@ is a setup mistake in the app shell, and a screen that crashes on its way to rep
 a save succeeded has turned a good outcome into a bad one.
 
 It closes P5.18 as well as P5.18b: `Snackbar` and `Toast` are the same object under two
-names, and HeroUI calls it `toast`.
+names, and the reference implementation calls it `toast`.

--- a/.claude/skills/xaui-component/SKILL.md
+++ b/.claude/skills/xaui-component/SKILL.md
@@ -290,7 +290,7 @@ decisions taken elsewhere in the same document or in CLAUDE.md. This skill wins:
 
 ## Pitfalls
 
-- Re-resolving the recipe inside a slot — that's HeroUI's model and it only works with a
+- Re-resolving the recipe inside a slot — that's the reference implementation's model and it only works with a
   class-cache engine. Resolve once at the root (R5).
 - Putting a token-dependent value in `.style.ts`. It belongs to the recipe.
 - Adding a prop instead of using `style`. R7 closes that door on purpose.

--- a/.claude/skills/xaui-system/SKILL.md
+++ b/.claude/skills/xaui-system/SKILL.md
@@ -11,7 +11,7 @@ if a helper becomes useful outside, it **moves** to `system/`, it is not re-expo
 `utils/`.
 
 Source of truth: `.project-specs/XAUI-V1-PLAN.md` §3 (style engine), §1 ter (what to take
-from HeroUI), §2 (folder layout), §9/P1 (acceptance criteria).
+from the reference implementation), §2 (folder layout), §9/P1 (acceptance criteria).
 
 ## `system/recipe/` — the style engine
 
@@ -90,7 +90,7 @@ different `color` adds **no entry** to the cache.
 ## `system/slot/`
 
 - `create-slot-context.ts` — strict context with a named error when a slot hook is used
-  outside its parent (`Error.captureStackTrace`, like HeroUI).
+  outside its parent (`Error.captureStackTrace`, like the reference implementation).
 - `children-to-string.ts` — recursive stringification (R3). **Do not inspect the first
   child**: try to stringify the whole tree; if it contains any React element, return
   `null` and pass children through; otherwise wrap the concatenated string in the default
@@ -131,7 +131,7 @@ Acceptance: the existing tests pass unmodified.
 
 ## `system/icon/`
 
-The gap HeroUI never closed: an icon is a third-party component, slot context doesn't reach
+The gap the reference implementation never closed: an icon is a third-party component, slot context doesn't reach
 it, so their users compute the colour by hand. XAUI's `Icon` reads the parent slot context
 for **size and colour**.
 

--- a/.project-specs/P2-API-REVIEW.md
+++ b/.project-specs/P2-API-REVIEW.md
@@ -137,7 +137,7 @@ limite assumée du fait d'envelopper un composant tiers.
 ### D. Le ripple — **corrigé**
 
 `feedbackVariant="scale-ripple"` ne dessinait rien. La cause était structurelle et se lit
-directement dans la source de HeroUI : **les handlers de toucher ne sont pas sur le
+directement dans la source de l'implémentation de référence : **les handlers de toucher ne sont pas sur le
 `Pressable`, ils sont sur la `View` du ripple lui-même.**
 
 `Pressable` porte le système de responder — il décide si un toucher devient un appui — et

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -13,113 +13,113 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 
 ## Phases
 
-| Ref    | Task                                                                             | Status  |
-| ------ | -------------------------------------------------------------------------------- | ------- |
-| P0.1   | Split into `@xaui/native-legacy` and scaffold v1                                 | done    |
-| P0.2   | Single token source and generator                                                | done    |
-| P0.3   | OKLab colour engine                                                              | done    |
-| P0.4   | Derived colour layer                                                             | done    |
-| P0.5   | Contrast guard in CI                                                             | done    |
-| P0.6   | `createTheme`                                                                    | done    |
-| P0.7   | `XAUIProvider`                                                                   | done    |
-| P0.7b  | `useAppearance` — the theme read as app chrome, with no navigator dependency     | done    |
-| P0.8   | Legacy `core-shim.ts`                                                            | done    |
-| P0.9   | Package hygiene and optional peers                                               | done    |
-| P0.10  | ESLint rule for R13                                                              | done    |
-| P0.11  | Publish `@xaui/native-legacy@0.2.11` and the codemod                             | done    |
-| P0.12  | Delete `@xaui/core` and `@xaui/icons`                                            | done    |
-| P0.13  | Publish `native` and `hybrid` on the `alpha` tag                                 | done    |
-| P1.1   | `system/recipe/` — engine, cache, tint                                           | done    |
-| P1.2   | `system/slot/` — context, `childrenToString`, merges                             | done    |
-| P1.3   | `system/pressable-feedback/`                                                     | done    |
-| P1.4   | `system/portal/`                                                                 | done    |
-| P1.5   | `system/icon/`                                                                   | done    |
-| P1.6   | Shared hooks                                                                     | done    |
-| P1.7   | `pnpm pack` uniqueness check on both packages                                    | done    |
-| P2     | The reference component and the API review                                       | done    |
-| P2.1   | The reference `Button`                                                           | done    |
-| P2.2   | Perf baseline — 200 buttons, re-renders and allocations                          | done    |
-| P2.3   | API review — blocking, nothing starts in P3 before it                            | done    |
-| P2.4   | Publish `@xaui/native` on the pre-release tag                                    | ci      |
-| P2.5   | Fix the ripple — it renders nothing (P2-API-REVIEW §D)                           | done    |
-| P2.5b  | `PressableFeedback` composes its overlays — no `feedbackVariant`                 | done    |
-| P2.6   | Style as props (R14) — `system/style-props/`, then the `Button`                  | done    |
-| P2.7   | `*Pressed` moves one way — towards the mode ink (P2-API-REVIEW §E)               | done    |
-| P2.7b  | `asChild` reached `Slot` as an array — every pressable threw                     | done    |
-| P2.7c  | Light `default` reads as grey, not as near-white                                 | done    |
-| P2.7d  | `warning` moves from `amber` to `orange` — the dark one read as gold             | done    |
-| P3     | The fifteen-component core                                                       | done    |
-| P3.1   | `Typography` + `TextSpan` — ten roles, HeroUI's values                           | done    |
-| P3.2   | `Icon` — R14's boundary in the type, plus its demo screen                        | done    |
-| P3.3   | `view/` — `Row`, `Column`, `Stack`, `Grid`; the rest dropped                     | done    |
-| P3.4   | `Card` — Header · Body · Title · Description · Footer                            | done    |
-| P3.5   | `Chip` — Label · Icon · Dot · Avatar · Close                                     | done    |
-| P3.6   | `Alert` — Icon · Content · Title · Description · Close                           | done    |
-| P3.7   | `Input` — Label · Field · Description · Error                                    | done    |
-| P3.7b  | Rename `Input` → `TextField` — component, `./text-field` subpath, demo           | done    |
-| P3.8   | `Checkbox` — Indicator · Label                                                   | done    |
-| P3.9   | `Radio` — Indicator · Label, the `Checkbox` in a circle                          | done    |
-| P3.10  | `Switch` — Track · Thumb · Label, two shapes                                     | done    |
-| P3.11  | `Avatar` — Image · Fallback · Initials, the fallback as a layer                  | done    |
-| P3.12  | `Badge` — a count, a dot, and the corner it hangs off                            | done    |
-| P3.13  | `Divider` — three separator levels; keeps its name, not HeroUI's `Separator`     | done    |
-| P3.14  | `Skeleton` — one fill, one pulse, sized by R14 alone                             | done    |
-| P3.14b | `Skeleton` drops its `variant` — the second fill was the less visible            | done    |
-| P3.15  | `Spinner` — seven inks, two rings, no SVG; supersedes legacy `Indicator`         | done    |
-| P4     | Docs, generated tables, `1.0.0`                                                  | todo    |
-| P4.1   | Live previews — alias `react-native` → `react-native-web` in Next.js             | done    |
-| P4.2   | Prop tables generated from the TS types                                          | done    |
-| P4.3   | Component pages, on the structure of plan §6                                     | done    |
-| P4.4   | Migration guide legacy → v1, with the table of plan §7                           | done    |
-| P4.5   | Regenerate `llms.txt`                                                            | done    |
-| P4.5b  | Unpublish `@xaui/mcp` and `@xaui/icons`                                          | todo    |
-| P4.6   | Publish `@xaui/native@1.0.0` — needs `changeset pre exit` first                  | todo    |
-| P5     | The remaining components, shipped under `1.x`                                    | todo    |
-| P5.1   | `InputOTP` — Group · Box · Value · Placeholder · Caret · Separator               | done    |
-| P5.2   | `TextArea` — Label · Field · Description · Error, over the `Input`               | done    |
-| P5.3   | `InputGroup` — Prefix · Field · Suffix · Icon, inside the `Input`                | done    |
-| P5.3b  | Rename `InputGroup` → `FieldGroup`, following `TextField`                        | done    |
-| P5.3c  | `NumberField` — over legacy `NumberInput`, following `TextField`                 | done    |
-| P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share             | done    |
-| P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not            | done    |
-| P5.3f  | `PhoneNumberField` — country prefix, searchable sheet and national number        | done    |
-| P5.3g  | `SearchField` — net new, a `TextField` with its mark, its clear and its search   | done    |
-| P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                | done    |
-| P5.5   | `Stepper` — slots over the existing group context                                | done    |
-| P5.6   | `Toolbar` — slots over the existing group context                                | dropped |
-| P5.7   | `ListBox` — slots over the existing group context                                | done    |
-| P5.7b  | `ListBoxGroup` — net new, sectioned `ListBox` with its headers                   | done    |
-| P5.7c  | `List` — virtualized rows over React Native `FlatList`                           | done    |
-| P5.8   | `Menu` — Trigger · Overlay · Content · Label · Group · Item                      | done    |
-| P5.9   | `SegmentButton` — slots over the existing group context                          | done    |
-| P5.10  | `Autocomplete` — slots over the existing group context                           | done    |
-| P5.10b | `Combobox` — the `Autocomplete` over a closed list                               | done    |
-| P5.11  | `Accordion` — Item · Trigger · Indicator · Content, over legacy `ExpansionPanel` | done    |
-| P5.12  | `BottomTabBar` — slots over the existing group context                           | dropped |
-| P5.13  | `Menubox` — slots over the existing group context                                | dropped |
-| P5.14  | `ProgressCircle` — circular, the determinate half of legacy `Indicator`          | done    |
-| P5.14b | `ProgressBar` — linear, over legacy `LinearProgressIndicator`                    | done    |
-| P5.15  | `Slider` — Output · Track · Fill · Thumb                                         | done    |
-| P5.16  | `Tabs` — List · Trigger · Label · Indicator · Content                            | done    |
-| P5.17  | `AppBar`                                                                         | dropped |
-| P5.18  | `Snackbar` — v1 transient notification over the shared toast queue               | done    |
-| P5.18b | `Toast` — Title · Description · Actions · Close, plus `ToastHost`                | done    |
-| P5.19  | `Snippet`                                                                        | dropped |
-| P5.20  | `Fab` — round or extended, the Button's table on a floating box                  | done    |
-| P5.21  | `FabMenu` — the FAB's actions as pills, anchored so the FAB never moves          | done    |
-| P5.22  | `Dialog` — Trigger · Overlay · Content · Title · Description · Close             | done    |
-| P5.23  | `BottomSheet` — Trigger · Overlay · Content · Handle · Title                     | done    |
-| P5.23b | `BottomSheetInput` — net new, a `TextField` that opens in a `BottomSheet`        | dropped |
-| P5.23c | `BottomSheet` reduced state — `collapsedHeight`, a two-state disclosure          | done    |
-| P5.24  | `Drawer`                                                                         | dropped |
-| P5.24b | `Popover` — Trigger · Overlay · Content · Title · Description · Close            | done    |
-| P5.25  | `Picker`                                                                         | dropped |
-| P5.25b | `WheelPicker` — net new, the spinning column the three below share               | done    |
-| P5.25c | `WheelDatePicker` — net new, `WheelPicker` columns for a date                    | dropped |
-| P5.25d | `WheelTimePicker` — net new, `WheelPicker` columns for a time                    | dropped |
-| P5.25e | `WheelDateTimePicker` — net new, the two above as one                            | dropped |
-| P5.26  | `DatePicker` — Trigger · Value · Indicator · Overlay · Content · Calendar        | done    |
-| P5.26b | `Calendar` — net new, no legacy equivalent                                       | done    |
+| Ref    | Task                                                                                               | Status  |
+| ------ | -------------------------------------------------------------------------------------------------- | ------- |
+| P0.1   | Split into `@xaui/native-legacy` and scaffold v1                                                   | done    |
+| P0.2   | Single token source and generator                                                                  | done    |
+| P0.3   | OKLab colour engine                                                                                | done    |
+| P0.4   | Derived colour layer                                                                               | done    |
+| P0.5   | Contrast guard in CI                                                                               | done    |
+| P0.6   | `createTheme`                                                                                      | done    |
+| P0.7   | `XAUIProvider`                                                                                     | done    |
+| P0.7b  | `useAppearance` — the theme read as app chrome, with no navigator dependency                       | done    |
+| P0.8   | Legacy `core-shim.ts`                                                                              | done    |
+| P0.9   | Package hygiene and optional peers                                                                 | done    |
+| P0.10  | ESLint rule for R13                                                                                | done    |
+| P0.11  | Publish `@xaui/native-legacy@0.2.11` and the codemod                                               | done    |
+| P0.12  | Delete `@xaui/core` and `@xaui/icons`                                                              | done    |
+| P0.13  | Publish `native` and `hybrid` on the `alpha` tag                                                   | done    |
+| P1.1   | `system/recipe/` — engine, cache, tint                                                             | done    |
+| P1.2   | `system/slot/` — context, `childrenToString`, merges                                               | done    |
+| P1.3   | `system/pressable-feedback/`                                                                       | done    |
+| P1.4   | `system/portal/`                                                                                   | done    |
+| P1.5   | `system/icon/`                                                                                     | done    |
+| P1.6   | Shared hooks                                                                                       | done    |
+| P1.7   | `pnpm pack` uniqueness check on both packages                                                      | done    |
+| P2     | The reference component and the API review                                                         | done    |
+| P2.1   | The reference `Button`                                                                             | done    |
+| P2.2   | Perf baseline — 200 buttons, re-renders and allocations                                            | done    |
+| P2.3   | API review — blocking, nothing starts in P3 before it                                              | done    |
+| P2.4   | Publish `@xaui/native` on the pre-release tag                                                      | ci      |
+| P2.5   | Fix the ripple — it renders nothing (P2-API-REVIEW §D)                                             | done    |
+| P2.5b  | `PressableFeedback` composes its overlays — no `feedbackVariant`                                   | done    |
+| P2.6   | Style as props (R14) — `system/style-props/`, then the `Button`                                    | done    |
+| P2.7   | `*Pressed` moves one way — towards the mode ink (P2-API-REVIEW §E)                                 | done    |
+| P2.7b  | `asChild` reached `Slot` as an array — every pressable threw                                       | done    |
+| P2.7c  | Light `default` reads as grey, not as near-white                                                   | done    |
+| P2.7d  | `warning` moves from `amber` to `orange` — the dark one read as gold                               | done    |
+| P3     | The fifteen-component core                                                                         | done    |
+| P3.1   | `Typography` + `TextSpan` — ten roles, the reference implementation's values                       | done    |
+| P3.2   | `Icon` — R14's boundary in the type, plus its demo screen                                          | done    |
+| P3.3   | `view/` — `Row`, `Column`, `Stack`, `Grid`; the rest dropped                                       | done    |
+| P3.4   | `Card` — Header · Body · Title · Description · Footer                                              | done    |
+| P3.5   | `Chip` — Label · Icon · Dot · Avatar · Close                                                       | done    |
+| P3.6   | `Alert` — Icon · Content · Title · Description · Close                                             | done    |
+| P3.7   | `Input` — Label · Field · Description · Error                                                      | done    |
+| P3.7b  | Rename `Input` → `TextField` — component, `./text-field` subpath, demo                             | done    |
+| P3.8   | `Checkbox` — Indicator · Label                                                                     | done    |
+| P3.9   | `Radio` — Indicator · Label, the `Checkbox` in a circle                                            | done    |
+| P3.10  | `Switch` — Track · Thumb · Label, two shapes                                                       | done    |
+| P3.11  | `Avatar` — Image · Fallback · Initials, the fallback as a layer                                    | done    |
+| P3.12  | `Badge` — a count, a dot, and the corner it hangs off                                              | done    |
+| P3.13  | `Divider` — three separator levels; keeps its name, not the reference implementation's `Separator` | done    |
+| P3.14  | `Skeleton` — one fill, one pulse, sized by R14 alone                                               | done    |
+| P3.14b | `Skeleton` drops its `variant` — the second fill was the less visible                              | done    |
+| P3.15  | `Spinner` — seven inks, two rings, no SVG; supersedes legacy `Indicator`                           | done    |
+| P4     | Docs, generated tables, `1.0.0`                                                                    | todo    |
+| P4.1   | Live previews — alias `react-native` → `react-native-web` in Next.js                               | done    |
+| P4.2   | Prop tables generated from the TS types                                                            | done    |
+| P4.3   | Component pages, on the structure of plan §6                                                       | done    |
+| P4.4   | Migration guide legacy → v1, with the table of plan §7                                             | done    |
+| P4.5   | Regenerate `llms.txt`                                                                              | done    |
+| P4.5b  | Unpublish `@xaui/mcp` and `@xaui/icons`                                                            | todo    |
+| P4.6   | Publish `@xaui/native@1.0.0` — needs `changeset pre exit` first                                    | todo    |
+| P5     | The remaining components, shipped under `1.x`                                                      | todo    |
+| P5.1   | `InputOTP` — Group · Box · Value · Placeholder · Caret · Separator                                 | done    |
+| P5.2   | `TextArea` — Label · Field · Description · Error, over the `Input`                                 | done    |
+| P5.3   | `InputGroup` — Prefix · Field · Suffix · Icon, inside the `Input`                                  | done    |
+| P5.3b  | Rename `InputGroup` → `FieldGroup`, following `TextField`                                          | done    |
+| P5.3c  | `NumberField` — over legacy `NumberInput`, following `TextField`                                   | done    |
+| P5.3d  | `NumberPad` — net new, the keypad `NumberInput` and `InputOTP` share                               | done    |
+| P5.3e  | `NumberStepper` — net new, the increment pair legacy `Stepper` is not                              | done    |
+| P5.3f  | `PhoneNumberField` — country prefix, searchable sheet and national number                          | done    |
+| P5.3g  | `SearchField` — net new, a `TextField` with its mark, its clear and its search                     | done    |
+| P5.4   | `Select` — Trigger · Value · Indicator · Overlay · Content · Item                                  | done    |
+| P5.5   | `Stepper` — slots over the existing group context                                                  | done    |
+| P5.6   | `Toolbar` — slots over the existing group context                                                  | dropped |
+| P5.7   | `ListBox` — slots over the existing group context                                                  | done    |
+| P5.7b  | `ListBoxGroup` — net new, sectioned `ListBox` with its headers                                     | done    |
+| P5.7c  | `List` — virtualized rows over React Native `FlatList`                                             | done    |
+| P5.8   | `Menu` — Trigger · Overlay · Content · Label · Group · Item                                        | done    |
+| P5.9   | `SegmentButton` — slots over the existing group context                                            | done    |
+| P5.10  | `Autocomplete` — slots over the existing group context                                             | done    |
+| P5.10b | `Combobox` — the `Autocomplete` over a closed list                                                 | done    |
+| P5.11  | `Accordion` — Item · Trigger · Indicator · Content, over legacy `ExpansionPanel`                   | done    |
+| P5.12  | `BottomTabBar` — slots over the existing group context                                             | dropped |
+| P5.13  | `Menubox` — slots over the existing group context                                                  | dropped |
+| P5.14  | `ProgressCircle` — circular, the determinate half of legacy `Indicator`                            | done    |
+| P5.14b | `ProgressBar` — linear, over legacy `LinearProgressIndicator`                                      | done    |
+| P5.15  | `Slider` — Output · Track · Fill · Thumb                                                           | done    |
+| P5.16  | `Tabs` — List · Trigger · Label · Indicator · Content                                              | done    |
+| P5.17  | `AppBar`                                                                                           | dropped |
+| P5.18  | `Snackbar` — v1 transient notification over the shared toast queue                                 | done    |
+| P5.18b | `Toast` — Title · Description · Actions · Close, plus `ToastHost`                                  | done    |
+| P5.19  | `Snippet`                                                                                          | dropped |
+| P5.20  | `Fab` — round or extended, the Button's table on a floating box                                    | done    |
+| P5.21  | `FabMenu` — the FAB's actions as pills, anchored so the FAB never moves                            | done    |
+| P5.22  | `Dialog` — Trigger · Overlay · Content · Title · Description · Close                               | done    |
+| P5.23  | `BottomSheet` — Trigger · Overlay · Content · Handle · Title                                       | done    |
+| P5.23b | `BottomSheetInput` — net new, a `TextField` that opens in a `BottomSheet`                          | dropped |
+| P5.23c | `BottomSheet` reduced state — `collapsedHeight`, a two-state disclosure                            | done    |
+| P5.24  | `Drawer`                                                                                           | dropped |
+| P5.24b | `Popover` — Trigger · Overlay · Content · Title · Description · Close                              | done    |
+| P5.25  | `Picker`                                                                                           | dropped |
+| P5.25b | `WheelPicker` — net new, the spinning column the three below share                                 | done    |
+| P5.25c | `WheelDatePicker` — net new, `WheelPicker` columns for a date                                      | dropped |
+| P5.25d | `WheelTimePicker` — net new, `WheelPicker` columns for a time                                      | dropped |
+| P5.25e | `WheelDateTimePicker` — net new, the two above as one                                              | dropped |
+| P5.26  | `DatePicker` — Trigger · Value · Indicator · Overlay · Content · Calendar                          | done    |
+| P5.26b | `Calendar` — net new, no legacy equivalent                                                         | done    |
 
 | P5.26b\* | `Calendar.YearPicker` — the years, mounted instead of the days | done |
 | P5.26c | `AgendaCalendar` — net new, the `Calendar` with its events | done |

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -1,6 +1,6 @@
 # XAUI v1 — Plan d'implémentation
 
-> Refonte de `@xaui/native` en librairie React Native pure, inspirée de HeroUI Native, l'existant étant republié figé sous `@xaui/native-legacy` le temps de la migration.
+> Refonte de `@xaui/native` en librairie React Native pure, inspirée de l'implémentation de référence, l'existant étant republié figé sous `@xaui/native-legacy` le temps de la migration.
 
 **État de départ** : `@xaui/native` v0.2.8, 47 composants publiés · `@xaui/hybrid` v0.0.14 · `@xaui/core`, `@xaui/icons`, `@xaui/mcp` · monorepo Turborepo/pnpm · docs Next.js, demo Expo.
 
@@ -28,13 +28,13 @@ Un composant = un root `forwardRef` + des slots en dot-notation. Aucune prop ne 
 Chaque slot porte son propre `style`. L'override est local et visible là où il s'applique.
 
 **R3 — Les children textuels sont auto-wrappés, via `childrenToString`.**
-On n'inspecte pas le premier enfant : on tente de **stringifier récursivement** l'arbre. S'il contient le moindre élément React, la fonction rend `null` et les children passent tels quels ; sinon on enveloppe la chaîne concaténée dans le slot texte par défaut. C'est l'implémentation de HeroUI, et elle traite correctement `<Button>{count} items</Button>` — un tableau `[3, ' items']` qu'un simple `isValidElement` aurait manqué.
+On n'inspecte pas le premier enfant : on tente de **stringifier récursivement** l'arbre. S'il contient le moindre élément React, la fonction rend `null` et les children passent tels quels ; sinon on enveloppe la chaîne concaténée dans le slot texte par défaut. C'est celle de l'implémentation de référence, et elle traite correctement `<Button>{count} items</Button>` — un tableau `[3, ' items']` qu'un simple `isValidElement` aurait manqué.
 
 **R4 — Le layout appartient au root.**
 `gap`, `alignItems`, `flexDirection` sont sur le root. **Les slots n'ont aucune marge propre.** Corollaire : l'ordre JSX est l'ordre à l'écran, donc `startContent` / `endContent` disparaissent.
 
 **R5 — Le contexte porte des valeurs résolues.** _(divergence assumée — voir §1 ter)_
-Le root résout `variant × size × état` (plus la teinte `color` si fournie) une fois et publie la couleur finale. Les slots ne re-résolvent rien. Valeur memoizée. HeroUI publie les props brutes et laisse chaque slot re-résoudre — c'est gratuit chez eux grâce au cache de `tv()`, ça ne l'est pas sans moteur de classes.
+Le root résout `variant × size × état` (plus la teinte `color` si fournie) une fois et publie la couleur finale. Les slots ne re-résolvent rien. Valeur memoizée. L'implémentation de référence publie les props brutes et laisse chaque slot re-résoudre — c'est gratuit chez eux grâce au cache de `tv()`, ça ne l'est pas sans moteur de classes.
 
 **R6 — Tokens dans les props, valeurs arbitraires dans `style`.**
 `size="md"` passe, `size={42}` est une erreur de type. C'est ce qui permet le cache de styles (§3) — l'ouvrir tue le gain de perf. La règle porte sur le **vocabulaire** : `variant`, `size`, `radius`. Les valeurs brutes ont leur propre chemin, **hors du cache** et résolu dans une seconde passe (§3) : `color` et les **props de style** de R14.
@@ -47,10 +47,10 @@ Le root résout `variant × size × état` (plus la teinte `color` si fournie) u
 
 **R9 — Chaque root forwarde `ref`, `style`, `testID` et les props d'accessibilité.**
 Sans ça : pas de gesture-handler, pas de mesure de layout, pas de focus programmatique, pas de `asChild`. **C'est irrattrapable après la 1.0.**
-Deux détails que HeroUI applique et qu'il faut reprendre : `accessibilityRole` a une valeur par défaut mais reste surchargeable par les props, et `style` accepte **la forme fonction** de `Pressable` (`(state) => style`), pas seulement un objet.
+Deux détails que l'implémentation de référence applique et qu'il faut reprendre : `accessibilityRole` a une valeur par défaut mais reste surchargeable par les props, et `style` accepte **la forme fonction** de `Pressable` (`(state) => style`), pas seulement un objet.
 
 **R10 — Chaque composant composé exporte son hook de contexte.**
-`export { useButton }`, `export { useChip }`. C'est ce qui permet à un tiers d'écrire son propre slot (`<Button.MyThing>`) sans forker la lib. HeroUI le fait sur chaque compound ; sans ça, `system/` ne sert à rien pour l'extérieur.
+`export { useButton }`, `export { useChip }`. C'est ce qui permet à un tiers d'écrire son propre slot (`<Button.MyThing>`) sans forker la lib. L'implémentation de référence le fait sur chaque compound ; sans ça, `system/` ne sert à rien pour l'extérieur.
 
 **R11 — `displayName` est namespacé.**
 `'XAUI.Button.Root'`, `'XAUI.Button.Label'`. C'est ce qui rend les stack traces et le React DevTools lisibles quand vingt composants ont un slot `Label`.
@@ -95,7 +95,7 @@ Le détail du jeu et de sa résolution est au §2 ter.
 
 ### `variant` — union plate, emphase et intention fusionnées
 
-`themeColor` disparaît. `color` est réservé aux valeurs brutes (§1 R7), donc l'intention sémantique remonte dans `variant`, comme le `Button` de HeroUI.
+`themeColor` disparaît. `color` est réservé aux valeurs brutes (§1 R7), donc l'intention sémantique remonte dans `variant`, comme le `Button` de l'implémentation de référence.
 
 ```ts
 type Variant =
@@ -130,7 +130,7 @@ Sept lignes de table, aucune logique de peinture dupliquée : ce sont les tokens
 
 ### `size` pilote la hauteur, jamais la largeur
 
-Vérifié dans la source de HeroUI Native (`src/styles/components/button.css`) : le root du bouton déclare `flex-direction`, `align-items`, `justify-content`, `border-width` — **et aucune largeur**. `size` ne fixe que la hauteur, le padding horizontal, le `gap` et le rayon.
+Vérifié dans la source de l'implémentation de référence (`src/styles/components/button.css`) : le root du bouton déclare `flex-direction`, `align-items`, `justify-content`, `border-width` — **et aucune largeur**. `size` ne fixe que la hauteur, le padding horizontal, le `gap` et le rayon.
 
 ```css
 .button__root--size-md {
@@ -145,7 +145,7 @@ Vérifié dans la source de HeroUI Native (`src/styles/components/button.css`) :
 }
 ```
 
-Conséquence, en React Native : `alignItems` vaut `stretch` par défaut, donc **un bouton sans largeur remplit son parent en `Column` et épouse son contenu en `Row`**. HeroUI n'a pas de prop `fullWidth` — le comportement natif suffit, et `className="self-start"` sert d'échappatoire.
+Conséquence, en React Native : `alignItems` vaut `stretch` par défaut, donc **un bouton sans largeur remplit son parent en `Column` et épouse son contenu en `Row`**. L'implémentation de référence n'a pas de prop `fullWidth` — le comportement natif suffit, et `className="self-start"` sert d'échappatoire.
 
 **Trois décisions pour XAUI :**
 
@@ -177,7 +177,7 @@ type TextVariant =
 
 Chaque rôle fixe **taille, interlignage, graisse et famille ensemble**. Ça supprime les props `size` et `weight` séparées du composant actuel, et avec elles les combinaisons illégales — un titre en `weight="light"`, un caption en `lg`. `style` reste l'échappatoire pour le cas hors système.
 
-Dix valeurs contre trois chez HeroUI : on garde l'échelle typographique que les 13 variantes encodaient déjà, sans en garder le vocabulaire.
+Dix valeurs contre trois chez l'implémentation de référence : on garde l'échelle typographique que les 13 variantes encodaient déjà, sans en garder le vocabulaire.
 
 ### `color` — la teinte, en valeur brute
 
@@ -220,9 +220,9 @@ Tous. Ceux qui n'ont pas d'intention légitime (`Card`, `Surface`, `Divider`, `S
 
 ---
 
-## 1 ter. Fidélité à HeroUI — l'audit
+## 1 ter. Fidélité à l'implémentation de référence — l'audit
 
-Vérifié dans leur source (`heroui-inc/heroui-native`), pas dans leur doc.
+Vérifié dans leur source, pas dans leur doc.
 
 ### Repris à l'identique
 
@@ -233,7 +233,7 @@ Vérifié dans leur source (`heroui-inc/heroui-native`), pas dans leur doc.
 | Contexte strict, erreur nommée     | `createContext({ name, strict })` + `Error.captureStackTrace` | identique                  |
 | Auto-wrap des children             | `childrenToString` récursif                                   | identique (R3)             |
 | Hook de contexte exporté           | `export { useButton }`                                        | identique (R10)            |
-| `displayName` namespacé            | `'HeroUINative.Button.Root'`                                  | `'XAUI.Button.Root'` (R11) |
+| `displayName` namespacé            | `'Reference.Button.Root'`                                     | `'XAUI.Button.Root'` (R11) |
 | `size` = hauteur, jamais largeur   | aucune largeur au root                                        | identique (§1 bis)         |
 | Aucune prop de style profonde      | `className` par slot seulement                                | `style` par slot (R2)      |
 | Tokens sémantiques plats           | `--color-accent`, `--color-danger-soft`                       | identique (§4)             |
@@ -451,7 +451,7 @@ Conséquence sur le code existant : **45 fichiers utilisent encore l'`Animated` 
 
 **`@xaui/core` → dissous.** Les tokens deviennent `theme/tokens.gen.ts` dans chaque package (§4). Les types partagés (`EdgeInsets`, `Alignment`, `Border`, `ShadowConfig`…) sont recopiés dans `native/src/theme/theme.type.ts` — ils sont purement déclaratifs, la duplication ne coûte rien. Le tree legacy reçoit un `core-shim.ts` qui réexporte sous les anciens noms pour que rien n'y soit touché.
 
-**`@xaui/icons` → supprimé.** Les 520 SVG partent. À la place, un primitif `Icon` dans `system/` qui adapte n'importe quelle lib tierce (Ionicons, Lucide, react-native-svg) **et lit le contexte de slot pour la couleur et la taille** (§5). C'est précisément le point faible de HeroUI Native — leur doc oblige l'utilisateur à résoudre la couleur d'icône à la main via `useThemeColor`.
+**`@xaui/icons` → supprimé.** Les 520 SVG partent. À la place, un primitif `Icon` dans `system/` qui adapte n'importe quelle lib tierce (Ionicons, Lucide, react-native-svg) **et lit le contexte de slot pour la couleur et la taille** (§5). C'est précisément le point faible de l'implémentation de référence — leur doc oblige l'utilisateur à résoudre la couleur d'icône à la main via `useThemeColor`.
 
 **`@xaui/mcp` → supprimé.** Sa `src/data/` est de la doc écrite à la main, déjà dupliquée avec `apps/docs` et les README. Elle est régénérée depuis la source unique de doc (§6) et servie par le site en `llms.txt` — la route `app/docs/llms-txt` existe déjà.
 
@@ -742,11 +742,11 @@ Une petite allocation, seulement quand la prop est passée. La table de cache re
 
 ---
 
-## 4. Le thème : deux couches, comme HeroUI
+## 4. Le thème : deux couches, comme l'implémentation de référence
 
 ### 4.1 La découverte structurante
 
-HeroUI n'écrit pas tous ses tokens. Il en écrit **une petite couche source**, et **dérive tout le reste** par calcul :
+L'implémentation de référence n'écrit pas tous ses tokens. Elle en écrit **une petite couche source**, et **dérive tout le reste** par calcul :
 
 | Fichier                | Rôle                                                     | Volume       |
 | ---------------------- | -------------------------------------------------------- | ------------ |
@@ -776,7 +776,7 @@ HeroUI n'écrit pas tous ses tokens. Il en écrit **une petite couche source**, 
 
 **C'est le vrai avantage DX du système**, et je l'avais manqué : on surcharge `accent`, et `accentPressed`, `accentSoft`, `accentSoftForeground` suivent tout seuls. Avec la liste plate que je proposais avant, changer la couleur de marque demandait douze valeurs à la main.
 
-**React Native n'a pas `color-mix()`.** La dérivation se fait donc en JS, au moment de la construction du thème. HeroUI fait déjà du calcul de couleur en JS avec son `colorKit` (`colorKit.setAlpha(...)` dans leur `Button.tsx`) — on fait pareil, en amont plutôt qu'en CSS.
+**React Native n'a pas `color-mix()`.** La dérivation se fait donc en JS, au moment de la construction du thème. L'implémentation de référence fait déjà du calcul de couleur en JS avec son `colorKit` (`colorKit.setAlpha(...)` dans leur `Button.tsx`) — on fait pareil, en amont plutôt qu'en CSS.
 
 ### 4.2 La couche source — ce qu'on écrit, ce qu'on surcharge
 
@@ -839,7 +839,7 @@ Plus quelques primitives constantes entre les deux modes — `white`, `black`, `
 
 ### 4.3 La couche dérivée — calculée, jamais écrite
 
-Une fonction `deriveColors(source)` applique les formules de HeroUI, transposées en JS :
+Une fonction `deriveColors(source)` applique les formules de l'implémentation de référence, transposées en JS :
 
 ```ts
 // états de press (leurs `-hover`, renommés — voir §1 ter)
@@ -853,7 +853,7 @@ surfacePressed = mix(surface, surfaceForeground, 0.08)
 ```
 
 **La direction du press est une décision, pas un effet de bord.** Mélanger vers le texte
-de la variante — ce que fait HeroUI — fait suivre à la direction la clarté du fond :
+de la variante — ce que fait l'implémentation de référence — fait suivre à la direction la clarté du fond :
 `#9333ea` porte un texte quasi blanc et s'éclaircissait sous le doigt en mode clair,
 `#c084fc` porte un texte sombre et s'assombrissait en mode sombre. Même composant, geste
 opposé, personne ne l'avait choisi. Vers `foreground`, c'est une direction unique — plus
@@ -936,13 +936,13 @@ radius = {
 }
 ```
 
-**Les ombres sont sémantiques, pas une échelle.** Trois rôles — `surface`, `overlay`, `field` — et non `sm | md | lg | xl`. Corollaire important : en mode sombre HeroUI **supprime** l'ombre de surface et remplace celle d'overlay par un liseré interne clair. Une échelle `sm→xl` ne peut pas exprimer ça ; trois rôles, si.
+**Les ombres sont sémantiques, pas une échelle.** Trois rôles — `surface`, `overlay`, `field` — et non `sm | md | lg | xl`. Corollaire important : en mode sombre l'implémentation de référence **supprime** l'ombre de surface et remplace celle d'overlay par un liseré interne clair. Une échelle `sm→xl` ne peut pas exprimer ça ; trois rôles, si.
 
 **`spacing` est une fonction, pas une table.** Base 4 px, comme Tailwind. `spacing(3) === 12`. Ça supprime la question « quel nom pour 12 px » et aligne les valeurs de leur CSS (`calc(var(--spacing) * 12)` = hauteur 48 du bouton `md`).
 
 ### 4.5 Configurer le thème — l'API
 
-**`HeroUINativeProvider` n'a aucune prop de thème.** Son `config` ne contient que `textProps`, `textInputProps`, `toast`, `animation`, `devInfo`, `isRTL`. Le thème se configure entièrement en CSS, lu via `useCSSVariable` de **Uniwind**, leur moteur de classes. C'est ce que XAUI ne peut pas faire — et ne doit pas vouloir faire, c'est la prémisse du projet.
+**Le provider de l'implémentation de référence n'a aucune prop de thème.** Son `config` ne contient que `textProps`, `textInputProps`, `toast`, `animation`, `devInfo`, `isRTL`. Le thème se configure entièrement en CSS, lu via `useCSSVariable` de **Uniwind**, leur moteur de classes. C'est ce que XAUI ne peut pas faire — et ne doit pas vouloir faire, c'est la prémisse du projet.
 
 #### `createTheme` au niveau module
 
@@ -1011,7 +1011,7 @@ const accent = useThemeColor('accent') // un token
 const [bg, fg] = useThemeColor(['background', 'foreground'])
 ```
 
-`useThemeColor` reprend la signature de HeroUI, y compris la surcharge tableau. C'est ce dont un utilisateur a besoin pour colorer une icône tierce ou un composant maison.
+`useThemeColor` reprend la signature de l'implémentation de référence, y compris la surcharge tableau. C'est ce dont un utilisateur a besoin pour colorer une icône tierce ou un composant maison.
 
 #### Plusieurs thèmes
 
@@ -1040,7 +1040,7 @@ tooling/tokens/source.ts     →  packages/native/src/theme/tokens.gen.ts   (nom
 
 ## 5. Le primitif `Icon`
 
-Le problème que HeroUI n'a pas résolu : une icône est un composant tiers, le contexte de slot ne l'atteint pas, donc l'utilisateur doit calculer la couleur à la main.
+Le problème que l'implémentation de référence n'a pas résolu : une icône est un composant tiers, le contexte de slot ne l'atteint pas, donc l'utilisateur doit calculer la couleur à la main.
 
 ```tsx
 // L'icône reçoit couleur et taille du contexte du Button — rien à calculer

--- a/.project-specs/derive.mjs
+++ b/.project-specs/derive.mjs
@@ -3,7 +3,7 @@ import { mix, alpha } from './oklab.mjs'
 /** Couche DÉRIVÉE — ~30 tokens calculés, jamais écrits à la main. */
 export function deriveColors(s) {
   return {
-    // états pressés (les `-hover` de HeroUI, renommés)
+    // états pressés (les `-hover` de l'implémentation de référence, renommés)
     accentPressed:  mix(s.accent,  s.accentForeground,  0.10),
     successPressed: mix(s.success, s.successForeground, 0.10),
     warningPressed: mix(s.warning, s.warningForeground, 0.10),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Merci de contribuer a XAUI. Ce document formalise les specs, l'architecture et l
 - Mode repo: monorepo Turborepo avec workspaces `pnpm`.
 - Packages coeur:
 - `@xaui/native`: tokens, moteur de couleurs, `createTheme` et `XAUIProvider`.
-- `@xaui/native`: composants React Native (API inspiree Flutter).
+- `@xaui/native`: composants React Native (API composition-first).
 - Applications:
 - `apps/demo`: bac a sable Expo.
 - `apps/docs`: site de documentation Next.js.
@@ -42,7 +42,7 @@ Principes:
 - Eviter `any` sauf justification technique claire.
 - Eviter les `console.log`, `console.error`, `debugger`.
 - Favoriser des retours anticipes pour limiter l'imbrication.
-- Garder les APIs coherentes avec l'approche Flutter-like.
+- Garder les APIs coherentes avec l'approche composition-first.
 
 ## Workflow local
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XAUI Library
 
-XAUI is a Flutter-inspired component system targeting React Native and hybrid web/native experiences within a Turborepo monorepo. `@xaui/native` holds the tokens, the theme and the single provider; `@xaui/native-legacy` is the frozen v0 tree, kept only until the v1 API reaches parity.
+XAUI is a composition-first component system targeting React Native and hybrid web/native experiences within a Turborepo monorepo. `@xaui/native` holds the tokens, the theme and the single provider; `@xaui/native-legacy` is the frozen v0 tree, kept only until the v1 API reaches parity.
 
 **[Documentation → ui.xtartapp.com](https://ui.xtartapp.com)**
 

--- a/apps/demo/app/accordion.tsx
+++ b/apps/demo/app/accordion.tsx
@@ -44,7 +44,7 @@ export default function AccordionScreen() {
     >
       <Section
         title="One at a time"
-        note="The default. Open a second row and the first closes. The height is animated by Reanimated's layout transition on HeroUI's spring — damping 140 against stiffness 1600, stiffer than the chevron's because a height is a longer distance than a rotation. Nothing is measured: the panel is mounted or it is not."
+        note="The default. Open a second row and the first closes. The height is animated by Reanimated's layout transition on the reference implementation's spring — damping 140 against stiffness 1600, stiffer than the chevron's because a height is a longer distance than a rotation. Nothing is measured: the panel is mounted or it is not."
       >
         <Faq />
       </Section>
@@ -58,7 +58,7 @@ export default function AccordionScreen() {
 
       <Section
         title="The four levels"
-        note="The Card's tokens under the Button's names: primary is the strong fill, secondary the quieter one. primary is HeroUI's surface variant. ghost is our default and is HeroUI's default — no container at all, only the hairlines separate the rows, and they run the full width because there is no edge to be inset from."
+        note="The Card's tokens under the Button's names: primary is the strong fill, secondary the quieter one. primary is the reference implementation's surface variant. ghost is our default and is the reference implementation's default — no container at all, only the hairlines separate the rows, and they run the full width because there is no edge to be inset from."
       >
         {VARIANTS.map(variant => (
           <Faq key={variant} variant={variant} only={variant} />
@@ -67,7 +67,7 @@ export default function AccordionScreen() {
 
       <Section
         title="Sizes"
-        note="size moves the row's inset, the gap before the chevron and the type. The vertical padding is one value across all four: HeroUI puts sixteen points above and below against twelve on the sides, which is what gives a row of plain text a target big enough to hit without a border to aim at."
+        note="size moves the row's inset, the gap before the chevron and the type. The vertical padding is one value across all four: The reference implementation puts sixteen points above and below against twelve on the sides, which is what gives a row of plain text a target big enough to hit without a border to aim at."
       >
         {SIZES.map(size => (
           <Faq key={size} size={size} variant="primary" only={size} />

--- a/apps/demo/app/alert.tsx
+++ b/apps/demo/app/alert.tsx
@@ -38,7 +38,7 @@ export default function AlertScreen() {
     >
       <Section
         title="The nine variants"
-        note="The Card's surface for the neutral level, the Chip's status ladder for the rest. default is HeroUI's alert exactly — a neutral card with the status carried by the icon — and the soft slices are the tinted surface most alerts want."
+        note="The Card's surface for the neutral level, the Chip's status ladder for the rest. default is the reference implementation's alert exactly — a neutral card with the status carried by the icon — and the soft slices are the tinted surface most alerts want."
       >
         {VARIANTS.map(variant => (
           <Alert key={variant} variant={variant}>
@@ -141,14 +141,15 @@ export default function AlertScreen() {
 
       <Section
         title="An icon that disagrees with its alert"
-        note="HeroUI colours the icon by status on a neutral surface. Here the variant decides both, and the case is an explicit color on the slot — a raw value, which is what R7 says an exception looks like."
+        note="the reference implementation colours the icon by status on a neutral surface. Here the variant decides both, and the case is an explicit color on the slot — a raw value, which is what R7 says an exception looks like."
       >
         <Alert>
           <Alert.Icon as={CheckIcon} color={theme.colors.success} />
           <Alert.Content>
             <Alert.Title>Profil enregistré</Alert.Title>
             <Alert.Description>
-              Surface neutre, coche verte — l&apos;alerte de HeroUI, écrite en clair.
+              Surface neutre, coche verte — l&apos;alerte de the reference
+              implementation, écrite en clair.
             </Alert.Description>
           </Alert.Content>
         </Alert>

--- a/apps/demo/app/avatar.tsx
+++ b/apps/demo/app/avatar.tsx
@@ -73,7 +73,7 @@ export default function AvatarScreen() {
 
       <Section
         title="size — one measurement, both sides"
-        note="32, 40, 48, 64: HeroUI's three steps plus the xs our ladder adds below them. The glyph runs ahead of the initials at the top of the scale, because two letters fill a circle that one icon has to sit inside with air around it."
+        note="32, 40, 48, 64: The reference implementation's three steps plus the xs our ladder adds below them. The glyph runs ahead of the initials at the top of the scale, because two letters fill a circle that one icon has to sit inside with air around it."
       >
         <Row>
           {SIZES.map(size => (
@@ -144,7 +144,7 @@ export default function AvatarScreen() {
 
       <Section
         title="radius — a circle at every size, unless you say otherwise"
-        note="Where HeroUI fixes one large radius for all three sizes, which makes their small avatars round and their large ones squircles. full says the shape the name means once."
+        note="Where the reference implementation fixes one large radius for all three sizes, which makes their small avatars round and their large ones squircles. full says the shape the name means once."
       >
         <Row>
           <Labelled label="full">
@@ -199,7 +199,7 @@ export default function AvatarScreen() {
 
       <Section
         title="A glyph needs no props"
-        note="Avatar.Fallback publishes the frame's resolved size and colour to IconContext, so an Icon written inside it inherits both. XAUI ships no icon set, so the mark is always the caller's — which is why there is no default person icon where HeroUI has one."
+        note="Avatar.Fallback publishes the frame's resolved size and colour to IconContext, so an Icon written inside it inherits both. XAUI ships no icon set, so the mark is always the caller's — which is why there is no default person icon where the reference implementation has one."
       >
         <Row>
           <Avatar variant="primary">

--- a/apps/demo/app/card.tsx
+++ b/apps/demo/app/card.tsx
@@ -111,7 +111,7 @@ export default function CardScreen() {
 
       <Section
         title="size — padding and type, never a height"
-        note="A card is a surface, not a control: it is as tall as what it holds. md is HeroUI's card measured — 16pt of padding, a 24pt radius, an 18/28 title over a 16/24 description — and the other three steps move around it."
+        note="A card is a surface, not a control: it is as tall as what it holds. md is the reference card measured — 16pt of padding, a 24pt radius, an 18/28 title over a 16/24 description — and the other three steps move around it."
       >
         {(['xs', 'sm', 'md', 'lg'] as const).map(size => (
           <Card key={size} size={size} variant="secondary">
@@ -269,7 +269,7 @@ export default function CardScreen() {
       </Section>
       <Section
         title="Card.Background — ce que la carte pose derrière elle"
-        note="Le root la hisse en tête quels que soient les enfants écrits avant : l'ordre JSX ne décide pas de l'empilement, comme pour les overlays de PressableFeedback. Elle porte son propre overflow et le rayon de la carte, donc le root garde son ombre — là où HeroUI clippe des deux côtés et la perd."
+        note="Le root la hisse en tête quels que soient les enfants écrits avant : l'ordre JSX ne décide pas de l'empilement, comme pour les overlays de PressableFeedback. Elle porte son propre overflow et le rayon de la carte, donc le root garde son ombre — là où l'implémentation de référence clippe des deux côtés et la perd."
       >
         <Card variant="ghost" size="lg" height={180} justifyContent="flex-end">
           <Card.Background source={{ uri: COVER }} />

--- a/apps/demo/app/divider.tsx
+++ b/apps/demo/app/divider.tsx
@@ -23,7 +23,7 @@ export default function DividerScreen() {
     >
       <Section
         title="size — the thickness, on the axis the orientation leaves free"
-        note="xs is one device pixel, HeroUI's thin; lg is their thick, six points. xs is the default, and it is the one place in the library that does not default to md — a rule you notice is a rule that is too thick."
+        note="xs is one device pixel, the reference implementation's thin; lg is their thick, six points. xs is the default, and it is the one place in the library that does not default to md — a rule you notice is a rule that is too thick."
       >
         {SIZES.map(size => (
           <View key={size} style={{ gap: 6 }}>

--- a/apps/demo/app/input-otp.tsx
+++ b/apps/demo/app/input-otp.tsx
@@ -37,7 +37,7 @@ export default function InputOTPScreen() {
 
       <Section
         title="The three levels"
-        note="The TextField's, token for token — a box of a code is a field one character wide. Tap each: the box the next character lands in takes a two-point accent ring, which is HeroUI's outline done with a border, because React Native has no outline."
+        note="The TextField's, token for token — a box of a code is a field one character wide. Tap each: the box the next character lands in takes a two-point accent ring, which is the reference implementation's outline done with a border, because React Native has no outline."
       >
         {VARIANTS.map(variant => (
           <View key={variant} style={{ gap: 6 }}>
@@ -78,7 +78,7 @@ export default function InputOTPScreen() {
 
       <Section
         title="size — the box, and the character in it"
-        note="md is HeroUI's OTP exactly: a 48 box 44 wide, an 18/28 semibold character, 8 between boxes. The width is the control height less one spacing step, which holds the proportion at the other three sizes."
+        note="md is the reference implementation's OTP exactly: a 48 box 44 wide, an 18/28 semibold character, 8 between boxes. The width is the control height less one spacing step, which holds the proportion at the other three sizes."
       >
         {(['sm', 'md', 'lg'] as const).map(size => (
           <InputOTP key={size} maxLength={4} size={size}>

--- a/apps/demo/app/radio.tsx
+++ b/apps/demo/app/radio.tsx
@@ -98,7 +98,7 @@ export default function RadioScreen() {
 
       <Section
         title="size — the circle, the dot, the gap and the type"
-        note="The same four boxes as the Checkbox, so a radio and a checkbox in one form line up. The dot keeps HeroUI's ratio — 10 in 24 — at every size."
+        note="The same four boxes as the Checkbox, so a radio and a checkbox in one form line up. The dot keeps the reference implementation's ratio — 10 in 24 — at every size."
       >
         {SIZES.map(size => (
           <Radio key={size} size={size} defaultSelected>

--- a/apps/demo/app/select.tsx
+++ b/apps/demo/app/select.tsx
@@ -43,14 +43,14 @@ export default function SelectScreen() {
 
       <Section
         title="The chevron turns on a spring"
-        note="HeroUI's numbers: damping 140 against stiffness 1000 at mass 4. Heavy enough not to overshoot, which is what a 180-degree turn needs — an oscillating chevron reads as a bug. It runs on the UI thread, so it keeps turning while the rows mount."
+        note="the reference implementation's numbers: damping 140 against stiffness 1000 at mass 4. Heavy enough not to overshoot, which is what a 180-degree turn needs — an oscillating chevron reads as a bug. It runs on the UI thread, so it keeps turning while the rows mount."
       >
         <Picker placeholder="Ouvrir, puis fermer" />
       </Section>
 
       <Section
         title="Sizes — the control scales, the list does not"
-        note="size moves the trigger's height, padding and type. The rows keep their own measurements: a lg select opening lg rows is a menu that fills the screen, and HeroUI takes the same position."
+        note="size moves the trigger's height, padding and type. The rows keep their own measurements: a lg select opening lg rows is a menu that fills the screen, and the reference implementation takes the same position."
       >
         {SIZES.map(size => (
           <Picker key={size} size={size} placeholder={size} />

--- a/apps/demo/app/slider.tsx
+++ b/apps/demo/app/slider.tsx
@@ -25,7 +25,7 @@ export default function SliderScreen() {
     >
       <Section
         title="Drag it, or press anywhere on the track"
-        note="A thin rail with a round knob riding on it, the legacy proportions rather than HeroUI's capsule: 6 to 10 points of rail under a 16 to 24 point disc. The knob overhangs the rail by half their difference on each side, and the rail reserves that overhang as a margin — otherwise the knob spills into whatever sits above and below. A press anywhere on the rail moves it there, and it grows 15% under the press rather than moving."
+        note="A thin rail with a round knob riding on it, the legacy proportions rather than the reference implementation's capsule: 6 to 10 points of rail under a 16 to 24 point disc. The knob overhangs the rail by half their difference on each side, and the rail reserves that overhang as a margin — otherwise the knob spills into whatever sits above and below. A press anywhere on the rail moves it there, and it grows 15% under the press rather than moving."
       >
         <Basic />
       </Section>

--- a/apps/demo/app/spinner.tsx
+++ b/apps/demo/app/spinner.tsx
@@ -59,7 +59,7 @@ export default function SpinnerScreen() {
 
       <Section
         title="The track — why it is two rings and not one"
-        note="The faint full circle is the track; the arc turns over it. Without it a rotating three-quarter ring reads as broken rather than as busy. HeroUI gets the same figure from a gradient stroke, which would need react-native-svg — an optional peer a core component cannot require."
+        note="The faint full circle is the track; the arc turns over it. Without it a rotating three-quarter ring reads as broken rather than as busy. The reference implementation gets the same figure from a gradient stroke, which would need react-native-svg — an optional peer a core component cannot require."
       >
         <Row>
           <Labelled label="lg · default">

--- a/apps/demo/app/surface.tsx
+++ b/apps/demo/app/surface.tsx
@@ -46,7 +46,7 @@ export default function SurfaceScreen() {
 
       <Section
         title="Sizes move the padding, the gap and the corner"
-        note="Never a height. A surface is a ground: how tall it is, is how tall what is on it is. md is HeroUI's, measured — sixteen points of padding on a twenty-four point corner."
+        note="Never a height. A surface is a ground: how tall it is, is how tall what is on it is. md is the reference implementation's, measured — sixteen points of padding on a twenty-four point corner."
       >
         {SIZES.map(size => (
           <Surface key={size} size={size} variant="secondary">

--- a/apps/demo/app/tag-group.tsx
+++ b/apps/demo/app/tag-group.tsx
@@ -54,7 +54,7 @@ export default function TagGroupScreen() {
 
       <Section
         title="Sizes"
-        note="HeroUI's three, step for step: the padding, the corner and the type all move together, and the remove button's box moves with the label so a tag with a cross is never taller than a tag without."
+        note="the reference implementation's three, step for step: the padding, the corner and the type all move together, and the remove button's box moves with the label so a tag with a cross is never taller than a tag without."
       >
         {SIZES.map(size => (
           <Removable key={size} size={size} />

--- a/apps/demo/app/text-area.tsx
+++ b/apps/demo/app/text-area.tsx
@@ -113,7 +113,7 @@ export default function TextAreaScreen() {
       </Section>
 
       <Section
-        title="height — HeroUI's fixed text area"
+        title="height — the reference implementation's fixed text area"
         note="Theirs is a fixed 128 that scrolls rather than one that grows. A style prop reproduces it exactly, which is the escape hatch rather than a second API."
       >
         <TextArea>

--- a/apps/demo/app/text-field.tsx
+++ b/apps/demo/app/text-field.tsx
@@ -26,7 +26,7 @@ export default function TextFieldScreen() {
     >
       <Section
         title="The four levels"
-        note="primary is HeroUI's field fill plus the theme's field shadow; secondary is their neutral one, and the default here. Tap each: the border darkens towards the mode's ink — fieldBorderFocus, no ring and no accent. ghost has no border to move, so its focus is the caret alone."
+        note="primary is the reference implementation's field fill plus the theme's field shadow; secondary is their neutral one, and the default here. Tap each: the border darkens towards the mode's ink — fieldBorderFocus, no ring and no accent. ghost has no border to move, so its focus is the caret alone."
       >
         {VARIANTS.map(variant => (
           <TextField key={variant} variant={variant}>
@@ -84,7 +84,7 @@ export default function TextFieldScreen() {
 
       <Section
         title="size — the field's minimum height, never its width"
-        note="A minimum and not a fixed height, which is where this component departs from the Button: a multiline field holds the user's own text and has to grow. md is HeroUI's input exactly — 48 minimum, 12 of padding, a 16/24 label, a 14/20 line below."
+        note="A minimum and not a fixed height, which is where this component departs from the Button: a multiline field holds the user's own text and has to grow. md is the reference implementation's input exactly — 48 minimum, 12 of padding, a 16/24 label, a 14/20 line below."
       >
         <TextField size="xs">
           <TextField.Label>xs · 32</TextField.Label>

--- a/apps/demo/app/toast.tsx
+++ b/apps/demo/app/toast.tsx
@@ -69,7 +69,7 @@ function Screen() {
 
       <Section
         title="The stack keeps three, and drops the oldest"
-        note="Every card is anchored to the same edge and pushed back by its transform alone — 10 points toward the edge and 3% smaller per step, HeroUI’s values — so a pile of eight costs the height of one. Press five times quickly: three shoulders, and the rest are queued at zero opacity rather than dropped. Then throw the front card away from its edge — 50 points or 500 a second — and each swipe promotes the next."
+        note="Every card is anchored to the same edge and pushed back by its transform alone — 10 points toward the edge and 3% smaller per step, the reference implementation’s values — so a pile of eight costs the height of one. Press five times quickly: three shoulders, and the rest are queued at zero opacity rather than dropped. Then throw the front card away from its edge — 50 points or 500 a second — and each swipe promotes the next."
       >
         <View style={{ flexDirection: 'row', gap: 8 }}>
           <Button

--- a/apps/docs/lib/data/native-api.generated.json
+++ b/apps/docs/lib/data/native-api.generated.json
@@ -7436,7 +7436,7 @@
           "name": "animation",
           "type": "boolean | undefined",
           "required": false,
-          "description": "`false` freezes the block at full opacity and mounts no worklet.  A boolean rather than HeroUI's `'shimmer' | 'pulse' | 'none'`: a shimmer is a gradient sweeping across the block, a gradient needs `react-native-svg`, and that is an optional peer a component in the core cannot require. One animation, so there is nothing for a name to choose between."
+          "description": "`false` freezes the block at full opacity and mounts no worklet.  A boolean rather than the reference implementation's `'shimmer' | 'pulse' | 'none'`: a shimmer is a gradient sweeping across the block, a gradient needs `react-native-svg`, and that is an optional peer a component in the core cannot require. One animation, so there is nothing for a name to choose between."
         },
         {
           "name": "style",

--- a/apps/docs/public/docs/accordion.md
+++ b/apps/docs/public/docs/accordion.md
@@ -158,7 +158,7 @@ Everything `View` takes, plus `ViewStyle` as props.
 
 **The height is never measured.** The panel is mounted or it is not, and Reanimated's
 layout transition animates the row between the two — `LinearTransition.springify()` on
-HeroUI's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
+The reference implementation's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
 on purpose: a height is a longer distance than a rotation, and at the chevron's stiffness
 the same damping makes a long panel take almost half a second to settle.
 
@@ -178,12 +178,12 @@ mass 4. It is a worklet, so it keeps turning while the panel's content mounts.
 
 ## The four levels
 
-| ours        | HeroUI    | fill               |
-| ----------- | --------- | ------------------ |
-| `primary`   | `surface` | `surface`          |
-| `secondary` | —         | `surfaceSecondary` |
-| `tertiary`  | —         | a border, no fill  |
-| `ghost`     | `default` | none — the default |
+| ours        | The reference implementation | fill               |
+| ----------- | ---------------------------- | ------------------ |
+| `primary`   | `surface`                    | `surface`          |
+| `secondary` | —                            | `surfaceSecondary` |
+| `tertiary`  | —                            | a border, no fill  |
+| `ghost`     | `default`                    | none — the default |
 
 The tokens are the `Card`'s — an accordion in `primary` **is** a card with rows in it, and
 two containers that look alike but are declared apart drift. Only the names differ, and

--- a/apps/docs/public/docs/alert.md
+++ b/apps/docs/public/docs/alert.md
@@ -121,7 +121,7 @@ with another.
 </Alert>
 ```
 
-This is HeroUI's alert written out: a neutral surface with the status carried by the icon
+This is the reference implementation's alert written out: a neutral surface with the status carried by the icon
 alone. There it is what `status` does; here the variant decides both the surface and the
 foreground, so an icon that has to disagree says so with a raw `color` (R7).
 
@@ -148,7 +148,7 @@ alert is a surface: it is as tall as the message it carries.
 | `md`   | 12      | 12  | 16/24 | 14/20       | 18   | 3           |
 | `lg`   | 16      | 14  | 18/28 | 16/24       | 20   | 4           |
 
-`md` is HeroUI's alert measured: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24 title
+`md` is the reference implementation's alert measured: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24 title
 above a 14/20 description, an 18pt icon. The icon's offset is **half the title's leading**
 rather than their hard-coded 3.5px — it lands on the same 3 at `md`, and stays right at
 the other three sizes.
@@ -171,7 +171,7 @@ takes the `Card`'s vocabulary for its neutral level and the `Chip`'s for the res
 | `danger-soft`  | `dangerSoft`  | `dangerSoftForeground`  | —      |
 
 `default` is the `Card`'s `default`, token for token — the surface fill and the surface
-shadow, which is HeroUI's alert root exactly. The elevation belongs to that one variant: a
+shadow, which is the reference implementation's alert root exactly. The elevation belongs to that one variant: a
 tinted alert already separates itself by its fill, and a shadow under it would read as dirt.
 
 `tertiary` and `ghost` are absent: an alert without a surface is a paragraph. The outlined
@@ -240,7 +240,7 @@ Everything `View` accepts, every `ViewStyle` key it does not already claim (R14)
 The three forms of `Icon` — `as`, a raw SVG child, `source` — plus the `ViewStyle` keys of
 its box as props (R14). `size` and `color` default to what the root resolved.
 
-**No default glyph**, where HeroUI ships three. XAUI publishes no icon set — `@xaui/icons`
+**No default glyph**, where the reference implementation ships three. XAUI publishes no icon set — `@xaui/icons`
 was deleted in P0 — so the icon is always yours, and the alert's job is to size and colour
 it rather than to choose it.
 

--- a/apps/docs/public/docs/avatar.md
+++ b/apps/docs/public/docs/avatar.md
@@ -90,12 +90,12 @@ a person or a thing, which is the category the `Chip` established. The three sta
 are here because an avatar reports as often as it identifies: a red frame for the account
 that failed to sync, a green one for the person who is online.
 
-It is HeroUI's `variant × color` matrix said once. Their `default` is this `default`, and
+It is the reference implementation's `variant × color` matrix said once. Their `default` is this `default`, and
 their `soft` crossed with five colours is `secondary` plus the five `-soft` names.
 
 ### `size` sets both sides
 
-Thirty-two, forty, forty-eight and sixty-four — HeroUI's three steps plus the `xs` our
+Thirty-two, forty, forty-eight and sixty-four — the reference implementation's three steps plus the `xs` our
 ladder adds below them, which is the size an avatar is inside a `Chip` or a list row. An
 avatar is a square before it is a circle, so there is one measurement rather than a width
 and a height that can drift apart.
@@ -106,7 +106,7 @@ to sit inside with air around it.
 
 ### `radius` — a circle at every size
 
-Where HeroUI fixes one large radius for all three sizes, which makes their small avatars
+Where the reference implementation fixes one large radius for all three sizes, which makes their small avatars
 round and their large ones squircles. `full` says the shape the name means once, and
 `radius` is still there for the logo that wants a square.
 
@@ -117,7 +117,7 @@ round and their large ones squircles. `full` says the shape the name means once,
 `Avatar.Image` is absolutely positioned over `Avatar.Fallback`, and an `Image` with nothing
 decoded yet draws nothing. So the initials show while the photo loads and **stay if the URL
 is wrong** — with no load-state machine, no `onError` to remember, and nothing to get out of
-sync. HeroUI runs a status enum for this; a stacking order says the same thing and cannot
+sync. The reference implementation runs a status enum for this; a stacking order says the same thing and cannot
 disagree with itself.
 
 JSX order between the two is therefore free. Write the image first, as the anatomy reads.
@@ -130,7 +130,7 @@ colour to `IconContext`, so an `Icon` written inside it needs no props at all.
 
 ### The fade
 
-`Avatar.Image` fades in over 200ms on `onLoad` — HeroUI's timing. It runs off a shared value
+`Avatar.Image` fades in over 200ms on `onLoad` — the reference implementation's timing. It runs off a shared value
 rather than off a mount animation, because the node has to be mounted from the first render
 or it never fetches: the moment worth animating is the decode, not the mount.
 `animation={false}` skips it and mounts no worklet.

--- a/apps/docs/public/docs/bottom-sheet.md
+++ b/apps/docs/public/docs/bottom-sheet.md
@@ -210,7 +210,7 @@ panel rather than a modal, and a dimmed page behind one reads oddly — leave
 
 ## Not `@gorhom/bottom-sheet`
 
-HeroUI wraps it. A sheet that slides, springs and dismisses is a pan gesture and a shared
+The reference implementation wraps it. A sheet that slides, springs and dismisses is a pan gesture and a shared
 value; taking a dependency for that would put a second animation library in every app that
 installs one component. What we lose is their scroll integration, which is worth having and
 worth its own change rather than a dependency.

--- a/apps/docs/public/docs/card.md
+++ b/apps/docs/public/docs/card.md
@@ -230,7 +230,7 @@ treatment.
 **The clip lives on the layer, not on the root.** `overflow: 'hidden'` cuts the node's own
 shadow on iOS, so putting it on the card would cost a `default` card the elevation its
 variant just gave it. This slot carries its own `overflow` and the card's radius — which is
-also why `radius` moves both slots together. HeroUI clips on both and loses the shadow.
+also why `radius` moves both slots together. The reference implementation clips on both and loses the shadow.
 
 Two forms, like `Icon`: `source` renders the image, and anything else is the caller's own
 layer, already positioned and clipped.

--- a/apps/docs/public/docs/changelog.md
+++ b/apps/docs/public/docs/changelog.md
@@ -1031,7 +1031,7 @@
   Nothing is walked and nothing is counted: the group publishes two gaps and a type scale, the
   sections are ordinary children, and one can be built out of something that is not a list.
 
-  For the record, since the name is theirs: HeroUI's `ListGroup` **is our `List`** — a Surface
+  For the record, since the name is theirs: The reference implementation's `ListGroup` **is our `List`** — a Surface
   container with Item · ItemPrefix · ItemContent · ItemTitle · ItemDescription · ItemSuffix,
   slot for slot. What ships here under that name is the thing neither of us had.
 
@@ -1137,7 +1137,7 @@
   decoration, and the disc is what makes it a target. `ghost` is the bare cross for a
   component already providing one.
 
-  Four sizes on a 24 / 28 / 32 / 40 box, `md` being HeroUI's measured and the `Dialog`'s. The
+  Four sizes on a 24 / 28 / 32 / 40 box, `md` being the reference implementation's measured and the `Dialog`'s. The
   bar is a ratio of the box rather than a table — a bar rotated a quarter turn spans
   `length / √2` per axis, so it is twice as long as the cross looks — which makes it one cross
   at four sizes instead of four drawings of one. **The stroke does not scale**: it is the
@@ -1156,7 +1156,7 @@
 - cb76b65: `List` — rows on a ground.
 
   `List.Item` and `List.ItemButton` with `ItemPrefix`, `ItemContent`, `ItemTitle`,
-  `ItemDescription` and `ItemSuffix`, on the anatomy `heroui-native`'s `ListGroup` uses.
+  `ItemDescription` and `ItemSuffix`, on the anatomy the reference implementation's `ListGroup` uses.
 
   **It is the `Accordion` with rows that do not open**, and it reads the same ladder, insets
   its separators the same way and lifts the same one variant. Two containers that look alike
@@ -1177,7 +1177,7 @@
   toggles it — a `Switch` in its suffix — which says out loud what it does and is reachable as
   the control it actually is.
 
-  **`ItemSuffix` draws nothing of its own.** HeroUI's puts a chevron there by default; the
+  **`ItemSuffix` draws nothing of its own.** The reference implementation's puts a chevron there by default; the
   trailing end of a settings row is a switch at least as often, and a slot that guesses makes
   you pass a child in order to render nothing.
 
@@ -1456,10 +1456,10 @@
 
 ### Patch Changes
 
-- 541cbe7: The toast stack collapses, like HeroUI's.
+- 541cbe7: The toast stack collapses, like the reference implementation's.
 
   It was a flex column with a gap: every card fully visible, one under the next, so six
-  toasts took six card heights down the screen. HeroUI's is a pile — one card in front, the
+  toasts took six card heights down the screen. The reference implementation's is a pile — one card in front, the
   rest scaled down and pushed toward the edge behind it, only their shoulders showing.
 
   Every card is now anchored to the same edge and its depth is entirely in its transform:
@@ -1472,7 +1472,7 @@
   keeps its timer and its place, and is promoted into view when the one in front leaves — so
   a burst of six shows all six instead of losing three.
 
-- 7557e46: The front toast can be thrown away with a swipe, like HeroUI's.
+- 7557e46: The front toast can be thrown away with a swipe, like the reference implementation's.
 
   Away from its edge — up on a top stack, down on a bottom one — past 50 points or 500 points
   a second, their thresholds, either alone being enough. Dragged the wrong way it resists
@@ -1484,7 +1484,7 @@
   any reasonable minimum, and dragging the second card out from under the first reads as a
   glitch rather than as a dismissal. `isSwipeable={false}` on the host turns it off.
 
-  Note that this dismisses **one** card and the pile empties a swipe at a time — HeroUI's
+  Note that this dismisses **one** card and the pile empties a swipe at a time — the reference implementation's
   gesture calls `hide(id)`, not a clear-all, and their provider has no such thing.
 
   The gesture runs on `react-native-gesture-handler`, already an optional peer, reached only
@@ -1521,16 +1521,16 @@
   a save succeeded has turned a good outcome into a bad one.
 
   It closes P5.18 as well as P5.18b: `Snackbar` and `Toast` are the same object under two
-  names, and HeroUI calls it `toast`.
+  names, and the reference implementation calls it `toast`.
 
 ## 0.9.1-alpha.44
 
 ### Patch Changes
 
-- 750a85a: `Dialog.Close` draws a cross when it is empty, like HeroUI's.
+- 750a85a: `Dialog.Close` draws a cross when it is empty, like the reference implementation's.
 
   It was a bare pressable that rendered whatever it was given and nothing when it was given
-  nothing, so `<Dialog.Close />` — the first line of HeroUI's own anatomy — put an invisible
+  nothing, so `<Dialog.Close />` — the first line of the reference implementation's own anatomy — put an invisible
   32 points in the corner. It now reads `system/close-button`, which draws the cross from two
   rotated bars, and the dialog's recipe resolves the box and the bar the way `Chip.Close`
   already did.
@@ -1572,7 +1572,7 @@
   No `variant`: the question a dialog asks is in its words, not in its fill.
 
   It also unblocks the `presentation` prop that `Select.Content` and `Menu.Content` are
-  written around but cannot offer — HeroUI has both, and `dialog` was half of what was
+  written around but cannot offer — the reference implementation has both, and `dialog` was half of what was
   missing.
 
 ## 0.9.1-alpha.43
@@ -1582,7 +1582,7 @@
 - ef43606: `BottomSheet` — Trigger · Overlay · Content · Handle · Title · Description · Close
 
   **Built on this library's own peers rather than on `@gorhom/bottom-sheet`**, which is what
-  HeroUI wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
+  the reference implementation wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
   value; taking a dependency for that would put a second animation library in every app that
   installs one component. What it costs is their snap points and their scroll integration —
   both worth having, and both worth their own change rather than a dependency.
@@ -1652,7 +1652,7 @@
 
   ### A rail with a knob on it, not a capsule with a core
 
-  The legacy proportions rather than HeroUI's: 6 to 10 points of rail under a 16 to 24 point
+  The legacy proportions rather than the reference implementation's: 6 to 10 points of rail under a 16 to 24 point
   disc. The knob overhangs the rail by half their difference on each side, and the rail
   reserves that overhang as a margin — without it the knob spills into whatever sits above
   and below, and the layout has no idea the control is thicker than its rail.
@@ -1806,7 +1806,7 @@
 
   `flex: 1` is `flexBasis: 0`. The measuring pass asks the panel how wide it wants to be, so
   there is no definite width for a zero basis to grow into: the row's content size is nothing,
-  the title collapses, and the panel holds that width. HeroUI writes `flex: 1` on the same
+  the title collapses, and the panel holds that width. The reference implementation writes `flex: 1` on the same
   node and gets away with it because their measuring pass hands the panel a definite width —
   ours asks a question a zero basis cannot answer.
 
@@ -1818,7 +1818,7 @@
   thirteen: a menu row is a title with an indicator beside it and sometimes a sentence under
   it, where a popover is prose alone.
 
-  `SubMenu` is not here. HeroUI ships it as its own component and it needs a second anchored
+  `SubMenu` is not here. The reference implementation ships it as its own component and it needs a second anchored
   panel whose trigger is a row of the first, which is worth its own change.
 
 ## 0.9.1-alpha.39
@@ -1886,7 +1886,7 @@
   sheet. Thirteen ems of the body size, about twenty-six characters a line — narrow on
   purpose. A popover is read at a glance, and a glance is two or three short lines rather
   than a paragraph; past that it stops being an aside and starts being a sheet with a tail.
-  It is where HeroUI's own panels land too, measured off their placement demos. A multiple of
+  It is where the reference implementation's own panels land too, measured off their placement demos. A multiple of
   the type rather than a number of points, so a theme that scales its type scales the panel
   with it.
 
@@ -1897,7 +1897,7 @@
   room for it went off the screen entirely — `start` and `end` were unusable and nothing said
   so until one was opened.
 
-  The panel may now overlap its own trigger. That is the right trade, and the one HeroUI's
+  The panel may now overlap its own trigger. That is the right trade, and the one the reference implementation's
   `useRelativePosition` makes too: a panel covering the button that opened it is legible, and
   a panel past the edge of the screen is not.
 
@@ -1911,12 +1911,12 @@
 
 - 7e04096: `Accordion` — Item · Trigger · Indicator · Content
 
-  P5.11, over the legacy `ExpansionPanel`. HeroUI Native calls it `accordion` and so does
+  P5.11, over the legacy `ExpansionPanel`. The reference implementation calls it `accordion` and so does
   this, which is also what the roadmap row now says.
 
   **The height is never measured.** The panel is mounted or it is not, and Reanimated's
   layout transition animates the row between the two — `LinearTransition.springify()` on
-  HeroUI's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
+  the reference implementation's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
   deliberately: a height is a longer distance than a rotation, and at the chevron's
   stiffness the same damping makes a long panel take almost half a second to settle.
 
@@ -1929,7 +1929,7 @@
   **The variant table is the `Card`'s, token for token.** An accordion in `default` _is_ a
   card with rows in it, and two containers that look alike but are declared apart drift —
   the drift showing up as an accordion sitting on a card with a fill one step off it.
-  `ghost` is the default and is HeroUI's own: rows separated by hairlines, on whatever page
+  `ghost` is the default and is the reference implementation's own: rows separated by hairlines, on whatever page
   they sit on.
 
   **The separators are the root's, drawn between its children.** A row that drew its own
@@ -1998,7 +1998,7 @@
   the same heights — so a select and a text input in one form read as one control rather
   than as two libraries meeting.
 
-  The visual values and the motion are HeroUI Native's, not the legacy component's. The
+  The visual values and the motion are the reference implementation's, not the legacy component's. The
   chevron turns 0 to −180° on their spring (damping 140, stiffness 1000, mass 4): heavily
   damped against a very high stiffness, so it arrives in a fifth of a second without
   overshooting, because an oscillating chevron reads as a bug rather than as motion. The
@@ -2028,11 +2028,11 @@
   chevron and the gap between them, and at that height the value gets nothing. The
   `TextField` keeps its `xs` because a field only has to hold text.
 
-  The panel's corner is `2xl`, not `3xl`. HeroUI's is their `--radius-3xl` on a base of 8,
+  The panel's corner is `2xl`, not `3xl`. The reference implementation's is their `--radius-3xl` on a base of 8,
   which is 24 points; our base is 12, so the same 24 is `2xl`. Reading their key rather than
   their number put a 36-point corner on it and made it read as a pill.
 
-  Two narrowings against HeroUI, both deliberate. `placement` is `top` or `bottom` only: a
+  Two narrowings against the reference implementation, both deliberate. `placement` is `top` or `bottom` only: a
   list as wide as its own field hanging off the side of it reads as a menu, and `start` and
   `end` belong to `Popover`. And there is no `presentation` prop — the bottom-sheet and
   dialog presentations need `BottomSheet` and `Dialog`, which do not exist yet.
@@ -2162,28 +2162,28 @@
   `Avatar.Image` is absolutely positioned over `Avatar.Fallback`, and an `Image` with nothing
   decoded yet draws nothing — so the initials show while the photo loads and **stay if the URL
   is wrong**, with no load-state machine, no `onError` to remember, and nothing to get out of
-  sync. HeroUI runs a status enum for this; a stacking order says the same thing and cannot
+  sync. The reference implementation runs a status enum for this; a stacking order says the same thing and cannot
   disagree with itself. JSX order between the two slots is therefore free.
 
   `variant` is the `Chip`'s eleven names, meaning here what they mean there — an avatar is a
   token _about_ a person or a thing, which is the category the `Chip` established. The three
   status families are present because an avatar reports as often as it identifies: a red frame
   for the account that failed to sync, a green one for the person who is online. It is
-  HeroUI's `variant × color` matrix said once.
+  the reference implementation's `variant × color` matrix said once.
 
   `size` sets both sides, because an avatar is a square before it is a circle — 32, 40, 48, 64,
-  HeroUI's three steps plus the one our ladder adds below them. The glyph inside the fallback
+  the reference implementation's three steps plus the one our ladder adds below them. The glyph inside the fallback
   runs ahead of the initials at the top of the scale, because two letters fill a circle that
   one person-icon has to sit inside with air around it.
 
-  `radius` defaults to `full`, where HeroUI fixes one large radius for all three sizes — which
+  `radius` defaults to `full`, where the reference implementation fixes one large radius for all three sizes — which
   makes their small avatars round and their large ones squircles.
 
   **No default glyph.** XAUI publishes no icon set, so the mark is always the caller's. What
   `Avatar.Fallback` does instead is publish the frame's resolved size and colour to
   `IconContext`, so an `Icon` written inside it needs no props at all.
 
-  The photo fades in over 200ms on `onLoad` — HeroUI's timing — driven by a shared value
+  The photo fades in over 200ms on `onLoad` — the reference implementation's timing — driven by a shared value
   rather than a mount animation, because the node has to be mounted from the first render or
   it never fetches. `animation={false}` skips it and mounts no worklet.
 
@@ -2210,11 +2210,11 @@
   accent announces the brand where there is nothing yet to announce; **no `tertiary` and no
   `ghost`**, because a skeleton with a border and no fill is an empty box.
 
-  HeroUI reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
+  The reference implementation reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
   lets a theme move the skeleton by moving `default`, rather than by discovering that a
   percentage of a text colour is where the placeholder grey came from.
 
-  **No shimmer**, where HeroUI's default is one: a shimmer is a gradient sweeping across the
+  **No shimmer**, where the reference implementation's default is one: a shimmer is a gradient sweeping across the
   block, a gradient needs `react-native-svg`, and that is an optional peer a component in the
   core cannot require. One animation, so `animation` is a boolean rather than a name to
   choose between — the block breathes between full opacity and a half, a second each way.
@@ -2272,7 +2272,7 @@
   `Animated.View` that collapses a section takes the thickness and the ink from the recipe and
   the height from a shared value.
 
-  `size` is the thickness — `xs` is HeroUI's `thin`, one device pixel, and `lg` is their
+  `size` is the thickness — `xs` is the reference implementation's `thin`, one device pixel, and `lg` is their
   `thick`, six points. **It defaults to `xs`**, the one place in the library that does not
   default to `md`: a rule you notice is a rule that is too thick.
 
@@ -2295,13 +2295,13 @@
   named: deleting is a `danger` wait. **No `ghost`**, because a spinner with no ink is not a
   spinner, and **no `-soft` slices**, because a soft slice is a fill softened.
 
-  HeroUI fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
+  The reference implementation fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
   therefore `react-native-svg` — an **optional peer**, which a component in the
   fifteen-component core cannot require. Two circles of one ink at two opacities read as the
   same figure, cost two views, and pull in nothing. The track is what does the work: a
   rotating three-quarter ring on its own reads as broken rather than as busy.
 
-  `size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, HeroUI's
+  `size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, the reference implementation's
   three steps plus the one our ladder adds between the first two. The stroke thickens once,
   at `lg`.
 
@@ -2412,7 +2412,7 @@
 
   The eighth entry of the core. **The root is the row, not the box**: it is the pressable, so
   tapping the label ticks the checkbox — which is the whole reason `Checkbox.Label` is a slot
-  here rather than a `Text` you put beside the component and wire up yourself. HeroUI needs a
+  here rather than a `Text` you put beside the component and wire up yourself. The reference implementation needs a
   second component (`ControlField`) for that; the plan's slots for this one are Indicator ·
   Label, and this is why.
 
@@ -2432,7 +2432,7 @@
   a box with no border and no fill is nothing at all — plus the four sizes, `radius`,
   `isInvalid` (which drops the resting fill and outranks the tint) and `isDisabled`.
 
-  `isIndeterminate` is ours and not HeroUI's: the legacy checkbox had it, a "select all" is
+  `isIndeterminate` is ours and not the reference implementation's: the legacy checkbox had it, a "select all" is
   what it is for, and `accessibilityState.checked: 'mixed'` is something only the component
   can say. A press resolves it to selected rather than toggling into it.
 
@@ -2485,7 +2485,7 @@
   suffix is most often a control and one that swallowed its own taps would be a reveal toggle
   you cannot press. A disabled `Input` takes the touches from both decorators all the same.
 
-  `InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one HeroUI's
+  `InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one the reference implementation's
   component does not: a glyph one step above the field's type, in the theme's
   `fieldPlaceholder`, so a form does not carry a hard-coded `#888` on every field.
 
@@ -2499,11 +2499,11 @@
 
 ### Patch Changes
 
-- 0c5435f: The `field` radius aligns on HeroUI's — 21 points becomes 12
+- 0c5435f: The `field` radius aligns on the reference implementation's — 21 points becomes 12
 
   `buildRadius` derived it as `base * 1.75`, which on the default base of 12 put a 48-tall
   field at 21 — 87% of its geometric maximum, so it read as a gélule rather than as a rounded
-  box. HeroUI reaches 12 for the same control from the other side of the scale: their
+  box. The reference implementation reaches 12 for the same control from the other side of the scale: their
   `--radius-field` is an alias of their `--radius-xl`, and their base is 8 where ours is 12.
 
   It coincides with `lg` at the default base and stays its own key, because that is what lets
@@ -2534,7 +2534,7 @@
   and `.Error` are literally the `Input`'s slots, re-exported rather than wrapped.
 
   Only `TextArea.Field` differs, by three things: `multiline`, the text pinned to the top, and
-  a height counted in lines. That is HeroUI's answer too — their `TextArea` is twenty lines
+  a height counted in lines. That is the reference implementation's answer too — their `TextArea` is twenty lines
   rendering their `Input` with the same three defaults.
 
   `rows` (default `3`) and `maxRows` are **raw values** (R6), like `color`: they resolve
@@ -2582,7 +2582,7 @@
   **The box takes the `lg` radius, 12 points, not `field`.** A field is wide, so 21 on a
   48-tall one reads as a rounded rectangle; a code box is very nearly square — 44 by 48 at
   `md`, 36 by 40 at `sm` — where the geometric maximum is 22, so the same 21 is a pill in all
-  but name and is clamped to one outright at the small end. Twelve is where HeroUI lands for
+  but name and is clamped to one outright at the small end. Twelve is where the reference implementation lands for
   the same box from the other direction: their `field` radius is their `xl`, and their scale's
   base is 8 where ours is 12.
 
@@ -2614,7 +2614,7 @@
   keep in step — and why `TextInputProps` are on the field rather than on the root.
 
   The first real use of the theme's `field*` family, derived in P0 and unread since. Four
-  variants, the library's emphasis levels narrowed like the `Card`'s, splitting HeroUI's
+  variants, the library's emphasis levels narrowed like the `Card`'s, splitting the reference implementation's
   two-name `primary | secondary` by saying what each of their ends already is: `primary` is
   their field fill plus the theme's `field` shadow, `secondary` their neutral fill and the
   default here, `tertiary` the border alone, `ghost` neither.
@@ -2626,7 +2626,7 @@
   against the box's own padding, so the JSX is identical either way and nothing is
   reparented; the field pays for the room and the box grows by the same amount.
 
-  Visually aligned with `heroui-native`: a 48pt minimum, 12pt of horizontal padding, a 16/24
+  Visually aligned with the reference implementation: a 48pt minimum, 12pt of horizontal padding, a 16/24
   label above the field and a 14/20 line below it at `md`. The height is a **minimum** rather
   than fixed — the one place this component departs from the `Button`'s rule, because a
   `multiline` field holds the user's own text and has to grow.
@@ -2645,11 +2645,11 @@
   `Alert.Icon`, `Alert.Content`, `Alert.Title`, `Alert.Description` and `Alert.Close`, laid
   out as a row of three columns spaced by the root's `gap` alone.
 
-  Nine variants: the `Card`'s `surface` for the neutral level — HeroUI's alert root, token
+  Nine variants: the `Card`'s `surface` for the neutral level — the reference implementation's alert root, token
   for token, shadow included — and the `Chip`'s status ladder for the rest, each family in
   its full and soft slice.
 
-  Visually aligned with `heroui-native`: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
+  Visually aligned with the reference implementation: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
   title above a 14/20 description and an 18pt icon at `md`. The icon's optical offset is
   derived from the title's leading rather than hard-coded, so it stays right at all four
   sizes.
@@ -2677,11 +2677,11 @@
   `Chip.Label`, `Chip.Icon`, `Chip.Dot`, `Chip.Avatar` and `Chip.Close`, spaced by the root
   alone, so JSX order is screen order and there is no `startContent` / `endContent`.
 
-  Eleven flat variants replace HeroUI's `variant × color` matrix: the `Button`'s five-step
+  Eleven flat variants replace the reference implementation's `variant × color` matrix: the `Button`'s five-step
   emphasis ladder plus the three status families it deliberately refused — a chip reports an
   outcome, so `success`, `warning` and `danger` each land here with their soft slice.
 
-  Visually aligned with `heroui-native`: 12pt of horizontal padding, a 14/20 label and a 28pt
+  Visually aligned with the reference implementation: 12pt of horizontal padding, a 14/20 label and a 28pt
   `md`, with the height fixed rather than derived from vertical padding so a chip carrying an
   avatar still lines up with the one beside it.
 
@@ -2739,7 +2739,7 @@
   what it holds. `isPressable` turns the surface into a `PressableFeedback` with a press
   wash, `accessibilityRole="button"` and the shared scale.
 
-  The rendering is HeroUI's card measured — `md` is 16pt of padding, a 24pt radius, an
+  The rendering is the reference implementation's card measured — `md` is 16pt of padding, a 24pt radius, an
   18/28 title in `medium` over a 16/24 description, no border on a filled surface — reached
   through our own vocabulary rather than through their utility classes, and with the gaps the
   component owns instead of leaving to the call site.
@@ -2756,7 +2756,7 @@
   The clip lives on the layer rather than on the root: `overflow: 'hidden'` cuts the node's
   own shadow on iOS, so clipping the card would cost a `default` one the elevation its variant
   just gave it. `radius` therefore moves both slots together — a corner that moved only the
-  root would round the card and leave its photo square. HeroUI reaches the same feature
+  root would round the card and leave its photo square. The reference implementation reaches the same feature
   through a `background` **prop** and clips on both nodes, losing the shadow.
 
   **The light `surfaceSecondary` moves up half a step**, `#f4f4f5` → `#ececee`. It sat so
@@ -2837,7 +2837,7 @@
 
 - 863cc86: `Typography` and `TextSpan` — the first entry of the v1 core
 
-  Ten roles, aligned with HeroUI Native's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
+  Ten roles, aligned with the reference implementation's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
   `code`. Each role fixes size, line height, weight and family **together**, which is why
   there is no `size` prop and no `weight` prop — the combinations they allowed (a heading in
   a light weight, a caption in a display size) become unwritable rather than discouraged.
@@ -2932,7 +2932,7 @@
 ### Patch Changes
 
 - cd06df1: Fix the press scale, which lurched on wide controls, and align the touch feedback with
-  HeroUI's values.
+  the reference implementation's values.
 
   **The scale was a flat `0.975` for every control.** What the eye reads is the displacement,
   not the ratio: that same ratio moves a 360pt row nine points and a 96pt chip two. It is now

--- a/apps/docs/public/docs/checkbox.md
+++ b/apps/docs/public/docs/checkbox.md
@@ -74,7 +74,7 @@ handler both happen, in that order.
 
 The border, the mark's fill and the label turn `danger`, and the **resting fill is
 dropped**: a box that is wrong reads as an outline rather than as a filled control that
-happens to be red at the edge. HeroUI reaches the same shape with a compound.
+happens to be red at the edge. The reference implementation reaches the same shape with a compound.
 
 It does not mount a message. Put one under the row yourself — a slot that silently renders
 nothing is a slot you cannot debug, which is the `TextField.Error` bargain again.
@@ -155,7 +155,7 @@ checkbox hugs its label; a row that has to fill its parent is a style prop away.
 The check is **derived from the box** — half its width, a quarter its height — rather than
 tabulated, so it is one glyph at four sizes instead of four drawings of one.
 
-`md` is HeroUI's checkbox measured: a 24pt box with the field's 1pt border. The corner is
+`md` is the reference implementation's checkbox measured: a 24pt box with the field's 1pt border. The corner is
 `md` (9) where theirs is `lg` (8) — the same key is 12 on our radius base, and 12 on a 24pt
 box is a circle, which is the `Radio`.
 
@@ -214,7 +214,7 @@ two components rather than a branch inside one.
 The press treatment is `PressableFeedback`'s, so `animation` on the root is the library's
 usual knob: `false`, `'disabled'`, `'disable-all'`, or the object.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `checkbox.tsx` and `checkbox.css` rather than eyeballed.
 

--- a/apps/docs/public/docs/chip.md
+++ b/apps/docs/public/docs/chip.md
@@ -141,14 +141,14 @@ differs from a `Button`'s.
 | `md`   | 28     | 12      | 14/20 | 6   | 22     |
 | `lg`   | 36     | 16      | 16/24 | 8   | 28     |
 
-The height is fixed where HeroUI uses vertical padding. Same numbers — theirs resolve to
+The height is fixed where the reference implementation uses vertical padding. Same numbers — theirs resolve to
 20, 28 and 36 — and a different reason to arrive at them: with padding, a chip carrying an
 avatar is taller than the chip beside it carrying only text, and a row of filters stops
 lining up.
 
 ### Variants
 
-Eleven flat names, replacing HeroUI's `variant × color` matrix — four emphases times five
+Eleven flat names, replacing the reference implementation's `variant × color` matrix — four emphases times five
 intents, of which nine combinations paint the same thing.
 
 The first five are the `Button`'s ladder, descending by how much accent is left. The six

--- a/apps/docs/public/docs/close-button.md
+++ b/apps/docs/public/docs/close-button.md
@@ -83,7 +83,7 @@ element carries its own label or its own text.
 | `md`   | 32  | 16  | ~11   |
 | `lg`   | 40  | 20  | ~14   |
 
-`md` is HeroUI's close button measured — a 32-point square — and it is the `Dialog`'s.
+`md` is the reference implementation's close button measured — a 32-point square — and it is the `Dialog`'s.
 
 The **bar** is twice as long as the cross looks: a bar rotated a quarter turn spans
 `length / √2` on each axis. It is kept as a ratio of the box rather than tabulated, so it is
@@ -123,7 +123,7 @@ because the base owns the press state — a cross has to be a different target f
 around it — and a root that does not know it is pressed cannot resolve a colour for it.
 Every other close button in the library reads the same way.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the 32-point box at the default size, the circle, the filled default rather
 than a bare glyph, the grown touch target, and children replacing the mark.

--- a/apps/docs/public/docs/combobox.md
+++ b/apps/docs/public/docs/combobox.md
@@ -115,7 +115,7 @@ All of them are the `Select`'s, resolved through `selectRecipe` exactly as the
 `Autocomplete`'s are: four field levels, three sizes, `radius`, `color`, `isInvalid`,
 `isDisabled`. A second table would be a third one to keep in step.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Theirs is `ComboBox` with `InputGroup` · `Value` · `Trigger` · `Popover`.
 

--- a/apps/docs/public/docs/dialog.md
+++ b/apps/docs/public/docs/dialog.md
@@ -108,7 +108,7 @@ which the dialog supplies. Two shapes, and the empty one is the default:
 **Empty, it draws a cross** — the shared button's, from two rotated bars rather than an
 icon, so the corner affordance works in a project that has installed no icon set.
 
-Every measurement is HeroUI's, read off their CSS. `close-button.css` sets
+Every measurement is the reference implementation's, read off their CSS. `close-button.css` sets
 `height: calc(var(--spacing) * 8)` on a spacing base of 4, so the box is **32 points**, and
 `isIconOnly` gives it `aspect-ratio: 1` and a radius past half its height — a circle. It is
 **filled**, not a bare glyph: their `CloseButton` is a `tertiary` button, and their
@@ -119,7 +119,7 @@ reads as decoration; the disc is what makes it a target.
 **It places itself nowhere.** `alignSelf="flex-end"` above the title, or `position`,
 `top` and `end` over content that has room for it — a title with space beside it and one
 without want different answers, and that is layout, which is the caller's (R4). This is
-what HeroUI does too: their own examples use `absolute top-3 inset-e-2.5`, `items-end` and
+what the reference implementation does too: their own examples use `absolute top-3 inset-e-2.5`, `items-end` and
 `self-end me-4` in three different dialogs. The placement is in the example, not in the
 component.
 

--- a/apps/docs/public/docs/divider.md
+++ b/apps/docs/public/docs/divider.md
@@ -85,7 +85,7 @@ past it.
 
 ### `size` is the thickness
 
-`xs` is HeroUI's `thin` — one device pixel, `StyleSheet.hairlineWidth` — and `lg` is their
+`xs` is the reference implementation's `thin` — one device pixel, `StyleSheet.hairlineWidth` — and `lg` is their
 `thick`, six points, with the two steps our ladder puts between them.
 
 It is `size` and not `thickness` because that is the vocabulary word (§1 bis), and it is

--- a/apps/docs/public/docs/field-group.md
+++ b/apps/docs/public/docs/field-group.md
@@ -201,12 +201,12 @@ There is no `size` here. The `TextField`'s decides everything:
 | `lg`   | 16              | 16  | 20   |
 
 The inset is the field's own horizontal padding, so the glyph starts where the text would
-have. The gap is that same step — HeroUI's, and it is what separates two glyphs in one
+have. The gap is that same step — the reference implementation's, and it is what separates two glyphs in one
 decorator.
 
 The icon sits **one step above the field's type**, exactly as on the `Button` and the
 `Chip`: a 16pt glyph beside 16pt of text reads as an icon smaller than the text it sits
-with. HeroUI's component sizes no icon at all — theirs is a number at the call site — so
+with. The reference implementation's component sizes no icon at all — theirs is a number at the call site — so
 this is a slot they do not have rather than a value we disagree on.
 
 ## Colour
@@ -230,7 +230,7 @@ fill is the caller's colour and the placeholder grey is no longer readable over 
 Everything else a tint touches — the border, the fill, the focus — is the `TextField`'s and
 reaches the group untouched.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `input-group.tsx` and `input-group.css` rather than eyeballed.
 

--- a/apps/docs/public/docs/input-otp.md
+++ b/apps/docs/public/docs/input-otp.md
@@ -185,7 +185,7 @@ and not the other is how a cleared field comes back on the next keystroke.
 | `md`   | 48 × 44 | 18/28     | 8   |
 | `lg`   | 56 × 52 | 20/28     | 10  |
 
-`md` is HeroUI's OTP measured. The width is the control height less one spacing step, which
+`md` is the reference implementation's OTP measured. The width is the control height less one spacing step, which
 reproduces their 48 × 44 and holds the proportion at the other two.
 
 ### The corner
@@ -195,7 +195,7 @@ A field is wide, so 21 on a 48-tall one reads as a rounded rectangle. A code box
 nearly square — 44 by 48 at `md`, 36 by 40 at `sm` — where the geometric maximum is 22, so
 the same 21 is a pill in all but name and is clamped to one outright at the small end.
 
-Twelve is where HeroUI lands for the same box from the other direction: their `field` radius
+Twelve is where the reference implementation lands for the same box from the other direction: their `field` radius
 is their `xl`, and their scale's base is 8 where ours is 12.
 
 **There is no `xs`**, where the rest of the library has four sizes. That box would be 28 by
@@ -214,7 +214,7 @@ Three of the `Input`'s four, token for token — a box of a code is a field one 
 | `secondary` | `default`         | `fieldBorder` | `accent`    | —       |
 | `tertiary`  | transparent       | `fieldBorder` | `accent`    | —       |
 
-**The active box takes a two-point ring** in the accent. HeroUI uses `outline-width: 2px`;
+**The active box takes a two-point ring** in the accent. The reference implementation uses `outline-width: 2px`;
 React Native has no `outline`, so it is a border — and two points rather than one, because a
 box that gains a colour without gaining weight reads as a rendering artefact next to five
 that did not. The box has a fixed width and height and centres what it holds, so the extra

--- a/apps/docs/public/docs/list-box.md
+++ b/apps/docs/public/docs/list-box.md
@@ -93,7 +93,7 @@ actually is.
 
 ## The suffix draws nothing of its own
 
-HeroUI's puts a chevron there by default. The trailing end of a settings row is a `Switch`
+The reference implementation's puts a chevron there by default. The trailing end of a settings row is a `Switch`
 at least as often, and a slot that guesses makes you pass a child in order to render
 nothing. The library ships `ChevronDownIcon`; a row that wants one says so.
 
@@ -204,7 +204,7 @@ disabled group has no live list in it.
 
 A `ListBox` outside any group is unchanged.
 
-### Alignment with `heroui-native`
+### Alignment with the reference implementation
 
 Their `ListBoxGroup` **is our `ListBox`** — a Surface container with Item · ItemPrefix ·
 ItemContent · ItemTitle · ItemDescription · ItemSuffix, slot for slot. What is here under

--- a/apps/docs/public/docs/menu.md
+++ b/apps/docs/public/docs/menu.md
@@ -164,7 +164,7 @@ the third component to read them, after the `Select` and the `Popover`.
 
 ## Not here yet
 
-**`SubMenu`.** HeroUI ships it as its own component and it needs a second anchored panel
+**`SubMenu`.** The reference implementation ships it as its own component and it needs a second anchored panel
 whose trigger is a row of the first — worth its own change rather than a corner of this one.
 
 ## Accessibility

--- a/apps/docs/public/docs/progress-bar.md
+++ b/apps/docs/public/docs/progress-bar.md
@@ -143,7 +143,7 @@ success, warning or danger.
 `Checkbox`'s pair, meaning the same thing on a line instead of in a box. Why a role and not
 an axis is written up once in [`checkbox.md`](../checkbox/checkbox.md#colour).
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the three sizes, the label-and-value header, the clamped range with
 `minValue` / `maxValue`, `formatOptions` through `Intl`, and Track · Fill as slots.

--- a/apps/docs/public/docs/progress-circle.md
+++ b/apps/docs/public/docs/progress-circle.md
@@ -128,7 +128,7 @@ than by a stylesheet. The recipe still owns them, on two slots it never renders 
 thing the `Tabs` recipe does with its `content` slot — because that is what makes a raw
 `color` reach the arc through `resolveTint`, which only maps roles a variant declared.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the three sizes, the clamped range, `formatOptions`, the SVG ring with a
 rounded cap starting at twelve o'clock, and Indicator · Value as slots.

--- a/apps/docs/public/docs/radio.md
+++ b/apps/docs/public/docs/radio.md
@@ -178,7 +178,7 @@ the auto-wrap does not apply.
 | `lg`   | 28     | 12  | 10  | 18/28 |
 
 The same four boxes as the `Checkbox`, so a radio and a checkbox in one form line up. The
-dot keeps HeroUI's ratio — 10 in 24 — rather than being tabulated, so it is one dot at four
+dot keeps the reference implementation's ratio — 10 in 24 — rather than being tabulated, so it is one dot at four
 sizes instead of four drawings of one.
 
 `radius` is `full` and overridable: a squared-off option in a segmented row is a real
@@ -201,7 +201,7 @@ tint is ignored while `isInvalid`, as on the `Checkbox`.
 Why a role and not an axis is written up once, in
 [`checkbox.md`](../checkbox/checkbox.md#colour), and it holds here unchanged.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `radio.tsx` and `radio.css`.
 

--- a/apps/docs/public/docs/select.md
+++ b/apps/docs/public/docs/select.md
@@ -217,7 +217,7 @@ goes, so choosing never shifts a label.
 
 ## Motion
 
-Three animations, HeroUI's values throughout.
+Three animations, the reference implementation's values throughout.
 
 **The chevron** turns 0 → −180° on a spring: damping 140, stiffness 1000, mass 4. Heavily
 damped against a very high stiffness, so it arrives in about a fifth of a second and does

--- a/apps/docs/public/docs/skeleton.md
+++ b/apps/docs/public/docs/skeleton.md
@@ -125,10 +125,10 @@ One pulse: the block breathes between full opacity and a half, a second each way
 and out. `animation={false}` freezes it at full and mounts no worklet — the branch renders
 a plain `View`, so a long list frozen for a screenshot costs nothing.
 
-**No shimmer**, where HeroUI's default is one. A shimmer is a gradient sweeping across the
+**No shimmer**, where the reference implementation's default is one. A shimmer is a gradient sweeping across the
 block; a gradient needs `react-native-svg`, and that is an optional peer a component in the
 fifteen-component core cannot require. One animation, so there is nothing for a name to
-choose between — `animation` is a boolean rather than HeroUI's
+choose between — `animation` is a boolean rather than the reference implementation's
 `'shimmer' | 'pulse' | 'none'`.
 
 ## Accessibility

--- a/apps/docs/public/docs/spinner.md
+++ b/apps/docs/public/docs/spinner.md
@@ -75,7 +75,7 @@ is a fill softened, and there is no fill here.
 
 ### `size` is the diameter
 
-Sixteen, twenty, twenty-four and thirty-two points — HeroUI's three steps plus the one our
+Sixteen, twenty, twenty-four and thirty-two points — the reference implementation's three steps plus the one our
 ladder adds between the first two. The stroke thickens once, at `lg`, because a 2pt ring on
 a 32pt circle reads as a hairline and a 3pt ring on a 16pt one reads as a doughnut.
 
@@ -103,7 +103,7 @@ still the last word.
 
 ### Why borders and not an SVG stroke
 
-HeroUI draws one arc fading from opaque to 55%, which needs a `linearGradient` and
+The reference implementation draws one arc fading from opaque to 55%, which needs a `linearGradient` and
 therefore `react-native-svg`. That package is an **optional peer** here, and a component in
 the fifteen-component core cannot require one. Two circles of a single ink at two opacities
 read as the same figure, cost two views, and pull in nothing.

--- a/apps/docs/public/docs/switch.md
+++ b/apps/docs/public/docs/switch.md
@@ -106,7 +106,7 @@ instead of a third pair of words for this component alone.
 ```
 
 The knob's children travel with it. Anything else you put in the track stays where you put
-it — a glyph at each end, for instance, which is what HeroUI's `StartContent` and
+it — a glyph at each end, for instance, which is what the reference implementation's `StartContent` and
 `EndContent` are; here they are two `View`s you position, because the track is a node you
 were given rather than one that was hidden from you.
 
@@ -149,7 +149,7 @@ the auto-wrap does not apply.
 | `md`   | 48 × 18 | 26   | 0     | 22     | 16/24 |
 | `lg`   | 56 × 20 | 30   | 0     | 26     | 18/28 |
 
-`md` is the legacy switch measured — a 48 × 28 track with a 22 knob — and HeroUI's is the
+`md` is the legacy switch measured — a 48 × 28 track with a 22 knob — and the reference implementation's is the
 same 48 wide.
 
 **The width is part of the control**, unlike everywhere else in the library, where `size`
@@ -198,12 +198,12 @@ transform is not one — but a transform does not mirror under RTL either, so th
 flipped by hand against `I18nManager.isRTL`. It is the one place in the library that reads
 it, and it reads it for a movement rather than for a layout.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `switch.tsx` and `switch.css`, and against the legacy component this
 one replaces.
 
-**Identical to HeroUI:** the 48pt track at `md`, the knob's `field` shadow, the accent
+**Identical to the reference implementation:** the 48pt track at `md`, the knob's `field` shadow, the accent
 track when on with a contrasting knob, the 175ms crossfade, and a default knob so nothing
 has to be written for the common case.
 

--- a/apps/docs/public/docs/tabs.md
+++ b/apps/docs/public/docs/tabs.md
@@ -149,7 +149,7 @@ there is no flash at the start of the row either.
 
 ## Not here yet
 
-**A scrollable list.** HeroUI's `Tabs.ScrollView` centres the chosen tab when the bar
+**A scrollable list.** The reference implementation's `Tabs.ScrollView` centres the chosen tab when the bar
 overflows, and that means the indicator has to account for a scroll offset the triggers'
 own layout does not report. Worth its own change.
 

--- a/apps/docs/public/docs/text-area.md
+++ b/apps/docs/public/docs/text-area.md
@@ -34,8 +34,8 @@ would change is the one telling you the truth.
 **Only `TextArea.Field` differs**, by three things: `multiline`, the text pinned to the top,
 and a height counted in lines.
 
-That is also HeroUI's answer — [their `TextArea`](https://github.com/heroui-inc/heroui-native/tree/main/src/components/text-area)
-is twenty lines rendering their `TextField` with the same three defaults. A component of its own
+That is also the reference implementation's answer — its `TextArea`
+is twenty lines rendering its `TextField` with the same three defaults. A component of its own
 is what a caller looks for; sharing every line of it is what keeps the two from drifting.
 
 So **everything in [`input.md`](../text-field/text-field.md) applies here**, and this page only covers
@@ -81,7 +81,7 @@ cache.
 
 ### A fixed height
 
-HeroUI's text area is a **fixed** 128 that scrolls rather than one that grows. That is a
+The reference implementation's text area is a **fixed** 128 that scrolls rather than one that grows. That is a
 style prop away (R14), rather than a second API:
 
 ```tsx

--- a/apps/docs/public/docs/text-field.md
+++ b/apps/docs/public/docs/text-field.md
@@ -129,13 +129,13 @@ and the reason there is no `fullWidth` prop.
 | `md`   | 48               | 12      | 16    | 16/24 | 14/20               |
 | `lg`   | 56               | 16      | 18    | 18/28 | 16/24               |
 
-`md` is HeroUI's input measured: a 48pt minimum, 12pt of horizontal padding, a 16/24 label
+`md` is the reference implementation's input measured: a 48pt minimum, 12pt of horizontal padding, a 16/24 label
 above the field and a 14/20 line below it.
 
 **A minimum and not a fixed height**, which is the one place this component departs from
 the rule the `Button` and the `Chip` follow. A `TextInput` with `multiline` holds three
 lines of the user's own text and has to grow; a control whose content is not the
-developer's cannot be truncated into shape. HeroUI reaches the same conclusion with
+developer's cannot be truncated into shape. The reference implementation reaches the same conclusion with
 `min-height`.
 
 The label and the help text carry a small horizontal inset — half the `md` field's padding
@@ -155,7 +155,7 @@ and nothing else has read since.
 | `tertiary`  | transparent       | `fieldBorder` | `fieldBorderFocus` | —       |
 | `ghost`     | transparent       | —             | — (no border)      | —       |
 
-The four names split HeroUI's two-name `primary | secondary` by saying what each of their
+The four names split the reference implementation's two-name `primary | secondary` by saying what each of their
 ends already is:
 
 - **`primary`** is their `primary` — the `fieldBackground` fill — plus the theme's `field`
@@ -168,7 +168,7 @@ ends already is:
   alone. Reach for `tertiary` when a focus ring matters.
 
 The first three name the `fieldBorder` edge and `ghost` gives it up. Its **width** is the
-theme's `borderWidth.field` — the same knob HeroUI exposes as `--field-border-width`, and
+theme's `borderWidth.field` — the same knob the reference implementation exposes as `--field-border-width`, and
 the one shipped default where the two libraries differ: **they ship `0`**, so their input is
 a fill with no visible edge, and we ship `1`. `createTheme({ borderWidth: { field: 0 } })`
 reproduces theirs exactly.
@@ -219,7 +219,7 @@ node that hears the event is `TextField.Field` — the field composes the caller
 `onBlur` with the two the context published, so your handlers run and the border still
 moves.
 
-### Alignment with `heroui-native`
+### Alignment with the reference implementation
 
 Measured against their `input.css`, `text-field.css`, `label.css`, `description.css`,
 `field-error.css` and `variables.css` rather than eyeballed.
@@ -236,10 +236,10 @@ both modes, and the field token is the one that can be themed apart later.
 
 **Two deltas, both deliberate and both in the theme rather than in this component:**
 
-| Token               | HeroUI           | XAUI              | Why                                                                                                                                                                                                                                                 |
-| ------------------- | ---------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `borderWidth.field` | `0`              | `1`               | Their input is a fill with no visible edge. Ours keeps a hairline, because `tertiary` — the border alone — has nothing left to be without it. Same knob, different shipped default: `createTheme({ borderWidth: { field: 0 } })` reproduces theirs. |
-| radius base         | `8` → field `14` | `12` → field `21` | `RADIUS_BASE` is a P0 decision that draws every corner in the library. Changing it for one component would be incoherent; changing it globally is a theme decision, not this one.                                                                   |
+| Token               | The reference implementation | XAUI              | Why                                                                                                                                                                                                                                                 |
+| ------------------- | ---------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `borderWidth.field` | `0`                          | `1`               | Their input is a fill with no visible edge. Ours keeps a hairline, because `tertiary` — the border alone — has nothing left to be without it. Same knob, different shipped default: `createTheme({ borderWidth: { field: 0 } })` reproduces theirs. |
+| radius base         | `8` → field `14`             | `12` → field `21` | `RADIUS_BASE` is a P0 decision that draws every corner in the library. Changing it for one component would be incoherent; changing it globally is a theme decision, not this one.                                                                   |
 
 **Two things we add that they do not have:** a focus state — their CSS has none, and the
 theme derived `fieldBorderFocus` for it — and the `field` shadow on `primary`, which is what

--- a/apps/docs/public/docs/toast.md
+++ b/apps/docs/public/docs/toast.md
@@ -109,7 +109,7 @@ and its depth is entirely in its transform, so a pile of eight costs the height 
 | 1         | `10` toward the edge | `0.97` |
 | 2         | `20`                 | `0.94` |
 
-Both numbers are HeroUI's, read off their `toast.animation.ts`: `translateY: [0, 10]` and
+Both numbers are the reference implementation's, read off their `toast.animation.ts`: `translateY: [0, 10]` and
 `scale: [1, 0.97]`, interpolated over the index. The shoulder a card leaves is
 `10 − 0.03 × height`, around 7 points on a two-line toast — enough to say there is another
 one, not enough to be read as a second card.
@@ -127,7 +127,7 @@ must not land on something nobody can see.
 The front card is thrown away by dragging it **away from its edge** — up on a top stack,
 down on a bottom one. The pile empties one card at a time, each swipe promoting the next.
 
-It goes past **50 points or 500 points a second**, HeroUI's thresholds, and either alone is
+It goes past **50 points or 500 points a second**, the reference implementation's thresholds, and either alone is
 enough: distance without velocity refuses a flick that clearly meant it, velocity without
 distance refuses a slow deliberate push. A toast is glanced at, so both readings count.
 
@@ -191,7 +191,7 @@ save succeeded has turned a good outcome into a bad one.
 
 ## It replaces `Snackbar`
 
-The legacy component is `Snackbar`. It is the same object under two names, and HeroUI calls
+The legacy component is `Snackbar`. It is the same object under two names, and the reference implementation calls
 it `toast`; the roadmap's P5.18 closes with this.
 
 | Legacy                        | v1                                     |

--- a/packages/native/CHANGELOG.md
+++ b/packages/native/CHANGELOG.md
@@ -1031,7 +1031,7 @@
   Nothing is walked and nothing is counted: the group publishes two gaps and a type scale, the
   sections are ordinary children, and one can be built out of something that is not a list.
 
-  For the record, since the name is theirs: HeroUI's `ListGroup` **is our `List`** — a Surface
+  For the record, since the name is theirs: The reference implementation's `ListGroup` **is our `List`** — a Surface
   container with Item · ItemPrefix · ItemContent · ItemTitle · ItemDescription · ItemSuffix,
   slot for slot. What ships here under that name is the thing neither of us had.
 
@@ -1137,7 +1137,7 @@
   decoration, and the disc is what makes it a target. `ghost` is the bare cross for a
   component already providing one.
 
-  Four sizes on a 24 / 28 / 32 / 40 box, `md` being HeroUI's measured and the `Dialog`'s. The
+  Four sizes on a 24 / 28 / 32 / 40 box, `md` being the reference implementation's measured and the `Dialog`'s. The
   bar is a ratio of the box rather than a table — a bar rotated a quarter turn spans
   `length / √2` per axis, so it is twice as long as the cross looks — which makes it one cross
   at four sizes instead of four drawings of one. **The stroke does not scale**: it is the
@@ -1156,7 +1156,7 @@
 - cb76b65: `List` — rows on a ground.
 
   `List.Item` and `List.ItemButton` with `ItemPrefix`, `ItemContent`, `ItemTitle`,
-  `ItemDescription` and `ItemSuffix`, on the anatomy `heroui-native`'s `ListGroup` uses.
+  `ItemDescription` and `ItemSuffix`, on the anatomy the reference implementation's `ListGroup` uses.
 
   **It is the `Accordion` with rows that do not open**, and it reads the same ladder, insets
   its separators the same way and lifts the same one variant. Two containers that look alike
@@ -1177,7 +1177,7 @@
   toggles it — a `Switch` in its suffix — which says out loud what it does and is reachable as
   the control it actually is.
 
-  **`ItemSuffix` draws nothing of its own.** HeroUI's puts a chevron there by default; the
+  **`ItemSuffix` draws nothing of its own.** The reference implementation's puts a chevron there by default; the
   trailing end of a settings row is a switch at least as often, and a slot that guesses makes
   you pass a child in order to render nothing.
 
@@ -1456,10 +1456,10 @@
 
 ### Patch Changes
 
-- 541cbe7: The toast stack collapses, like HeroUI's.
+- 541cbe7: The toast stack collapses, like the reference implementation's.
 
   It was a flex column with a gap: every card fully visible, one under the next, so six
-  toasts took six card heights down the screen. HeroUI's is a pile — one card in front, the
+  toasts took six card heights down the screen. The reference implementation's is a pile — one card in front, the
   rest scaled down and pushed toward the edge behind it, only their shoulders showing.
 
   Every card is now anchored to the same edge and its depth is entirely in its transform:
@@ -1472,7 +1472,7 @@
   keeps its timer and its place, and is promoted into view when the one in front leaves — so
   a burst of six shows all six instead of losing three.
 
-- 7557e46: The front toast can be thrown away with a swipe, like HeroUI's.
+- 7557e46: The front toast can be thrown away with a swipe, like the reference implementation's.
 
   Away from its edge — up on a top stack, down on a bottom one — past 50 points or 500 points
   a second, their thresholds, either alone being enough. Dragged the wrong way it resists
@@ -1484,7 +1484,7 @@
   any reasonable minimum, and dragging the second card out from under the first reads as a
   glitch rather than as a dismissal. `isSwipeable={false}` on the host turns it off.
 
-  Note that this dismisses **one** card and the pile empties a swipe at a time — HeroUI's
+  Note that this dismisses **one** card and the pile empties a swipe at a time — the reference implementation's
   gesture calls `hide(id)`, not a clear-all, and their provider has no such thing.
 
   The gesture runs on `react-native-gesture-handler`, already an optional peer, reached only
@@ -1521,16 +1521,16 @@
   a save succeeded has turned a good outcome into a bad one.
 
   It closes P5.18 as well as P5.18b: `Snackbar` and `Toast` are the same object under two
-  names, and HeroUI calls it `toast`.
+  names, and the reference implementation calls it `toast`.
 
 ## 0.9.1-alpha.44
 
 ### Patch Changes
 
-- 750a85a: `Dialog.Close` draws a cross when it is empty, like HeroUI's.
+- 750a85a: `Dialog.Close` draws a cross when it is empty, like the reference implementation's.
 
   It was a bare pressable that rendered whatever it was given and nothing when it was given
-  nothing, so `<Dialog.Close />` — the first line of HeroUI's own anatomy — put an invisible
+  nothing, so `<Dialog.Close />` — the first line of the reference implementation's own anatomy — put an invisible
   32 points in the corner. It now reads `system/close-button`, which draws the cross from two
   rotated bars, and the dialog's recipe resolves the box and the bar the way `Chip.Close`
   already did.
@@ -1572,7 +1572,7 @@
   No `variant`: the question a dialog asks is in its words, not in its fill.
 
   It also unblocks the `presentation` prop that `Select.Content` and `Menu.Content` are
-  written around but cannot offer — HeroUI has both, and `dialog` was half of what was
+  written around but cannot offer — the reference implementation has both, and `dialog` was half of what was
   missing.
 
 ## 0.9.1-alpha.43
@@ -1582,7 +1582,7 @@
 - ef43606: `BottomSheet` — Trigger · Overlay · Content · Handle · Title · Description · Close
 
   **Built on this library's own peers rather than on `@gorhom/bottom-sheet`**, which is what
-  HeroUI wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
+  the reference implementation wraps. A sheet that slides, springs and dismisses is a pan gesture and a shared
   value; taking a dependency for that would put a second animation library in every app that
   installs one component. What it costs is their snap points and their scroll integration —
   both worth having, and both worth their own change rather than a dependency.
@@ -1652,7 +1652,7 @@
 
   ### A rail with a knob on it, not a capsule with a core
 
-  The legacy proportions rather than HeroUI's: 6 to 10 points of rail under a 16 to 24 point
+  The legacy proportions rather than the reference implementation's: 6 to 10 points of rail under a 16 to 24 point
   disc. The knob overhangs the rail by half their difference on each side, and the rail
   reserves that overhang as a margin — without it the knob spills into whatever sits above
   and below, and the layout has no idea the control is thicker than its rail.
@@ -1806,7 +1806,7 @@
 
   `flex: 1` is `flexBasis: 0`. The measuring pass asks the panel how wide it wants to be, so
   there is no definite width for a zero basis to grow into: the row's content size is nothing,
-  the title collapses, and the panel holds that width. HeroUI writes `flex: 1` on the same
+  the title collapses, and the panel holds that width. The reference implementation writes `flex: 1` on the same
   node and gets away with it because their measuring pass hands the panel a definite width —
   ours asks a question a zero basis cannot answer.
 
@@ -1818,7 +1818,7 @@
   thirteen: a menu row is a title with an indicator beside it and sometimes a sentence under
   it, where a popover is prose alone.
 
-  `SubMenu` is not here. HeroUI ships it as its own component and it needs a second anchored
+  `SubMenu` is not here. The reference implementation ships it as its own component and it needs a second anchored
   panel whose trigger is a row of the first, which is worth its own change.
 
 ## 0.9.1-alpha.39
@@ -1886,7 +1886,7 @@
   sheet. Thirteen ems of the body size, about twenty-six characters a line — narrow on
   purpose. A popover is read at a glance, and a glance is two or three short lines rather
   than a paragraph; past that it stops being an aside and starts being a sheet with a tail.
-  It is where HeroUI's own panels land too, measured off their placement demos. A multiple of
+  It is where the reference implementation's own panels land too, measured off their placement demos. A multiple of
   the type rather than a number of points, so a theme that scales its type scales the panel
   with it.
 
@@ -1897,7 +1897,7 @@
   room for it went off the screen entirely — `start` and `end` were unusable and nothing said
   so until one was opened.
 
-  The panel may now overlap its own trigger. That is the right trade, and the one HeroUI's
+  The panel may now overlap its own trigger. That is the right trade, and the one the reference implementation's
   `useRelativePosition` makes too: a panel covering the button that opened it is legible, and
   a panel past the edge of the screen is not.
 
@@ -1911,12 +1911,12 @@
 
 - 7e04096: `Accordion` — Item · Trigger · Indicator · Content
 
-  P5.11, over the legacy `ExpansionPanel`. HeroUI Native calls it `accordion` and so does
+  P5.11, over the legacy `ExpansionPanel`. The reference implementation calls it `accordion` and so does
   this, which is also what the roadmap row now says.
 
   **The height is never measured.** The panel is mounted or it is not, and Reanimated's
   layout transition animates the row between the two — `LinearTransition.springify()` on
-  HeroUI's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
+  the reference implementation's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
   deliberately: a height is a longer distance than a rotation, and at the chevron's
   stiffness the same damping makes a long panel take almost half a second to settle.
 
@@ -1929,7 +1929,7 @@
   **The variant table is the `Card`'s, token for token.** An accordion in `default` _is_ a
   card with rows in it, and two containers that look alike but are declared apart drift —
   the drift showing up as an accordion sitting on a card with a fill one step off it.
-  `ghost` is the default and is HeroUI's own: rows separated by hairlines, on whatever page
+  `ghost` is the default and is the reference implementation's own: rows separated by hairlines, on whatever page
   they sit on.
 
   **The separators are the root's, drawn between its children.** A row that drew its own
@@ -1998,7 +1998,7 @@
   the same heights — so a select and a text input in one form read as one control rather
   than as two libraries meeting.
 
-  The visual values and the motion are HeroUI Native's, not the legacy component's. The
+  The visual values and the motion are the reference implementation's, not the legacy component's. The
   chevron turns 0 to −180° on their spring (damping 140, stiffness 1000, mass 4): heavily
   damped against a very high stiffness, so it arrives in a fifth of a second without
   overshooting, because an oscillating chevron reads as a bug rather than as motion. The
@@ -2028,11 +2028,11 @@
   chevron and the gap between them, and at that height the value gets nothing. The
   `TextField` keeps its `xs` because a field only has to hold text.
 
-  The panel's corner is `2xl`, not `3xl`. HeroUI's is their `--radius-3xl` on a base of 8,
+  The panel's corner is `2xl`, not `3xl`. The reference implementation's is their `--radius-3xl` on a base of 8,
   which is 24 points; our base is 12, so the same 24 is `2xl`. Reading their key rather than
   their number put a 36-point corner on it and made it read as a pill.
 
-  Two narrowings against HeroUI, both deliberate. `placement` is `top` or `bottom` only: a
+  Two narrowings against the reference implementation, both deliberate. `placement` is `top` or `bottom` only: a
   list as wide as its own field hanging off the side of it reads as a menu, and `start` and
   `end` belong to `Popover`. And there is no `presentation` prop — the bottom-sheet and
   dialog presentations need `BottomSheet` and `Dialog`, which do not exist yet.
@@ -2162,28 +2162,28 @@
   `Avatar.Image` is absolutely positioned over `Avatar.Fallback`, and an `Image` with nothing
   decoded yet draws nothing — so the initials show while the photo loads and **stay if the URL
   is wrong**, with no load-state machine, no `onError` to remember, and nothing to get out of
-  sync. HeroUI runs a status enum for this; a stacking order says the same thing and cannot
+  sync. The reference implementation runs a status enum for this; a stacking order says the same thing and cannot
   disagree with itself. JSX order between the two slots is therefore free.
 
   `variant` is the `Chip`'s eleven names, meaning here what they mean there — an avatar is a
   token _about_ a person or a thing, which is the category the `Chip` established. The three
   status families are present because an avatar reports as often as it identifies: a red frame
   for the account that failed to sync, a green one for the person who is online. It is
-  HeroUI's `variant × color` matrix said once.
+  the reference implementation's `variant × color` matrix said once.
 
   `size` sets both sides, because an avatar is a square before it is a circle — 32, 40, 48, 64,
-  HeroUI's three steps plus the one our ladder adds below them. The glyph inside the fallback
+  the reference implementation's three steps plus the one our ladder adds below them. The glyph inside the fallback
   runs ahead of the initials at the top of the scale, because two letters fill a circle that
   one person-icon has to sit inside with air around it.
 
-  `radius` defaults to `full`, where HeroUI fixes one large radius for all three sizes — which
+  `radius` defaults to `full`, where the reference implementation fixes one large radius for all three sizes — which
   makes their small avatars round and their large ones squircles.
 
   **No default glyph.** XAUI publishes no icon set, so the mark is always the caller's. What
   `Avatar.Fallback` does instead is publish the frame's resolved size and colour to
   `IconContext`, so an `Icon` written inside it needs no props at all.
 
-  The photo fades in over 200ms on `onLoad` — HeroUI's timing — driven by a shared value
+  The photo fades in over 200ms on `onLoad` — the reference implementation's timing — driven by a shared value
   rather than a mount animation, because the node has to be mounted from the first render or
   it never fetches. `animation={false}` skips it and mounts no worklet.
 
@@ -2210,11 +2210,11 @@
   accent announces the brand where there is nothing yet to announce; **no `tertiary` and no
   `ghost`**, because a skeleton with a border and no fill is an empty box.
 
-  HeroUI reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
+  The reference implementation reaches the same grey from `muted` at 30% opacity. Naming the token instead is what
   lets a theme move the skeleton by moving `default`, rather than by discovering that a
   percentage of a text colour is where the placeholder grey came from.
 
-  **No shimmer**, where HeroUI's default is one: a shimmer is a gradient sweeping across the
+  **No shimmer**, where the reference implementation's default is one: a shimmer is a gradient sweeping across the
   block, a gradient needs `react-native-svg`, and that is an optional peer a component in the
   core cannot require. One animation, so `animation` is a boolean rather than a name to
   choose between — the block breathes between full opacity and a half, a second each way.
@@ -2272,7 +2272,7 @@
   `Animated.View` that collapses a section takes the thickness and the ink from the recipe and
   the height from a shared value.
 
-  `size` is the thickness — `xs` is HeroUI's `thin`, one device pixel, and `lg` is their
+  `size` is the thickness — `xs` is the reference implementation's `thin`, one device pixel, and `lg` is their
   `thick`, six points. **It defaults to `xs`**, the one place in the library that does not
   default to `md`: a rule you notice is a rule that is too thick.
 
@@ -2295,13 +2295,13 @@
   named: deleting is a `danger` wait. **No `ghost`**, because a spinner with no ink is not a
   spinner, and **no `-soft` slices**, because a soft slice is a fill softened.
 
-  HeroUI fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
+  The reference implementation fades a single arc from opaque to 55%, which needs an SVG `linearGradient` and
   therefore `react-native-svg` — an **optional peer**, which a component in the
   fifteen-component core cannot require. Two circles of one ink at two opacities read as the
   same figure, cost two views, and pull in nothing. The track is what does the work: a
   rotating three-quarter ring on its own reads as broken rather than as busy.
 
-  `size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, HeroUI's
+  `size` is the diameter and the only measurement a circle has — 16, 20, 24, 32, the reference implementation's
   three steps plus the one our ladder adds between the first two. The stroke thickens once,
   at `lg`.
 
@@ -2412,7 +2412,7 @@
 
   The eighth entry of the core. **The root is the row, not the box**: it is the pressable, so
   tapping the label ticks the checkbox — which is the whole reason `Checkbox.Label` is a slot
-  here rather than a `Text` you put beside the component and wire up yourself. HeroUI needs a
+  here rather than a `Text` you put beside the component and wire up yourself. The reference implementation needs a
   second component (`ControlField`) for that; the plan's slots for this one are Indicator ·
   Label, and this is why.
 
@@ -2432,7 +2432,7 @@
   a box with no border and no fill is nothing at all — plus the four sizes, `radius`,
   `isInvalid` (which drops the resting fill and outranks the tint) and `isDisabled`.
 
-  `isIndeterminate` is ours and not HeroUI's: the legacy checkbox had it, a "select all" is
+  `isIndeterminate` is ours and not the reference implementation's: the legacy checkbox had it, a "select all" is
   what it is for, and `accessibilityState.checked: 'mixed'` is something only the component
   can say. A press resolves it to selected rather than toggling into it.
 
@@ -2485,7 +2485,7 @@
   suffix is most often a control and one that swallowed its own taps would be a reveal toggle
   you cannot press. A disabled `Input` takes the touches from both decorators all the same.
 
-  `InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one HeroUI's
+  `InputGroup.Icon` is the slot `Button`, `Chip` and `Alert` already have, and the one the reference implementation's
   component does not: a glyph one step above the field's type, in the theme's
   `fieldPlaceholder`, so a form does not carry a hard-coded `#888` on every field.
 
@@ -2499,11 +2499,11 @@
 
 ### Patch Changes
 
-- 0c5435f: The `field` radius aligns on HeroUI's — 21 points becomes 12
+- 0c5435f: The `field` radius aligns on the reference implementation's — 21 points becomes 12
 
   `buildRadius` derived it as `base * 1.75`, which on the default base of 12 put a 48-tall
   field at 21 — 87% of its geometric maximum, so it read as a gélule rather than as a rounded
-  box. HeroUI reaches 12 for the same control from the other side of the scale: their
+  box. The reference implementation reaches 12 for the same control from the other side of the scale: their
   `--radius-field` is an alias of their `--radius-xl`, and their base is 8 where ours is 12.
 
   It coincides with `lg` at the default base and stays its own key, because that is what lets
@@ -2534,7 +2534,7 @@
   and `.Error` are literally the `Input`'s slots, re-exported rather than wrapped.
 
   Only `TextArea.Field` differs, by three things: `multiline`, the text pinned to the top, and
-  a height counted in lines. That is HeroUI's answer too — their `TextArea` is twenty lines
+  a height counted in lines. That is the reference implementation's answer too — their `TextArea` is twenty lines
   rendering their `Input` with the same three defaults.
 
   `rows` (default `3`) and `maxRows` are **raw values** (R6), like `color`: they resolve
@@ -2582,7 +2582,7 @@
   **The box takes the `lg` radius, 12 points, not `field`.** A field is wide, so 21 on a
   48-tall one reads as a rounded rectangle; a code box is very nearly square — 44 by 48 at
   `md`, 36 by 40 at `sm` — where the geometric maximum is 22, so the same 21 is a pill in all
-  but name and is clamped to one outright at the small end. Twelve is where HeroUI lands for
+  but name and is clamped to one outright at the small end. Twelve is where the reference implementation lands for
   the same box from the other direction: their `field` radius is their `xl`, and their scale's
   base is 8 where ours is 12.
 
@@ -2614,7 +2614,7 @@
   keep in step — and why `TextInputProps` are on the field rather than on the root.
 
   The first real use of the theme's `field*` family, derived in P0 and unread since. Four
-  variants, the library's emphasis levels narrowed like the `Card`'s, splitting HeroUI's
+  variants, the library's emphasis levels narrowed like the `Card`'s, splitting the reference implementation's
   two-name `primary | secondary` by saying what each of their ends already is: `primary` is
   their field fill plus the theme's `field` shadow, `secondary` their neutral fill and the
   default here, `tertiary` the border alone, `ghost` neither.
@@ -2626,7 +2626,7 @@
   against the box's own padding, so the JSX is identical either way and nothing is
   reparented; the field pays for the room and the box grows by the same amount.
 
-  Visually aligned with `heroui-native`: a 48pt minimum, 12pt of horizontal padding, a 16/24
+  Visually aligned with the reference implementation: a 48pt minimum, 12pt of horizontal padding, a 16/24
   label above the field and a 14/20 line below it at `md`. The height is a **minimum** rather
   than fixed — the one place this component departs from the `Button`'s rule, because a
   `multiline` field holds the user's own text and has to grow.
@@ -2645,11 +2645,11 @@
   `Alert.Icon`, `Alert.Content`, `Alert.Title`, `Alert.Description` and `Alert.Close`, laid
   out as a row of three columns spaced by the root's `gap` alone.
 
-  Nine variants: the `Card`'s `surface` for the neutral level — HeroUI's alert root, token
+  Nine variants: the `Card`'s `surface` for the neutral level — the reference implementation's alert root, token
   for token, shadow included — and the `Chip`'s status ladder for the rest, each family in
   its full and soft slice.
 
-  Visually aligned with `heroui-native`: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
+  Visually aligned with the reference implementation: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24
   title above a 14/20 description and an 18pt icon at `md`. The icon's optical offset is
   derived from the title's leading rather than hard-coded, so it stays right at all four
   sizes.
@@ -2677,11 +2677,11 @@
   `Chip.Label`, `Chip.Icon`, `Chip.Dot`, `Chip.Avatar` and `Chip.Close`, spaced by the root
   alone, so JSX order is screen order and there is no `startContent` / `endContent`.
 
-  Eleven flat variants replace HeroUI's `variant × color` matrix: the `Button`'s five-step
+  Eleven flat variants replace the reference implementation's `variant × color` matrix: the `Button`'s five-step
   emphasis ladder plus the three status families it deliberately refused — a chip reports an
   outcome, so `success`, `warning` and `danger` each land here with their soft slice.
 
-  Visually aligned with `heroui-native`: 12pt of horizontal padding, a 14/20 label and a 28pt
+  Visually aligned with the reference implementation: 12pt of horizontal padding, a 14/20 label and a 28pt
   `md`, with the height fixed rather than derived from vertical padding so a chip carrying an
   avatar still lines up with the one beside it.
 
@@ -2739,7 +2739,7 @@
   what it holds. `isPressable` turns the surface into a `PressableFeedback` with a press
   wash, `accessibilityRole="button"` and the shared scale.
 
-  The rendering is HeroUI's card measured — `md` is 16pt of padding, a 24pt radius, an
+  The rendering is the reference implementation's card measured — `md` is 16pt of padding, a 24pt radius, an
   18/28 title in `medium` over a 16/24 description, no border on a filled surface — reached
   through our own vocabulary rather than through their utility classes, and with the gaps the
   component owns instead of leaving to the call site.
@@ -2756,7 +2756,7 @@
   The clip lives on the layer rather than on the root: `overflow: 'hidden'` cuts the node's
   own shadow on iOS, so clipping the card would cost a `default` one the elevation its variant
   just gave it. `radius` therefore moves both slots together — a corner that moved only the
-  root would round the card and leave its photo square. HeroUI reaches the same feature
+  root would round the card and leave its photo square. The reference implementation reaches the same feature
   through a `background` **prop** and clips on both nodes, losing the shadow.
 
   **The light `surfaceSecondary` moves up half a step**, `#f4f4f5` → `#ececee`. It sat so
@@ -2837,7 +2837,7 @@
 
 - 863cc86: `Typography` and `TextSpan` — the first entry of the v1 core
 
-  Ten roles, aligned with HeroUI Native's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
+  Ten roles, aligned with the reference implementation's `text`: `h1`–`h6`, `body`, `body-sm`, `body-xs` and
   `code`. Each role fixes size, line height, weight and family **together**, which is why
   there is no `size` prop and no `weight` prop — the combinations they allowed (a heading in
   a light weight, a caption in a display size) become unwritable rather than discouraged.
@@ -2932,7 +2932,7 @@
 ### Patch Changes
 
 - cd06df1: Fix the press scale, which lurched on wide controls, and align the touch feedback with
-  HeroUI's values.
+  the reference implementation's values.
 
   **The scale was a flat `0.975` for every control.** What the eye reads is the displacement,
   not the ratio: that same ratio moves a 360pt row nine points and a 96pt chip two. It is now

--- a/packages/native/src/__tests__/components/toast/toast.utils.test.ts
+++ b/packages/native/src/__tests__/components/toast/toast.utils.test.ts
@@ -10,7 +10,7 @@ describe('toastStackStyle', () => {
     })
   })
 
-  it('peeks 10 points and shrinks 3% per step, HeroUI’s values', () => {
+  it('peeks 10 points and shrinks 3% per step, the reference implementation’s values', () => {
     expect(toastStackStyle(1, 'top', 3)).toMatchObject({
       translateY: 10,
       scale: 0.97,
@@ -27,7 +27,7 @@ describe('toastStackStyle', () => {
   })
 
   it('keeps going past the last visible card rather than piling on it', () => {
-    // HeroUI clamps only the front side of the interpolation. Two cards at the same depth
+    // The reference implementation clamps only the front side of the interpolation. Two cards at the same depth
     // would read as one, which is the bug this asserts against.
     expect(toastStackStyle(4, 'top', 3).translateY).toBe(40)
     expect(toastStackStyle(3, 'top', 3).translateY).not.toBe(

--- a/packages/native/src/components/accordion/accordion.animation.ts
+++ b/packages/native/src/components/accordion/accordion.animation.ts
@@ -9,7 +9,7 @@ import { Easing, FadeIn, FadeOut, LinearTransition } from 'react-native-reanimat
  * content grows afterwards — an image loading, a list filling — would be stuck at the
  * height it had when it was measured.
  *
- * HeroUI's spring, and stiffer than the chevron's: 1600 against 1000. A height is a
+ * The reference implementation's spring, and stiffer than the chevron's: 1600 against 1000. A height is a
  * bigger distance than a rotation, and at the chevron's stiffness the same damping makes
  * a long panel take almost half a second to settle.
  */

--- a/packages/native/src/components/accordion/accordion.md
+++ b/packages/native/src/components/accordion/accordion.md
@@ -158,7 +158,7 @@ Everything `View` takes, plus `ViewStyle` as props.
 
 **The height is never measured.** The panel is mounted or it is not, and Reanimated's
 layout transition animates the row between the two — `LinearTransition.springify()` on
-HeroUI's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
+The reference implementation's numbers, damping 140 against stiffness **1600**. Stiffer than the chevron's 1000
 on purpose: a height is a longer distance than a rotation, and at the chevron's stiffness
 the same damping makes a long panel take almost half a second to settle.
 
@@ -178,12 +178,12 @@ mass 4. It is a worklet, so it keeps turning while the panel's content mounts.
 
 ## The four levels
 
-| ours        | HeroUI    | fill               |
-| ----------- | --------- | ------------------ |
-| `primary`   | `surface` | `surface`          |
-| `secondary` | —         | `surfaceSecondary` |
-| `tertiary`  | —         | a border, no fill  |
-| `ghost`     | `default` | none — the default |
+| ours        | The reference implementation | fill               |
+| ----------- | ---------------------------- | ------------------ |
+| `primary`   | `surface`                    | `surface`          |
+| `secondary` | —                            | `surfaceSecondary` |
+| `tertiary`  | —                            | a border, no fill  |
+| `ghost`     | `default`                    | none — the default |
 
 The tokens are the `Card`'s — an accordion in `primary` **is** a card with rows in it, and
 two containers that look alike but are declared apart drift. Only the names differ, and

--- a/packages/native/src/components/accordion/accordion.recipe.ts
+++ b/packages/native/src/components/accordion/accordion.recipe.ts
@@ -59,7 +59,7 @@ const SIZES: Record<Size, SizeStep> = {
 }
 
 /**
- * The trigger is taller than it is wide-padded, and deliberately: HeroUI puts sixteen
+ * The trigger is taller than it is wide-padded, and deliberately: The reference implementation puts sixteen
  * points above and below against twelve on the sides, which is what gives a row of plain
  * text a target big enough to hit without a border to aim at.
  */
@@ -147,7 +147,7 @@ export const accordionRecipe = createRecipe({
    * edge to be inset from, so its rows run the full width and the hairline runs with them
    * — which is the difference between a list on a page and a list in a box.
    *
-   * `primary` is the only one lifted. It is the one that reads as a card, and HeroUI puts
+   * `primary` is the only one lifted. It is the one that reads as a card, and the reference implementation puts
    * their `--shadow-surface` on exactly that variant. `secondary` and `tertiary` have too
    * little fill to lift — a shadow under either would read as dirt rather than as height
    * — and in dark mode the theme's surface shadow is already nothing (§4), which is why

--- a/packages/native/src/components/accordion/accordion.type.ts
+++ b/packages/native/src/components/accordion/accordion.type.ts
@@ -29,7 +29,7 @@ export type AccordionSlot =
  * the `Button`'s five nor the `Card`'s four read that cleanly — both put `default`
  * somewhere in the middle of an order it does not name a position in.
  *
- * `ghost` is the default here, and it is HeroUI's own `default`: rows separated by
+ * `ghost` is the default here, and it is the reference implementation's own `default`: rows separated by
  * hairlines, on whatever page they sit on. `primary` is their `surface`.
  */
 export type AccordionVariant = 'primary' | 'secondary' | 'tertiary' | 'ghost'

--- a/packages/native/src/components/alert/alert-icon.tsx
+++ b/packages/native/src/components/alert/alert-icon.tsx
@@ -18,7 +18,7 @@ import type { AlertIconProps } from './alert.type'
  * The size and the colour come from the root, which resolved them once; an explicit `size`
  * or `color` still wins, and that is the escape hatch for the alert whose icon has to
  * disagree with its variant — a neutral `default` surface with a green check, which is how
- * HeroUI colours its own.
+ * The reference implementation colours its own.
  *
  * **This slot renders a box**, unlike `Button.Icon` and `Chip.Icon`, which hand their
  * props straight to a third-party component. It has to: an alert's icon sits beside a
@@ -26,7 +26,7 @@ import type { AlertIconProps } from './alert.type'
  * line's cap-height means offsetting it by half the leading. That is a style, and a style
  * needs a node — which is also what lets this slot carry style props at all.
  *
- * **No default glyph**, where HeroUI ships three. XAUI publishes no icon set — `@xaui/icons`
+ * **No default glyph**, where the reference implementation ships three. XAUI publishes no icon set — `@xaui/icons`
  * was deleted in P0 — so an icon here is always the caller's, and the alert's job is to
  * size and colour it rather than to choose it.
  */

--- a/packages/native/src/components/alert/alert.md
+++ b/packages/native/src/components/alert/alert.md
@@ -121,7 +121,7 @@ with another.
 </Alert>
 ```
 
-This is HeroUI's alert written out: a neutral surface with the status carried by the icon
+This is the reference implementation's alert written out: a neutral surface with the status carried by the icon
 alone. There it is what `status` does; here the variant decides both the surface and the
 foreground, so an icon that has to disagree says so with a raw `color` (R7).
 
@@ -148,7 +148,7 @@ alert is a surface: it is as tall as the message it carries.
 | `md`   | 12      | 12  | 16/24 | 14/20       | 18   | 3           |
 | `lg`   | 16      | 14  | 18/28 | 16/24       | 20   | 4           |
 
-`md` is HeroUI's alert measured: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24 title
+`md` is the reference implementation's alert measured: 12pt of padding, a 12pt gap, a 24pt radius, a 16/24 title
 above a 14/20 description, an 18pt icon. The icon's offset is **half the title's leading**
 rather than their hard-coded 3.5px — it lands on the same 3 at `md`, and stays right at
 the other three sizes.
@@ -171,7 +171,7 @@ takes the `Card`'s vocabulary for its neutral level and the `Chip`'s for the res
 | `danger-soft`  | `dangerSoft`  | `dangerSoftForeground`  | —      |
 
 `default` is the `Card`'s `default`, token for token — the surface fill and the surface
-shadow, which is HeroUI's alert root exactly. The elevation belongs to that one variant: a
+shadow, which is the reference implementation's alert root exactly. The elevation belongs to that one variant: a
 tinted alert already separates itself by its fill, and a shadow under it would read as dirt.
 
 `tertiary` and `ghost` are absent: an alert without a surface is a paragraph. The outlined
@@ -240,7 +240,7 @@ Everything `View` accepts, every `ViewStyle` key it does not already claim (R14)
 The three forms of `Icon` — `as`, a raw SVG child, `source` — plus the `ViewStyle` keys of
 its box as props (R14). `size` and `color` default to what the root resolved.
 
-**No default glyph**, where HeroUI ships three. XAUI publishes no icon set — `@xaui/icons`
+**No default glyph**, where the reference implementation ships three. XAUI publishes no icon set — `@xaui/icons`
 was deleted in P0 — so the icon is always yours, and the alert's job is to size and colour
 it rather than to choose it.
 

--- a/packages/native/src/components/alert/alert.recipe.ts
+++ b/packages/native/src/components/alert/alert.recipe.ts
@@ -47,7 +47,7 @@ const VARIANT_TOKENS: Record<AlertVariant, VariantTokens> = {
 /**
  * How far the description sits behind the title.
  *
- * HeroUI uses the `muted` token here. This is a fraction of the title's own colour
+ * The reference implementation uses the `muted` token here. This is a fraction of the title's own colour
  * instead, for the reason the `Card` gives: an alert's foreground is not fixed — a
  * `danger` alert paints its text on a saturated red, and a grey `muted` on that is the one
  * combination that stops being readable. The value is `muted` solved for, so an untinted
@@ -65,7 +65,7 @@ const DESCRIPTION_OPACITY = 0.6
  *
  * The icon's `paddingTop` is **half the title's leading**: a glyph is a solid box and a
  * line of text is not, so aligning their boxes puts the glyph visibly above the cap-height
- * it should sit level with. HeroUI hard-codes 3.5px for their single size; deriving it
+ * it should sit level with. The reference implementation hard-codes 3.5px for their single size; deriving it
  * gives the same 3 at `md` and keeps the other three sizes right.
  */
 function sizeAxis(step: SizeStep) {
@@ -112,7 +112,7 @@ type SizeStep = {
 }
 
 /**
- * `md` is the anchor, and it is HeroUI's alert measured: 12pt of padding, a 12pt gap, a
+ * `md` is the anchor, and it is the reference implementation's alert measured: 12pt of padding, a 12pt gap, a
  * 24pt radius, a 16/24 title above a 14/20 description, an 18pt icon. Their scale has a
  * single step; ours moves around that one, a step of type and a level of radius at a time.
  */
@@ -204,7 +204,7 @@ export const alertRecipe = createRecipe({
    *
    * The icon takes the **title's** colour rather than a status colour of its own — on a
    * `danger` alert the readable colour is the one the title already uses, and on a
-   * `danger-soft` one that token *is* the red. HeroUI arrives at the same place from the
+   * `danger-soft` one that token *is* the red. The reference implementation arrives at the same place from the
    * other direction, colouring the icon by status on a neutral surface; here the variant
    * decides both, and an icon that has to disagree with its alert says so itself with
    * `<Alert.Icon color={…} />`.

--- a/packages/native/src/components/alert/alert.type.ts
+++ b/packages/native/src/components/alert/alert.type.ts
@@ -28,7 +28,7 @@ export type AlertSlot =
  * status vocabulary of the `Chip` for the rest.
  *
  * - **`default`** — the `surface` fill and the surface shadow, exactly the `Card`'s
- *   `default`. This is HeroUI's alert: a neutral card, with the status carried by the icon
+ *   `default`. This is the reference implementation's alert: a neutral card, with the status carried by the icon
  *   rather than by the background.
  * - **`primary` / `secondary`** — the full accent and its soft slice, for the
  *   informational alert that is not an outcome.

--- a/packages/native/src/components/autocomplete/autocomplete-content.tsx
+++ b/packages/native/src/components/autocomplete/autocomplete-content.tsx
@@ -15,7 +15,7 @@ import { AutocompleteSearch } from './autocomplete-search'
 import { AutocompleteProvider, useAutocomplete } from './autocomplete.context'
 import type { AutocompleteContentProps } from './autocomplete.type'
 
-/** HeroUI's, point for point: eight from the trigger, twelve from every screen edge. */
+/** the reference implementation's, point for point: eight from the trigger, twelve from every screen edge. */
 const DEFAULT_OFFSET = 8
 const DEFAULT_INSETS = { top: 12, bottom: 12, start: 12, end: 12 }
 

--- a/packages/native/src/components/avatar/avatar-fallback.tsx
+++ b/packages/native/src/components/avatar/avatar-fallback.tsx
@@ -22,7 +22,7 @@ import type { AvatarFallbackProps } from './avatar.type'
  * It is a layer rather than a state: `Avatar.Image` is absolutely positioned over it, so
  * this slot is simply always there. Nothing here knows whether an image exists.
  *
- * **No default glyph**, where HeroUI ships a person icon. XAUI publishes no icon set —
+ * **No default glyph**, where the reference implementation ships a person icon. XAUI publishes no icon set —
  * `@xaui/icons` was deleted in P0 — so the mark is always the caller's. What this slot does
  * instead is publish the frame's resolved size and colour to `IconContext`, so an `Icon`
  * written inside it needs no props at all.

--- a/packages/native/src/components/avatar/avatar-image.tsx
+++ b/packages/native/src/components/avatar/avatar-image.tsx
@@ -10,7 +10,7 @@ import { useStyleProps } from '../../system/style-props'
 import { avatarSheet } from './avatar.style'
 import type { AvatarImageProps } from './avatar.type'
 
-/** Long enough to read as an arrival, short enough not to delay a face. HeroUI's 200ms. */
+/** Long enough to read as an arrival, short enough not to delay a face. The reference implementation's 200ms. */
 const FADE_DURATION = 200
 
 /**

--- a/packages/native/src/components/avatar/avatar.md
+++ b/packages/native/src/components/avatar/avatar.md
@@ -90,12 +90,12 @@ a person or a thing, which is the category the `Chip` established. The three sta
 are here because an avatar reports as often as it identifies: a red frame for the account
 that failed to sync, a green one for the person who is online.
 
-It is HeroUI's `variant × color` matrix said once. Their `default` is this `default`, and
+It is the reference implementation's `variant × color` matrix said once. Their `default` is this `default`, and
 their `soft` crossed with five colours is `secondary` plus the five `-soft` names.
 
 ### `size` sets both sides
 
-Thirty-two, forty, forty-eight and sixty-four — HeroUI's three steps plus the `xs` our
+Thirty-two, forty, forty-eight and sixty-four — the reference implementation's three steps plus the `xs` our
 ladder adds below them, which is the size an avatar is inside a `Chip` or a list row. An
 avatar is a square before it is a circle, so there is one measurement rather than a width
 and a height that can drift apart.
@@ -106,7 +106,7 @@ to sit inside with air around it.
 
 ### `radius` — a circle at every size
 
-Where HeroUI fixes one large radius for all three sizes, which makes their small avatars
+Where the reference implementation fixes one large radius for all three sizes, which makes their small avatars
 round and their large ones squircles. `full` says the shape the name means once, and
 `radius` is still there for the logo that wants a square.
 
@@ -117,7 +117,7 @@ round and their large ones squircles. `full` says the shape the name means once,
 `Avatar.Image` is absolutely positioned over `Avatar.Fallback`, and an `Image` with nothing
 decoded yet draws nothing. So the initials show while the photo loads and **stay if the URL
 is wrong** — with no load-state machine, no `onError` to remember, and nothing to get out of
-sync. HeroUI runs a status enum for this; a stacking order says the same thing and cannot
+sync. The reference implementation runs a status enum for this; a stacking order says the same thing and cannot
 disagree with itself.
 
 JSX order between the two is therefore free. Write the image first, as the anatomy reads.
@@ -130,7 +130,7 @@ colour to `IconContext`, so an `Icon` written inside it needs no props at all.
 
 ### The fade
 
-`Avatar.Image` fades in over 200ms on `onLoad` — HeroUI's timing. It runs off a shared value
+`Avatar.Image` fades in over 200ms on `onLoad` — the reference implementation's timing. It runs off a shared value
 rather than off a mount animation, because the node has to be mounted from the first render
 or it never fetches: the moment worth animating is the decode, not the mount.
 `animation={false}` skips it and mounts no worklet.

--- a/packages/native/src/components/avatar/avatar.recipe.ts
+++ b/packages/native/src/components/avatar/avatar.recipe.ts
@@ -10,7 +10,7 @@ const SLOTS = ['root', 'fallback', 'initials', 'icon'] as const
  * a thing, which is the category the `Chip` established, so a name means here what it
  * means there.
  *
- * They colour the **frame**, which is all that shows when there is no image. HeroUI says
+ * They colour the **frame**, which is all that shows when there is no image. The reference implementation says
  * the same set as a `variant × color` matrix; these eleven flat names say it once.
  *
  * No `…Pressed` roles: an avatar is not a control. One inside a pressable row is a child of
@@ -34,12 +34,12 @@ const VARIANT_TOKENS: Record<AvatarVariant, VariantTokens> = {
  * `size` drives the diameter and the type inside it — **never a width of its own**. An
  * avatar is a square before it is a circle, so the one measurement sets both sides.
  *
- * Forty, forty-eight and sixty-four are HeroUI's three steps; `xs` is the thirty-two our
+ * Forty, forty-eight and sixty-four are the reference implementation's three steps; `xs` is the thirty-two our
  * ladder adds below them, which is the size an avatar is inside a `Chip` or a list row.
  *
  * The glyph runs ahead of the initials at the top of the scale — 12, 14, 16, 20 against
  * 12, 12, 14, 16 — because two letters fill a circle that one person-icon has to sit
- * inside with air around it. HeroUI ships the same two ladders, for the same reason.
+ * inside with air around it. The reference implementation ships the same two ladders, for the same reason.
  */
 function sizeAxis(step: SizeStep) {
   return (theme: XAUITheme): SlotStyles<AvatarSlot> => {
@@ -132,7 +132,7 @@ export const avatarRecipe = createRecipe({
   },
 
   /**
-   * A circle at every size, where HeroUI fixes one large radius for all three — which
+   * A circle at every size, where the reference implementation fixes one large radius for all three — which
    * makes their small avatars round and their large ones squircles. `full` says the shape
    * the name means once, and `radius` is still there for the logo that wants a square.
    */

--- a/packages/native/src/components/avatar/avatar.tsx
+++ b/packages/native/src/components/avatar/avatar.tsx
@@ -30,7 +30,7 @@ import type { AvatarProps } from './avatar.type'
  * **The fallback is not a state, it is the layer underneath.** `Avatar.Image` is absolutely
  * positioned over `Avatar.Fallback`, so the fallback is what shows before the image decodes
  * and what shows again if the URL is wrong — with no load-state machine, no `onError` to
- * remember, and nothing to get out of sync. HeroUI runs a status enum for this; a stacking
+ * remember, and nothing to get out of sync. The reference implementation runs a status enum for this; a stacking
  * order says the same thing and cannot disagree with itself.
  *
  * R3 — a stringifiable tree becomes the initials, which is the majority case:

--- a/packages/native/src/components/avatar/avatar.type.ts
+++ b/packages/native/src/components/avatar/avatar.type.ts
@@ -29,7 +29,7 @@ export type AvatarSlot = 'root' | 'fallback' | 'initials' | 'icon'
  * often as it identifies — a red frame for the account that failed to sync, a green one for
  * the person who is online.
  *
- * It is HeroUI's `variant × color` matrix said once: their `default` is this `default`, and
+ * It is the reference implementation's `variant × color` matrix said once: their `default` is this `default`, and
  * their `soft` crossed with five colours is `secondary` plus the five `-soft` names.
  */
 export type AvatarVariant =

--- a/packages/native/src/components/bottom-sheet/bottom-sheet.md
+++ b/packages/native/src/components/bottom-sheet/bottom-sheet.md
@@ -210,7 +210,7 @@ panel rather than a modal, and a dimmed page behind one reads oddly — leave
 
 ## Not `@gorhom/bottom-sheet`
 
-HeroUI wraps it. A sheet that slides, springs and dismisses is a pan gesture and a shared
+The reference implementation wraps it. A sheet that slides, springs and dismisses is a pan gesture and a shared
 value; taking a dependency for that would put a second animation library in every app that
 installs one component. What we lose is their scroll integration, which is worth having and
 worth its own change rather than a dependency.

--- a/packages/native/src/components/bottom-sheet/bottom-sheet.recipe.ts
+++ b/packages/native/src/components/bottom-sheet/bottom-sheet.recipe.ts
@@ -3,7 +3,7 @@ import type { RadiusKey, XAUITheme } from '../../theme/theme.type'
 
 const SLOTS = ['overlay', 'content', 'handle', 'title', 'description'] as const
 
-/** The grab bar: HeroUI's proportions, in points because a pill is not a gap. */
+/** The grab bar: The reference implementation's proportions, in points because a pill is not a gap. */
 const HANDLE = { width: 36, height: 4 } as const
 
 /**
@@ -55,7 +55,7 @@ export const bottomSheetRecipe = createRecipe({
       backgroundColor: theme.colors.overlay,
       padding: theme.spacing(5),
       gap: theme.spacing(2),
-      // HeroUI's `--radius-4xl` on a base of 8 is 32 points; the nearest on our base of 12
+      // The reference implementation's `--radius-4xl` on a base of 8 is 32 points; the nearest on our base of 12
       // is `3xl` at 36. A sheet's corner is the largest in the library because it is the
       // only edge of it you can see.
       borderTopStartRadius: theme.radius['3xl'],

--- a/packages/native/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/packages/native/src/components/bottom-sheet/bottom-sheet.tsx
@@ -26,7 +26,7 @@ import type { BottomSheetProps } from './bottom-sheet.type'
  * **The root renders no node.** It holds one piece of state and the styles the slots read.
  *
  * It is built on this library's own peers rather than on `@gorhom/bottom-sheet`, which is
- * what HeroUI wraps. A sheet that slides, springs and dismisses is a pan gesture and a
+ * what the reference implementation wraps. A sheet that slides, springs and dismisses is a pan gesture and a
  * shared value; taking a dependency for that would put a second animation library in every
  * app that installs one component.
  */

--- a/packages/native/src/components/card/card-background.tsx
+++ b/packages/native/src/components/card/card-background.tsx
@@ -26,7 +26,7 @@ import type { CardBackgroundProps } from './card.type'
  * **The clip lives here, not on the root.** React Native's `overflow: 'hidden'` cuts the
  * node's own shadow on iOS, so putting it on the card would cost a `default` card the
  * elevation its variant just gave it. This layer carries its own `overflow` and the card's
- * radius, which rounds the image without touching the shadow — where HeroUI clips on both
+ * radius, which rounds the image without touching the shadow — where the reference implementation clips on both
  * and loses it.
  *
  * Two forms, like `Icon`: `source` renders the image, and anything else is a layer of the

--- a/packages/native/src/components/card/card.md
+++ b/packages/native/src/components/card/card.md
@@ -230,7 +230,7 @@ treatment.
 **The clip lives on the layer, not on the root.** `overflow: 'hidden'` cuts the node's own
 shadow on iOS, so putting it on the card would cost a `default` card the elevation its
 variant just gave it. This slot carries its own `overflow` and the card's radius — which is
-also why `radius` moves both slots together. HeroUI clips on both and loses the shadow.
+also why `radius` moves both slots together. The reference implementation clips on both and loses the shadow.
 
 Two forms, like `Icon`: `source` renders the image, and anything else is the caller's own
 layer, already positioned and clipped.

--- a/packages/native/src/components/card/card.recipe.ts
+++ b/packages/native/src/components/card/card.recipe.ts
@@ -101,7 +101,7 @@ type SizeStep = {
 }
 
 /**
- * `md` is the anchor, and it is HeroUI's card measured: 16pt of padding, a 24pt radius,
+ * `md` is the anchor, and it is the reference implementation's card measured: 16pt of padding, a 24pt radius,
  * an 18/28 title one step above a 16/24 description. Their scale has a single step; ours
  * moves around that one, a step of type and a level of radius at a time.
  */

--- a/packages/native/src/components/card/card.utils.ts
+++ b/packages/native/src/components/card/card.utils.ts
@@ -34,7 +34,7 @@ function isBackground(node: ReactNode): boolean {
  *
  * Without this, source order would decide the stacking: a `Card.Background` written after
  * the header would sit over it and hide the card's own content, which is exactly the
- * invisible ordering rule composition should not carry. HeroUI avoids the same trap by
+ * invisible ordering rule composition should not carry. The reference implementation avoids the same trap by
  * making the background a **prop** rather than a child; hoisting keeps it a child, which
  * is what R1 asks for.
  *

--- a/packages/native/src/components/checkbox/checkbox.md
+++ b/packages/native/src/components/checkbox/checkbox.md
@@ -74,7 +74,7 @@ handler both happen, in that order.
 
 The border, the mark's fill and the label turn `danger`, and the **resting fill is
 dropped**: a box that is wrong reads as an outline rather than as a filled control that
-happens to be red at the edge. HeroUI reaches the same shape with a compound.
+happens to be red at the edge. The reference implementation reaches the same shape with a compound.
 
 It does not mount a message. Put one under the row yourself — a slot that silently renders
 nothing is a slot you cannot debug, which is the `TextField.Error` bargain again.
@@ -155,7 +155,7 @@ checkbox hugs its label; a row that has to fill its parent is a style prop away.
 The check is **derived from the box** — half its width, a quarter its height — rather than
 tabulated, so it is one glyph at four sizes instead of four drawings of one.
 
-`md` is HeroUI's checkbox measured: a 24pt box with the field's 1pt border. The corner is
+`md` is the reference implementation's checkbox measured: a 24pt box with the field's 1pt border. The corner is
 `md` (9) where theirs is `lg` (8) — the same key is 12 on our radius base, and 12 on a 24pt
 box is a circle, which is the `Radio`.
 
@@ -214,7 +214,7 @@ two components rather than a branch inside one.
 The press treatment is `PressableFeedback`'s, so `animation` on the root is the library's
 usual knob: `false`, `'disabled'`, `'disable-all'`, or the object.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `checkbox.tsx` and `checkbox.css` rather than eyeballed.
 

--- a/packages/native/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/native/src/components/checkbox/checkbox.recipe.ts
@@ -87,7 +87,7 @@ type SizeStep = {
 }
 
 /**
- * `md` is the anchor, and it is HeroUI's checkbox measured: a 24pt box with the field's
+ * `md` is the anchor, and it is the reference implementation's checkbox measured: a 24pt box with the field's
  * 1pt border and an 8pt corner. Their scale has a single size; ours moves around that one,
  * a spacing step and a step of type at a time.
  *
@@ -164,7 +164,7 @@ export const checkboxRecipe = createRecipe({
      * Declared after `size` so its border wins. The resting fill is dropped rather than
      * repainted — `undefined` over a colour is what RN reads as "no background" — because
      * a box that is wrong should read as an outline, not as a filled control that happens
-     * to be red at the edge. HeroUI reaches the same shape with a compound.
+     * to be red at the edge. The reference implementation reaches the same shape with a compound.
      */
     isInvalid: {
       true: theme => ({

--- a/packages/native/src/components/checkbox/checkbox.type.ts
+++ b/packages/native/src/components/checkbox/checkbox.type.ts
@@ -20,7 +20,7 @@ export type CheckboxSlot = 'root' | 'indicator' | 'fill' | 'check' | 'dash' | 'l
  * Three of the `Input`'s four levels, and they mean here what they mean there — this is
  * the `field*` family again, on a box 24pt wide instead of a field 48pt tall.
  *
- * - **`primary`** — the `fieldBackground` fill plus the theme's `field` shadow. HeroUI's
+ * - **`primary`** — the `fieldBackground` fill plus the theme's `field` shadow. The reference implementation's
  *   `primary`, with the elevation their flat token only implies.
  * - **`secondary`** — the neutral `default` fill, and the default here for the reason it
  *   is the `Input`'s: on a plain background a white box is its border and nothing else,

--- a/packages/native/src/components/chip/chip.md
+++ b/packages/native/src/components/chip/chip.md
@@ -141,14 +141,14 @@ differs from a `Button`'s.
 | `md`   | 28     | 12      | 14/20 | 6   | 22     |
 | `lg`   | 36     | 16      | 16/24 | 8   | 28     |
 
-The height is fixed where HeroUI uses vertical padding. Same numbers — theirs resolve to
+The height is fixed where the reference implementation uses vertical padding. Same numbers — theirs resolve to
 20, 28 and 36 — and a different reason to arrive at them: with padding, a chip carrying an
 avatar is taller than the chip beside it carrying only text, and a row of filters stops
 lining up.
 
 ### Variants
 
-Eleven flat names, replacing HeroUI's `variant × color` matrix — four emphases times five
+Eleven flat names, replacing the reference implementation's `variant × color` matrix — four emphases times five
 intents, of which nine combinations paint the same thing.
 
 The first five are the `Button`'s ladder, descending by how much accent is left. The six

--- a/packages/native/src/components/chip/chip.recipe.ts
+++ b/packages/native/src/components/chip/chip.recipe.ts
@@ -66,7 +66,7 @@ const VARIANT_TOKENS: Record<ChipVariant, VariantTokens> = {
  * its label, which is what `alignSelf: 'flex-start'` in `base` says, and there is no
  * `fullWidth` here any more than on a `Button`.
  *
- * The height is fixed where HeroUI uses vertical padding. Same numbers — theirs resolve
+ * The height is fixed where the reference implementation uses vertical padding. Same numbers — theirs resolve
  * to 20, 28 and 36 — and a different reason to arrive at them: with padding, a chip
  * carrying an avatar is taller than the chip next to it carrying only text, and a row of
  * filters stops lining up. A height decided by the size holds the row together and lets
@@ -141,7 +141,7 @@ type SizeStep = {
 }
 
 /**
- * `md` is the anchor, and it is HeroUI's chip measured: 12pt of horizontal padding, a
+ * `md` is the anchor, and it is the reference implementation's chip measured: 12pt of horizontal padding, a
  * 14/20 label, 28pt tall. Their scale has three steps and ours has four, so `xs` and `lg`
  * are theirs and `sm` is the step our ladder adds between the first two.
  */
@@ -199,19 +199,19 @@ export const chipRecipe = createRecipe({
       // A chip hugs its content where a `Button` fills its column. The difference is what
       // the two are: a button is a control the layout sizes, a chip is a token *about*
       // something, and a tag stretched across a screen has stopped being one. It is also
-      // the one line of HeroUI's chip that is not a measurement.
+      // the one line of the reference implementation's chip that is not a measurement.
       alignSelf: 'flex-start',
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
       borderWidth: 0,
-      // The capsule the name means, at every size. HeroUI reaches it through a radius
+      // The capsule the name means, at every size. The reference implementation reaches it through a radius
       // ladder that React Native would clamp to the same pill anyway; saying `full` says
       // it once, and `radius` is still there for the tag that wants square corners.
       borderRadius: theme.radius.full,
       // Squircle corners for when `radius` overrides the pill. Free on Android.
       borderCurve: 'continuous',
-      // Deliberately no `overflow: 'hidden'`, where HeroUI clips: the press overlays
+      // Deliberately no `overflow: 'hidden'`, where the reference implementation clips: the press overlays
       // carry their own corners (`system/pressable-feedback/`), so nothing needs the clip
       // — and clipping here would cut a badge or a shadow a caller hangs off the chip.
     },

--- a/packages/native/src/components/chip/chip.type.ts
+++ b/packages/native/src/components/chip/chip.type.ts
@@ -36,7 +36,7 @@ export type ChipSlot =
  * `tertiary` a border, `ghost` nothing at all. A name means here exactly what it means on
  * a `Button`, which is what makes this one vocabulary rather than two.
  *
- * It replaces HeroUI's `variant × color` matrix — four emphases times five intents, of
+ * It replaces the reference implementation's `variant × color` matrix — four emphases times five intents, of
  * which nine combinations paint the same thing. Eleven flat names say the same set once.
  */
 export type ChipVariant =

--- a/packages/native/src/components/close-button/close-button.md
+++ b/packages/native/src/components/close-button/close-button.md
@@ -83,7 +83,7 @@ element carries its own label or its own text.
 | `md`   | 32  | 16  | ~11   |
 | `lg`   | 40  | 20  | ~14   |
 
-`md` is HeroUI's close button measured — a 32-point square — and it is the `Dialog`'s.
+`md` is the reference implementation's close button measured — a 32-point square — and it is the `Dialog`'s.
 
 The **bar** is twice as long as the cross looks: a bar rotated a quarter turn spans
 `length / √2` on each axis. It is kept as a ratio of the box rather than tabulated, so it is
@@ -123,7 +123,7 @@ because the base owns the press state — a cross has to be a different target f
 around it — and a root that does not know it is pressed cannot resolve a colour for it.
 Every other close button in the library reads the same way.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the 32-point box at the default size, the circle, the filled default rather
 than a bare glyph, the grown touch target, and children replacing the mark.

--- a/packages/native/src/components/close-button/close-button.recipe.ts
+++ b/packages/native/src/components/close-button/close-button.recipe.ts
@@ -33,7 +33,7 @@ const VARIANT_TOKENS: Record<CloseButtonVariant, VariantTokens> = {
 /**
  * The box, and the length of one of the two bars that cross in it.
  *
- * `md` is the `Dialog`'s cross, which is HeroUI's measured: a 32-point square, and a bar
+ * `md` is the `Dialog`'s cross, which is the reference implementation's measured: a 32-point square, and a bar
  * long enough to draw a cross about 11 points wide — a bar rotated a quarter turn spans
  * `length / √2` on each axis, so the bar is twice as long as it looks. Keeping that as a
  * **ratio** is what makes it one cross at four sizes rather than four drawings, exactly as

--- a/packages/native/src/components/combobox/combobox.md
+++ b/packages/native/src/components/combobox/combobox.md
@@ -115,7 +115,7 @@ All of them are the `Select`'s, resolved through `selectRecipe` exactly as the
 `Autocomplete`'s are: four field levels, three sizes, `radius`, `color`, `isInvalid`,
 `isDisabled`. A second table would be a third one to keep in step.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Theirs is `ComboBox` with `InputGroup` · `Value` · `Trigger` · `Popover`.
 

--- a/packages/native/src/components/date-picker/date-picker-content.tsx
+++ b/packages/native/src/components/date-picker/date-picker-content.tsx
@@ -8,7 +8,7 @@ import { useStyleProps } from '../../system/style-props'
 import { DatePickerProvider, useDatePicker } from './date-picker.context'
 import type { DatePickerContentProps } from './date-picker.type'
 
-/** HeroUI's, point for point: eight from the trigger, twelve from every screen edge. */
+/** the reference implementation's, point for point: eight from the trigger, twelve from every screen edge. */
 const DEFAULT_OFFSET = 8
 const DEFAULT_INSETS = { top: 12, bottom: 12, start: 12, end: 12 }
 

--- a/packages/native/src/components/dialog/dialog.md
+++ b/packages/native/src/components/dialog/dialog.md
@@ -108,7 +108,7 @@ which the dialog supplies. Two shapes, and the empty one is the default:
 **Empty, it draws a cross** — the shared button's, from two rotated bars rather than an
 icon, so the corner affordance works in a project that has installed no icon set.
 
-Every measurement is HeroUI's, read off their CSS. `close-button.css` sets
+Every measurement is the reference implementation's, read off their CSS. `close-button.css` sets
 `height: calc(var(--spacing) * 8)` on a spacing base of 4, so the box is **32 points**, and
 `isIconOnly` gives it `aspect-ratio: 1` and a radius past half its height — a circle. It is
 **filled**, not a bare glyph: their `CloseButton` is a `tertiary` button, and their
@@ -119,7 +119,7 @@ reads as decoration; the disc is what makes it a target.
 **It places itself nowhere.** `alignSelf="flex-end"` above the title, or `position`,
 `top` and `end` over content that has room for it — a title with space beside it and one
 without want different answers, and that is layout, which is the caller's (R4). This is
-what HeroUI does too: their own examples use `absolute top-3 inset-e-2.5`, `items-end` and
+what the reference implementation does too: their own examples use `absolute top-3 inset-e-2.5`, `items-end` and
 `self-end me-4` in three different dialogs. The placement is in the example, not in the
 component.
 

--- a/packages/native/src/components/dialog/dialog.recipe.ts
+++ b/packages/native/src/components/dialog/dialog.recipe.ts
@@ -16,7 +16,7 @@ const SLOTS = [
 /**
  * The cross's box, and the length of one of its two bars.
  *
- * Both are HeroUI's, read off `close-button.css` rather than guessed:
+ * Both are the reference implementation's, read off `close-button.css` rather than guessed:
  * `height: calc(var(--spacing) * 8)` on a spacing base of 4 is 32 points, and `isIconOnly`
  * makes it `aspect-ratio: 1` — a 32-point square, rounded to a circle by a radius their
  * `sm` size sets past half of it.
@@ -67,7 +67,7 @@ export const dialogRecipe = createRecipe({
       content: {
         backgroundColor: theme.colors.overlay,
         padding: theme.spacing(5),
-        // HeroUI's `--radius-3xl` on a base of 8 is 24 points; our base is 12, so the same
+        // The reference implementation's `--radius-3xl` on a base of 8 is 24 points; our base is 12, so the same
         // 24 is `2xl`. Reading their key rather than their number puts a pill on it.
         borderRadius: theme.radius['2xl'],
         borderCurve: 'continuous',

--- a/packages/native/src/components/divider/divider.md
+++ b/packages/native/src/components/divider/divider.md
@@ -85,7 +85,7 @@ past it.
 
 ### `size` is the thickness
 
-`xs` is HeroUI's `thin` — one device pixel, `StyleSheet.hairlineWidth` — and `lg` is their
+`xs` is the reference implementation's `thin` — one device pixel, `StyleSheet.hairlineWidth` — and `lg` is their
 `thick`, six points, with the two steps our ladder puts between them.
 
 It is `size` and not `thickness` because that is the vocabulary word (§1 bis), and it is

--- a/packages/native/src/components/divider/divider.recipe.ts
+++ b/packages/native/src/components/divider/divider.recipe.ts
@@ -36,7 +36,7 @@ const HAIRLINE = StyleSheet.hairlineWidth
  * two. Declaration order is application order, so `orientation` runs second and always
  * wins on the axis it frees.
  *
- * `xs` is HeroUI's `thin` and `lg` is their `thick`, six points, with the two steps our
+ * `xs` is the reference implementation's `thin` and `lg` is their `thick`, six points, with the two steps our
  * ladder puts between them.
  */
 function thickness(of: (theme: XAUITheme) => number) {

--- a/packages/native/src/components/fab/fab.tsx
+++ b/packages/native/src/components/fab/fab.tsx
@@ -14,7 +14,7 @@ import { FabSpinner } from './fab-spinner'
 import { fabSheet } from './fab.style'
 import type { FabProps } from './fab.type'
 
-/** How far in from the edge it floats, in points. Material's, and HeroUI's. */
+/** How far in from the edge it floats, in points. Material's, and the reference implementation's. */
 const DEFAULT_OFFSET = 16
 
 /**

--- a/packages/native/src/components/field-group/field-group-icon.tsx
+++ b/packages/native/src/components/field-group/field-group-icon.tsx
@@ -20,7 +20,7 @@ import type { FieldGroupIconProps } from './field-group.type'
  * `primary` field, where the fill is the caller's colour and the placeholder grey is no
  * longer readable over it.
  *
- * It is not one of HeroUI's three parts: theirs colour the glyph at the call site. This is
+ * It is not one of the reference implementation's three parts: theirs colour the glyph at the call site. This is
  * the same slot `Button`, `Chip` and `Alert` all have, and it exists so that a form does
  * not carry a hard-coded `#888` on every field.
  */

--- a/packages/native/src/components/field-group/field-group.md
+++ b/packages/native/src/components/field-group/field-group.md
@@ -201,12 +201,12 @@ There is no `size` here. The `TextField`'s decides everything:
 | `lg`   | 16              | 16  | 20   |
 
 The inset is the field's own horizontal padding, so the glyph starts where the text would
-have. The gap is that same step — HeroUI's, and it is what separates two glyphs in one
+have. The gap is that same step — the reference implementation's, and it is what separates two glyphs in one
 decorator.
 
 The icon sits **one step above the field's type**, exactly as on the `Button` and the
 `Chip`: a 16pt glyph beside 16pt of text reads as an icon smaller than the text it sits
-with. HeroUI's component sizes no icon at all — theirs is a number at the call site — so
+with. The reference implementation's component sizes no icon at all — theirs is a number at the call site — so
 this is a slot they do not have rather than a value we disagree on.
 
 ## Colour
@@ -230,7 +230,7 @@ fill is the caller's colour and the placeholder grey is no longer readable over 
 Everything else a tint touches — the border, the fill, the focus — is the `TextField`'s and
 reaches the group untouched.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `input-group.tsx` and `input-group.css` rather than eyeballed.
 

--- a/packages/native/src/components/input-otp/input-otp.md
+++ b/packages/native/src/components/input-otp/input-otp.md
@@ -185,7 +185,7 @@ and not the other is how a cleared field comes back on the next keystroke.
 | `md`   | 48 × 44 | 18/28     | 8   |
 | `lg`   | 56 × 52 | 20/28     | 10  |
 
-`md` is HeroUI's OTP measured. The width is the control height less one spacing step, which
+`md` is the reference implementation's OTP measured. The width is the control height less one spacing step, which
 reproduces their 48 × 44 and holds the proportion at the other two.
 
 ### The corner
@@ -195,7 +195,7 @@ A field is wide, so 21 on a 48-tall one reads as a rounded rectangle. A code box
 nearly square — 44 by 48 at `md`, 36 by 40 at `sm` — where the geometric maximum is 22, so
 the same 21 is a pill in all but name and is clamped to one outright at the small end.
 
-Twelve is where HeroUI lands for the same box from the other direction: their `field` radius
+Twelve is where the reference implementation lands for the same box from the other direction: their `field` radius
 is their `xl`, and their scale's base is 8 where ours is 12.
 
 **There is no `xs`**, where the rest of the library has four sizes. That box would be 28 by
@@ -214,7 +214,7 @@ Three of the `Input`'s four, token for token — a box of a code is a field one 
 | `secondary` | `default`         | `fieldBorder` | `accent`    | —       |
 | `tertiary`  | transparent       | `fieldBorder` | `accent`    | —       |
 
-**The active box takes a two-point ring** in the accent. HeroUI uses `outline-width: 2px`;
+**The active box takes a two-point ring** in the accent. The reference implementation uses `outline-width: 2px`;
 React Native has no `outline`, so it is a border — and two points rather than one, because a
 box that gains a colour without gaining weight reads as a rendering artefact next to five
 that did not. The box has a fixed width and height and centres what it holds, so the extra

--- a/packages/native/src/components/input-otp/input-otp.recipe.ts
+++ b/packages/native/src/components/input-otp/input-otp.recipe.ts
@@ -44,7 +44,7 @@ const VARIANT_TOKENS: Record<InputOTPVariant, VariantTokens> = {
   },
 }
 
-/** How far behind its own colour a placeholder character sits. HeroUI's 50%, exactly. */
+/** How far behind its own colour a placeholder character sits. The reference implementation's 50%, exactly. */
 const PLACEHOLDER_OPACITY = 0.5
 
 /**
@@ -59,7 +59,7 @@ const ACTIVE_BORDER_WIDTH = 2
  * `size` drives the box, the type inside it and the gaps — there is no width to set
  * separately, because a box is a square-ish thing whose width follows its height.
  *
- * `md` is HeroUI's OTP measured: a 48pt box 44pt wide, an 18/28 semibold character, 8pt
+ * `md` is the reference implementation's OTP measured: a 48pt box 44pt wide, an 18/28 semibold character, 8pt
  * between boxes. The width is the control height less one spacing step, which reproduces
  * their 48 × 44 and keeps the proportion at the other three sizes.
  */
@@ -90,7 +90,7 @@ function sizeAxis(step: SizeStep) {
   }
 }
 
-/** HeroUI's caret and separator thickness — a half step, at every size. */
+/** the reference implementation's caret and separator thickness — a half step, at every size. */
 const CARET_WIDTH = 0.5
 const SEPARATOR_WIDTH = 2
 

--- a/packages/native/src/components/input-otp/input-otp.type.ts
+++ b/packages/native/src/components/input-otp/input-otp.type.ts
@@ -34,7 +34,7 @@ export type InputOTPSlot =
  * they go**. With no fill and no border there is nothing to count. It is the reason the
  * `Checkbox` has no `ghost` either — a box that is not a box is not a box.
  *
- * HeroUI splits their OTP slot the same two ways their input is split, and they reach for
+ * The reference implementation splits their OTP slot the same two ways their input is split, and they reach for
  * the `field` shadow on `primary` here explicitly — which is the same reading our `Input`
  * takes.
  */

--- a/packages/native/src/components/list-box/list-box-item-suffix.tsx
+++ b/packages/native/src/components/list-box/list-box-item-suffix.tsx
@@ -7,7 +7,7 @@ import type { ListBoxItemSuffixProps } from './list-box.type'
 /**
  * What trails the row: a value, a switch, a chevron, a badge.
  *
- * **It draws nothing of its own.** HeroUI's puts a chevron here by default; the trailing
+ * **It draws nothing of its own.** The reference implementation's puts a chevron here by default; the trailing
  * end of a settings row is a `Switch` at least as often, and a slot that guesses makes you
  * pass a child in order to render nothing. What goes there is the row's business, and the
  * row is one line away from saying so.

--- a/packages/native/src/components/list-box/list-box.md
+++ b/packages/native/src/components/list-box/list-box.md
@@ -93,7 +93,7 @@ actually is.
 
 ## The suffix draws nothing of its own
 
-HeroUI's puts a chevron there by default. The trailing end of a settings row is a `Switch`
+The reference implementation's puts a chevron there by default. The trailing end of a settings row is a `Switch`
 at least as often, and a slot that guesses makes you pass a child in order to render
 nothing. The library ships `ChevronDownIcon`; a row that wants one says so.
 
@@ -204,7 +204,7 @@ disabled group has no live list in it.
 
 A `ListBox` outside any group is unchanged.
 
-### Alignment with `heroui-native`
+### Alignment with the reference implementation
 
 Their `ListBoxGroup` **is our `ListBox`** — a Surface container with Item · ItemPrefix ·
 ItemContent · ItemTitle · ItemDescription · ItemSuffix, slot for slot. What is here under

--- a/packages/native/src/components/menu/menu.md
+++ b/packages/native/src/components/menu/menu.md
@@ -164,7 +164,7 @@ the third component to read them, after the `Select` and the `Popover`.
 
 ## Not here yet
 
-**`SubMenu`.** HeroUI ships it as its own component and it needs a second anchored panel
+**`SubMenu`.** The reference implementation ships it as its own component and it needs a second anchored panel
 whose trigger is a row of the first — worth its own change rather than a corner of this one.
 
 ## Accessibility

--- a/packages/native/src/components/menu/menu.recipe.ts
+++ b/packages/native/src/components/menu/menu.recipe.ts
@@ -43,7 +43,7 @@ export function menuMeasure(fontSize: number): number {
   return fontSize * 15
 }
 
-/** HeroUI's, in spacing steps: the panel is inset less than its rows are padded. */
+/** the reference implementation's, in spacing steps: the panel is inset less than its rows are padded. */
 const PANEL_PADDING_HORIZONTAL = 1.5
 const PANEL_PADDING_VERTICAL = 3
 const ITEM_PADDING_HORIZONTAL = 2.5
@@ -117,7 +117,7 @@ export const menuRecipe = createRecipe({
       // `flex: 1` is `flexBasis: 0`, and the panel is measured before it has a width: with
       // a basis of zero and no definite width to grow into, the row's content size is
       // nothing and the title collapses. The whole menu measured as a 70-point capsule
-      // with no text in it. HeroUI writes `flex: 1` here and gets away with it because
+      // with no text in it. The reference implementation writes `flex: 1` here and gets away with it because
       // their measuring pass hands the panel a definite width; ours asks the panel how
       // wide it wants to be, which is a question a zero basis cannot answer.
       flexGrow: 1,

--- a/packages/native/src/components/popover/popover-content.tsx
+++ b/packages/native/src/components/popover/popover-content.tsx
@@ -10,7 +10,7 @@ import { popoverMeasure } from './popover.recipe'
 import { PopoverProvider, usePopover } from './popover.context'
 import type { PopoverContentProps, PopoverInsets } from './popover.type'
 
-/** HeroUI's: nine from the trigger, twelve from every screen edge. */
+/** the reference implementation's: nine from the trigger, twelve from every screen edge. */
 const DEFAULT_OFFSET = 9
 const DEFAULT_INSETS: Required<PopoverInsets> = {
   top: 12,

--- a/packages/native/src/components/popover/popover.recipe.ts
+++ b/packages/native/src/components/popover/popover.recipe.ts
@@ -16,7 +16,7 @@ const SLOTS = ['trigger', 'overlay', 'content', 'title', 'description'] as const
  * Thirteen ems, which is about twenty-six characters a line — narrow, and deliberately so.
  * A popover is read at a glance, and a glance is two or three short lines rather than a
  * paragraph; past this it stops being an aside and starts being a sheet with a tail. It is
- * also where HeroUI's own panels land, measured off their placement demos: a little over
+ * also where the reference implementation's own panels land, measured off their placement demos: a little over
  * two hundred points on a three-hundred-and-ninety point screen.
  *
  * A measure rather than a number of points, so a theme that scales its type scales the
@@ -35,7 +35,7 @@ export const popoverRecipe = createRecipe({
     content: {
       position: 'absolute',
       backgroundColor: theme.colors.overlay,
-      // HeroUI's twelve by sixteen: a panel is read, not scanned, so it is wider-padded
+      // The reference implementation's twelve by sixteen: a panel is read, not scanned, so it is wider-padded
       // than it is tall-padded.
       paddingVertical: theme.spacing(3),
       paddingHorizontal: theme.spacing(4),

--- a/packages/native/src/components/progress-bar/progress-bar.md
+++ b/packages/native/src/components/progress-bar/progress-bar.md
@@ -143,7 +143,7 @@ success, warning or danger.
 `Checkbox`'s pair, meaning the same thing on a line instead of in a box. Why a role and not
 an axis is written up once in [`checkbox.md`](../checkbox/checkbox.md#colour).
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the three sizes, the label-and-value header, the clamped range with
 `minValue` / `maxValue`, `formatOptions` through `Intl`, and Track · Fill as slots.

--- a/packages/native/src/components/progress-circle/progress-circle.md
+++ b/packages/native/src/components/progress-circle/progress-circle.md
@@ -128,7 +128,7 @@ than by a stylesheet. The recipe still owns them, on two slots it never renders 
 thing the `Tabs` recipe does with its `content` slot — because that is what makes a raw
 `color` reach the arc through `resolveTint`, which only maps roles a variant declared.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 **Identical:** the three sizes, the clamped range, `formatOptions`, the SVG ring with a
 rounded cap starting at twelve o'clock, and Indicator · Value as slots.

--- a/packages/native/src/components/radio/radio.md
+++ b/packages/native/src/components/radio/radio.md
@@ -178,7 +178,7 @@ the auto-wrap does not apply.
 | `lg`   | 28     | 12  | 10  | 18/28 |
 
 The same four boxes as the `Checkbox`, so a radio and a checkbox in one form line up. The
-dot keeps HeroUI's ratio — 10 in 24 — rather than being tabulated, so it is one dot at four
+dot keeps the reference implementation's ratio — 10 in 24 — rather than being tabulated, so it is one dot at four
 sizes instead of four drawings of one.
 
 `radius` is `full` and overridable: a squared-off option in a segmented row is a real
@@ -201,7 +201,7 @@ tint is ignored while `isInvalid`, as on the `Checkbox`.
 Why a role and not an axis is written up once, in
 [`checkbox.md`](../checkbox/checkbox.md#colour), and it holds here unchanged.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `radio.tsx` and `radio.css`.
 

--- a/packages/native/src/components/radio/radio.recipe.ts
+++ b/packages/native/src/components/radio/radio.recipe.ts
@@ -39,7 +39,7 @@ const VARIANT_TOKENS: Record<RadioVariant, VariantTokens> = {
  * width**, exactly as on the `Checkbox`, and the two ladders are the same four boxes so
  * that a radio and a checkbox in one form line up.
  *
- * The dot is **derived from the circle** rather than tabulated: HeroUI's is 10 in a 24,
+ * The dot is **derived from the circle** rather than tabulated: The reference implementation's is 10 in a 24,
  * and keeping the ratio is what makes it one dot at four sizes instead of four drawings.
  */
 function sizeAxis(step: SizeStep) {
@@ -61,7 +61,7 @@ function sizeAxis(step: SizeStep) {
   }
 }
 
-/** HeroUI's 10pt dot in their 24pt circle, kept as a ratio so every size gets one. */
+/** the reference implementation's 10pt dot in their 24pt circle, kept as a ratio so every size gets one. */
 const THUMB_RATIO = 10 / 24
 
 type SizeStep = {
@@ -72,7 +72,7 @@ type SizeStep = {
   label: FontSizeKey
 }
 
-/** `md` is HeroUI's radio measured: a 24pt circle with the field's 1pt border. */
+/** `md` is the reference implementation's radio measured: a 24pt circle with the field's 1pt border. */
 const SIZES: Record<RadioSize, SizeStep> = {
   sm: { box: 5, gap: 2, label: 'sm' },
   md: { box: 6, gap: 2, label: 'md' },

--- a/packages/native/src/components/select/select-content.tsx
+++ b/packages/native/src/components/select/select-content.tsx
@@ -12,7 +12,7 @@ import { collectItemLabels } from '../../utils/item-labels'
 import type { SelectContentProps, SelectInsets } from './select.type'
 import { useEffect } from 'react'
 
-/** HeroUI's, point for point: eight from the trigger, twelve from every screen edge. */
+/** the reference implementation's, point for point: eight from the trigger, twelve from every screen edge. */
 const DEFAULT_OFFSET = 8
 const DEFAULT_INSETS: Required<SelectInsets> = {
   top: 12,

--- a/packages/native/src/components/select/select-indicator.tsx
+++ b/packages/native/src/components/select/select-indicator.tsx
@@ -18,7 +18,7 @@ import type { SelectIndicatorProps } from './select.type'
  *
  * It rotates on a spring rather than a timing curve. A 180-degree turn on a curve reads
  * as an animation playing next to the list; on a spring heavy enough not to overshoot it
- * reads as the list pushing the glyph round — which is the same trade HeroUI makes, with
+ * reads as the list pushing the glyph round — which is the same trade the reference implementation makes, with
  * the same numbers.
  *
  * The rotation is a worklet on the UI thread, so it keeps turning while JavaScript is

--- a/packages/native/src/components/select/select.md
+++ b/packages/native/src/components/select/select.md
@@ -217,7 +217,7 @@ goes, so choosing never shifts a label.
 
 ## Motion
 
-Three animations, HeroUI's values throughout.
+Three animations, the reference implementation's values throughout.
 
 **The chevron** turns 0 → −180° on a spring: damping 140, stiffness 1000, mass 4. Heavily
 damped against a very high stiffness, so it arrives in about a fifth of a second and does

--- a/packages/native/src/components/select/select.recipe.ts
+++ b/packages/native/src/components/select/select.recipe.ts
@@ -88,7 +88,7 @@ const SIZES: Record<SelectSize, SizeStep> = {
 
 /**
  * The list's own measurements do **not** scale with `size`. A `lg` trigger opening a list
- * of `lg` rows is a menu that fills the screen, and HeroUI takes the same position: their
+ * of `lg` rows is a menu that fills the screen, and the reference implementation takes the same position: their
  * item padding is one value whatever the trigger is. `size` is the control's scale, and
  * the list is not the control.
  */
@@ -100,7 +100,7 @@ const LIST = {
   itemGap: 2,
   labelPaddingHorizontal: 2,
   labelPaddingVertical: 1.5,
-  /** The check's box, in spacing steps like the rest — five of them, HeroUI's twenty. */
+  /** The check's box, in spacing steps like the rest — five of them, the reference implementation's twenty. */
   indicator: 5,
 } as const
 
@@ -165,7 +165,7 @@ export const selectRecipe = createRecipe({
       backgroundColor: theme.colors.overlay,
       padding: theme.spacing(LIST.padding),
       // The panel is not the field, so it is rounder — but not by three steps of our
-      // scale. HeroUI's panel is their `--radius-3xl` on a base of 8, which is 24 points;
+      // scale. The reference implementation's panel is their `--radius-3xl` on a base of 8, which is 24 points;
       // ours is a base of 12, so the same 24 is `2xl`. Reading their key rather than
       // their number is what put a 36-point corner on it and made it read as a pill.
       borderRadius: theme.radius['2xl'],

--- a/packages/native/src/components/skeleton/skeleton.md
+++ b/packages/native/src/components/skeleton/skeleton.md
@@ -125,10 +125,10 @@ One pulse: the block breathes between full opacity and a half, a second each way
 and out. `animation={false}` freezes it at full and mounts no worklet — the branch renders
 a plain `View`, so a long list frozen for a screenshot costs nothing.
 
-**No shimmer**, where HeroUI's default is one. A shimmer is a gradient sweeping across the
+**No shimmer**, where the reference implementation's default is one. A shimmer is a gradient sweeping across the
 block; a gradient needs `react-native-svg`, and that is an optional peer a component in the
 fifteen-component core cannot require. One animation, so there is nothing for a name to
-choose between — `animation` is a boolean rather than HeroUI's
+choose between — `animation` is a boolean rather than the reference implementation's
 `'shimmer' | 'pulse' | 'none'`.
 
 ## Accessibility

--- a/packages/native/src/components/skeleton/skeleton.recipe.ts
+++ b/packages/native/src/components/skeleton/skeleton.recipe.ts
@@ -8,7 +8,7 @@ const SLOTS = ['root'] as const
  * One line, because the component has no `variant` to choose between — `SkeletonProps`
  * says why. `default` is the neutral fill the rest of the library uses for a `secondary`
  * `Button`, which is the grey a placeholder wants: a block on the page rather than a hole
- * in it. HeroUI reaches the same value from `muted` at 30% opacity; naming the token is
+ * in it. The reference implementation reaches the same value from `muted` at 30% opacity; naming the token is
  * what lets a theme move the skeleton by moving `default`.
  *
  * The role is declared rather than the colour written into `paint`, because `resolveTint`

--- a/packages/native/src/components/skeleton/skeleton.tsx
+++ b/packages/native/src/components/skeleton/skeleton.tsx
@@ -14,7 +14,7 @@ import { useXAUITheme } from '../../theme/theme-hooks'
 import { skeletonRecipe } from './skeleton.recipe'
 import type { SkeletonProps } from './skeleton.type'
 
-/** One breath in, one breath out. HeroUI's pulse, at HeroUI's timing. */
+/** One breath in, one breath out. The reference implementation's pulse, at the reference implementation's timing. */
 const PULSE_DURATION = 1000
 
 /** How far down the block breathes. Under a half and the pulse reads as a flicker. */

--- a/packages/native/src/components/skeleton/skeleton.type.ts
+++ b/packages/native/src/components/skeleton/skeleton.type.ts
@@ -53,7 +53,7 @@ type SkeletonOwnProps = {
   /**
    * `false` freezes the block at full opacity and mounts no worklet.
    *
-   * A boolean rather than HeroUI's `'shimmer' | 'pulse' | 'none'`: a shimmer is a
+   * A boolean rather than the reference implementation's `'shimmer' | 'pulse' | 'none'`: a shimmer is a
    * gradient sweeping across the block, a gradient needs `react-native-svg`, and that is
    * an optional peer a component in the core cannot require. One animation, so there is
    * nothing for a name to choose between.

--- a/packages/native/src/components/slider/slider-thumb.tsx
+++ b/packages/native/src/components/slider/slider-thumb.tsx
@@ -24,7 +24,7 @@ import type { SliderThumbProps } from './slider.type'
  * the scale can stay on the other thread.
  *
  * It is a **disc of the page's own colour inside a ring of the fill's**, which is the
- * legacy component's shape rather than HeroUI's capsule-with-a-core. A solid accent knob
+ * legacy component's shape rather than the reference implementation's capsule-with-a-core. A solid accent knob
  * on an accent fill disappears the moment the value reaches the top; a ring never does.
  */
 export function SliderThumb({

--- a/packages/native/src/components/slider/slider.recipe.ts
+++ b/packages/native/src/components/slider/slider.recipe.ts
@@ -45,7 +45,7 @@ type SizeStep = {
  * The legacy slider's proportions, point for point.
  *
  * A **thin rail with a round knob on it**, not a capsule with a core inside — which is what
- * this component shipped as, borrowed from HeroUI's. The rail is 6 to 10 points and the
+ * this component shipped as, borrowed from the reference implementation's. The rail is 6 to 10 points and the
  * knob 16 to 24, so the knob overhangs the rail by half their difference on each side. That
  * overhang is the shape: it is what makes the knob read as sitting *on* a line rather than
  * as a segment *of* one.

--- a/packages/native/src/components/spinner/spinner.md
+++ b/packages/native/src/components/spinner/spinner.md
@@ -75,7 +75,7 @@ is a fill softened, and there is no fill here.
 
 ### `size` is the diameter
 
-Sixteen, twenty, twenty-four and thirty-two points — HeroUI's three steps plus the one our
+Sixteen, twenty, twenty-four and thirty-two points — the reference implementation's three steps plus the one our
 ladder adds between the first two. The stroke thickens once, at `lg`, because a 2pt ring on
 a 32pt circle reads as a hairline and a 3pt ring on a 16pt one reads as a doughnut.
 
@@ -103,7 +103,7 @@ still the last word.
 
 ### Why borders and not an SVG stroke
 
-HeroUI draws one arc fading from opaque to 55%, which needs a `linearGradient` and
+The reference implementation draws one arc fading from opaque to 55%, which needs a `linearGradient` and
 therefore `react-native-svg`. That package is an **optional peer** here, and a component in
 the fifteen-component core cannot require one. Two circles of a single ink at two opacities
 read as the same figure, cost two views, and pull in nothing.

--- a/packages/native/src/components/spinner/spinner.recipe.ts
+++ b/packages/native/src/components/spinner/spinner.recipe.ts
@@ -32,7 +32,7 @@ const VARIANT_TOKENS: Record<SpinnerVariant, VariantTokens> = {
  * How much of the ink is left in the track — the full circle the arc sweeps over.
  *
  * It is what separates this from `Button.Spinner`'s bare arc, and it is the whole reason
- * the component reads as HeroUI's does: their spinner is one stroke fading from opaque to
+ * the component reads as the reference implementation's does: their spinner is one stroke fading from opaque to
  * 55%, which needs a gradient and therefore `react-native-svg`. Two rings of one colour
  * at two opacities is the same figure drawn with borders — no optional peer for a core
  * component, and no SVG node per spinner in a list.
@@ -43,7 +43,7 @@ const TRACK_OPACITY = 0.18
  * `size` drives the diameter and the stroke together. There is no width axis to speak of:
  * a spinner is a circle, so its `size` is the only measurement it has.
  *
- * The four steps are HeroUI's three — 16, 24, 32 — with the 20 our ladder adds between
+ * The four steps are the reference implementation's three — 16, 24, 32 — with the 20 our ladder adds between
  * the first two. The stroke thickens once, at `lg`: a 2pt ring on a 32pt circle reads as
  * a hairline, and a 3pt ring on a 16pt one reads as a doughnut.
  */

--- a/packages/native/src/components/spinner/spinner.tsx
+++ b/packages/native/src/components/spinner/spinner.tsx
@@ -22,7 +22,7 @@ import type { SpinnerProps } from './spinner.type'
  * the same circle with a quarter missing. There is nothing between them for a slot to
  * name, and the two are one figure rather than two parts.
  *
- * It is HeroUI's spinner drawn with borders instead of a gradient stroke. Theirs fades a
+ * It is the reference implementation's spinner drawn with borders instead of a gradient stroke. Theirs fades a
  * single arc from opaque to 55%, which needs an SVG `linearGradient` and therefore
  * `react-native-svg` — an optional peer, which a component in the fifteen-component core
  * cannot require. Two circles of one ink at two opacities read as the same figure and

--- a/packages/native/src/components/stepper/stepper.recipe.ts
+++ b/packages/native/src/components/stepper/stepper.recipe.ts
@@ -60,7 +60,7 @@ type SizeStep = {
  * wide as its parent lets it be and a horizontal one splits that width evenly, which is
  * RN's own behaviour and the reason there is no `fullWidth` prop here either.
  *
- * `md`'s indicator is twenty-eight points, HeroUI's, measured off their own stepper.
+ * `md`'s indicator is twenty-eight points, the reference implementation's, measured off their own stepper.
  */
 const SIZES: Record<Size, SizeStep> = {
   xs: {

--- a/packages/native/src/components/surface/surface.recipe.ts
+++ b/packages/native/src/components/surface/surface.recipe.ts
@@ -28,7 +28,7 @@ type SizeStep = { padding: number; gap: number; radius: RadiusKey }
  * `size` moves the padding, the gap and the corner — **never a height**. A surface is a
  * ground: how tall it is, is how tall what is on it is.
  *
- * `md` is HeroUI's, measured: sixteen points of padding on a twenty-four point corner.
+ * `md` is the reference implementation's, measured: sixteen points of padding on a twenty-four point corner.
  */
 const SIZES: Record<Size, SizeStep> = {
   xs: { padding: 2.5, gap: 1.5, radius: 'lg' },

--- a/packages/native/src/components/switch/switch.md
+++ b/packages/native/src/components/switch/switch.md
@@ -106,7 +106,7 @@ instead of a third pair of words for this component alone.
 ```
 
 The knob's children travel with it. Anything else you put in the track stays where you put
-it — a glyph at each end, for instance, which is what HeroUI's `StartContent` and
+it — a glyph at each end, for instance, which is what the reference implementation's `StartContent` and
 `EndContent` are; here they are two `View`s you position, because the track is a node you
 were given rather than one that was hidden from you.
 
@@ -149,7 +149,7 @@ the auto-wrap does not apply.
 | `md`   | 48 × 18 | 26   | 0     | 22     | 16/24 |
 | `lg`   | 56 × 20 | 30   | 0     | 26     | 18/28 |
 
-`md` is the legacy switch measured — a 48 × 28 track with a 22 knob — and HeroUI's is the
+`md` is the legacy switch measured — a 48 × 28 track with a 22 knob — and the reference implementation's is the
 same 48 wide.
 
 **The width is part of the control**, unlike everywhere else in the library, where `size`
@@ -198,12 +198,12 @@ transform is not one — but a transform does not mirror under RTL either, so th
 flipped by hand against `I18nManager.isRTL`. It is the one place in the library that reads
 it, and it reads it for a movement rather than for a layout.
 
-## Alignment with `heroui-native`
+## Alignment with the reference implementation
 
 Measured against their `switch.tsx` and `switch.css`, and against the legacy component this
 one replaces.
 
-**Identical to HeroUI:** the 48pt track at `md`, the knob's `field` shadow, the accent
+**Identical to the reference implementation:** the 48pt track at `md`, the knob's `field` shadow, the accent
 track when on with a contrasting knob, the 175ms crossfade, and a default knob so nothing
 has to be written for the common case.
 

--- a/packages/native/src/components/switch/switch.recipe.ts
+++ b/packages/native/src/components/switch/switch.recipe.ts
@@ -95,7 +95,7 @@ type SizeStep = {
 
 /**
  * `md` is the legacy switch measured — a 48 × 28 track with a 22 thumb and 3 of padding —
- * and HeroUI's is the same 48 wide. Ours moves around that one, a spacing step at a time.
+ * and the reference implementation's is the same 48 wide. Ours moves around that one, a spacing step at a time.
  */
 const INSIDE: Record<SwitchSize, SizeStep> = {
   sm: { track: 11, height: 6.5, thumb: 5, padding: 0.75, gap: 2, label: 'sm' },

--- a/packages/native/src/components/switch/switch.style.ts
+++ b/packages/native/src/components/switch/switch.style.ts
@@ -3,6 +3,6 @@
  * on two nodes, and they have to arrive together — which they only do if neither owns the
  * number.
  *
- * 175ms is HeroUI's, and it is the length of the platform's own switch.
+ * 175ms is the reference implementation's, and it is the length of the platform's own switch.
  */
 export const SWITCH_DURATION = 175

--- a/packages/native/src/components/tabs/tabs.md
+++ b/packages/native/src/components/tabs/tabs.md
@@ -149,7 +149,7 @@ there is no flash at the start of the row either.
 
 ## Not here yet
 
-**A scrollable list.** HeroUI's `Tabs.ScrollView` centres the chosen tab when the bar
+**A scrollable list.** The reference implementation's `Tabs.ScrollView` centres the chosen tab when the bar
 overflows, and that means the indicator has to account for a scroll offset the triggers'
 own layout does not report. Worth its own change.
 

--- a/packages/native/src/components/tag-group/tag-group.recipe.ts
+++ b/packages/native/src/components/tag-group/tag-group.recipe.ts
@@ -31,7 +31,7 @@ type SizeStep = {
   cross: number
 }
 
-/** HeroUI's, step for step. */
+/** the reference implementation's, step for step. */
 const SIZES: Record<TagGroupSize, SizeStep> = {
   sm: {
     paddingVertical: 0.5,

--- a/packages/native/src/components/text-area/text-area.md
+++ b/packages/native/src/components/text-area/text-area.md
@@ -34,8 +34,8 @@ would change is the one telling you the truth.
 **Only `TextArea.Field` differs**, by three things: `multiline`, the text pinned to the top,
 and a height counted in lines.
 
-That is also HeroUI's answer — [their `TextArea`](https://github.com/heroui-inc/heroui-native/tree/main/src/components/text-area)
-is twenty lines rendering their `TextField` with the same three defaults. A component of its own
+That is also the reference implementation's answer — its `TextArea`
+is twenty lines rendering its `TextField` with the same three defaults. A component of its own
 is what a caller looks for; sharing every line of it is what keeps the two from drifting.
 
 So **everything in [`input.md`](../text-field/text-field.md) applies here**, and this page only covers
@@ -81,7 +81,7 @@ cache.
 
 ### A fixed height
 
-HeroUI's text area is a **fixed** 128 that scrolls rather than one that grows. That is a
+The reference implementation's text area is a **fixed** 128 that scrolls rather than one that grows. That is a
 style prop away (R14), rather than a second API:
 
 ```tsx

--- a/packages/native/src/components/text-area/text-area.tsx
+++ b/packages/native/src/components/text-area/text-area.tsx
@@ -24,7 +24,7 @@ const DEFAULT_ROWS = 3
  * `.Error` **are** the `TextField`'s slots — not wrappers around them, the same components —
  * and only `TextArea.Field` differs, by being multiline and by taking its height in lines.
  *
- * That is also HeroUI's answer: their `TextArea` renders their `TextField` with three defaults.
+ * That is also the reference implementation's answer: their `TextArea` renders their `TextField` with three defaults.
  * A component of its own is what a caller looks for; sharing every line of it is what
  * keeps the two from drifting.
  *

--- a/packages/native/src/components/text-field/text-field.md
+++ b/packages/native/src/components/text-field/text-field.md
@@ -129,13 +129,13 @@ and the reason there is no `fullWidth` prop.
 | `md`   | 48               | 12      | 16    | 16/24 | 14/20               |
 | `lg`   | 56               | 16      | 18    | 18/28 | 16/24               |
 
-`md` is HeroUI's input measured: a 48pt minimum, 12pt of horizontal padding, a 16/24 label
+`md` is the reference implementation's input measured: a 48pt minimum, 12pt of horizontal padding, a 16/24 label
 above the field and a 14/20 line below it.
 
 **A minimum and not a fixed height**, which is the one place this component departs from
 the rule the `Button` and the `Chip` follow. A `TextInput` with `multiline` holds three
 lines of the user's own text and has to grow; a control whose content is not the
-developer's cannot be truncated into shape. HeroUI reaches the same conclusion with
+developer's cannot be truncated into shape. The reference implementation reaches the same conclusion with
 `min-height`.
 
 The label and the help text carry a small horizontal inset — half the `md` field's padding
@@ -155,7 +155,7 @@ and nothing else has read since.
 | `tertiary`  | transparent       | `fieldBorder` | `fieldBorderFocus` | —       |
 | `ghost`     | transparent       | —             | — (no border)      | —       |
 
-The four names split HeroUI's two-name `primary | secondary` by saying what each of their
+The four names split the reference implementation's two-name `primary | secondary` by saying what each of their
 ends already is:
 
 - **`primary`** is their `primary` — the `fieldBackground` fill — plus the theme's `field`
@@ -168,7 +168,7 @@ ends already is:
   alone. Reach for `tertiary` when a focus ring matters.
 
 The first three name the `fieldBorder` edge and `ghost` gives it up. Its **width** is the
-theme's `borderWidth.field` — the same knob HeroUI exposes as `--field-border-width`, and
+theme's `borderWidth.field` — the same knob the reference implementation exposes as `--field-border-width`, and
 the one shipped default where the two libraries differ: **they ship `0`**, so their input is
 a fill with no visible edge, and we ship `1`. `createTheme({ borderWidth: { field: 0 } })`
 reproduces theirs exactly.
@@ -219,7 +219,7 @@ node that hears the event is `TextField.Field` — the field composes the caller
 `onBlur` with the two the context published, so your handlers run and the border still
 moves.
 
-### Alignment with `heroui-native`
+### Alignment with the reference implementation
 
 Measured against their `input.css`, `text-field.css`, `label.css`, `description.css`,
 `field-error.css` and `variables.css` rather than eyeballed.
@@ -236,10 +236,10 @@ both modes, and the field token is the one that can be themed apart later.
 
 **Two deltas, both deliberate and both in the theme rather than in this component:**
 
-| Token               | HeroUI           | XAUI              | Why                                                                                                                                                                                                                                                 |
-| ------------------- | ---------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `borderWidth.field` | `0`              | `1`               | Their input is a fill with no visible edge. Ours keeps a hairline, because `tertiary` — the border alone — has nothing left to be without it. Same knob, different shipped default: `createTheme({ borderWidth: { field: 0 } })` reproduces theirs. |
-| radius base         | `8` → field `14` | `12` → field `21` | `RADIUS_BASE` is a P0 decision that draws every corner in the library. Changing it for one component would be incoherent; changing it globally is a theme decision, not this one.                                                                   |
+| Token               | The reference implementation | XAUI              | Why                                                                                                                                                                                                                                                 |
+| ------------------- | ---------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `borderWidth.field` | `0`                          | `1`               | Their input is a fill with no visible edge. Ours keeps a hairline, because `tertiary` — the border alone — has nothing left to be without it. Same knob, different shipped default: `createTheme({ borderWidth: { field: 0 } })` reproduces theirs. |
+| radius base         | `8` → field `14`             | `12` → field `21` | `RADIUS_BASE` is a P0 decision that draws every corner in the library. Changing it for one component would be incoherent; changing it globally is a theme decision, not this one.                                                                   |
 
 **Two things we add that they do not have:** a focus state — their CSS has none, and the
 theme derived `fieldBorderFocus` for it — and the `field` shadow on `primary`, which is what

--- a/packages/native/src/components/text-field/text-field.recipe.ts
+++ b/packages/native/src/components/text-field/text-field.recipe.ts
@@ -28,7 +28,7 @@ const SLOTS = [
  * A variant **names tokens and computes nothing**: `paint` below decides where they land.
  *
  * The first three name the `fieldBorder` edge and `ghost` gives it up. Its **width** is
- * the theme's `borderWidth.field`, which is the same knob HeroUI exposes as
+ * the theme's `borderWidth.field`, which is the same knob the reference implementation exposes as
  * `--field-border-width` — and the one number where the two libraries' defaults differ:
  * they ship it at `0`, so their input is a fill with no visible edge, and we ship `1`.
  * `createTheme({ borderWidth: { field: 0 } })` reproduces theirs exactly.
@@ -75,7 +75,7 @@ const VARIANT_TOKENS: Record<TextFieldVariant, VariantTokens> = {
  * The height is a **minimum**, which is the one place this component departs from the
  * fixed-height rule the `Button` and the `Chip` follow. The reason is `multiline`: a
  * `TextInput` holding three lines of the user's own text has to grow, and a control whose
- * content is not the developer's cannot be truncated into shape. HeroUI reaches the same
+ * content is not the developer's cannot be truncated into shape. The reference implementation reaches the same
  * conclusion with `min-height` on their single size.
  *
  * The `gap` is one point tighter than the spacing scale's whole steps at every size — 3,
@@ -166,7 +166,7 @@ type SizeStep = {
 }
 
 /**
- * `md` is the anchor, and it is HeroUI's input measured: a 48pt minimum, 12pt of
+ * `md` is the anchor, and it is the reference implementation's input measured: a 48pt minimum, 12pt of
  * horizontal padding, a 16/24 label above the field and a 14/20 line below it. Their scale
  * has a single step; ours moves around that one, a control height and a step of type at a
  * time.
@@ -299,7 +299,7 @@ export const textFieldRecipe = createRecipe({
       borderWidth: theme.borderWidth.field,
       // The theme has a radius named for this component, so every size uses it and the
       // `radius` axis is what overrides it — the same shape a `Chip` takes from `full`.
-      // It is HeroUI's twelve points since the scale was aligned on theirs; it was 21,
+      // It is the reference implementation's twelve points since the scale was aligned on theirs; it was 21,
       // which put a 48-tall field at 87% of its geometric maximum.
       borderRadius: theme.radius.field,
       borderCurve: 'continuous',

--- a/packages/native/src/components/text-field/text-field.type.ts
+++ b/packages/native/src/components/text-field/text-field.type.ts
@@ -28,11 +28,11 @@ export type TextFieldSlot =
  * `success`, `warning` and `danger` are absent here for the same reason they are there.
  *
  * This is where the theme's `field*` family is finally read, and the four names split
- * HeroUI's two-name `primary | secondary` by saying what each of their ends already is:
+ * the reference implementation's two-name `primary | secondary` by saying what each of their ends already is:
  *
- * - **`primary`** — the `fieldBackground` fill plus the theme's `field` shadow. HeroUI's
+ * - **`primary`** — the `fieldBackground` fill plus the theme's `field` shadow. The reference implementation's
  *   `primary`, with the elevation their flat token only implies.
- * - **`secondary`** — the neutral `default` fill. HeroUI's `secondary`, and the default
+ * - **`secondary`** — the neutral `default` fill. The reference implementation's `secondary`, and the default
  *   here: on a plain background a white field is its border and nothing else, while on a
  *   card the `fieldBackground` token *is* the card's own colour.
  * - **`tertiary`** — the border alone, no fill. The same drop the `Button`'s `tertiary`
@@ -41,7 +41,7 @@ export type TextFieldSlot =
  *   to move, so its focus shows in the caret alone.
  *
  * The first three name the `fieldBorder` edge and `ghost` gives it up. Its width is the
- * theme's `borderWidth.field` — HeroUI's `--field-border-width`, which they ship at `0`
+ * theme's `borderWidth.field` — the reference implementation's `--field-border-width`, which they ship at `0`
  * and we ship at `1`. That is the one shipped default where the two differ;
  * `createTheme({ borderWidth: { field: 0 } })` reproduces theirs.
  */

--- a/packages/native/src/components/toast/toast.animation.ts
+++ b/packages/native/src/components/toast/toast.animation.ts
@@ -31,13 +31,13 @@ export function toastExiting(placement: ToastPlacement) {
 /**
  * How a card moves when the pile shifts — a dismissal promoting everything forward by one.
  *
- * HeroUI's 300 ms, and a timing rather than a spring: the cards move together, and a
+ * The reference implementation's 300 ms, and a timing rather than a spring: the cards move together, and a
  * spring would have them arrive at slightly different moments and read as a shuffle.
  */
 export const STACK_TIMING = { duration: 300 }
 
 /**
- * The swipe that throws a card away, in HeroUI's numbers.
+ * The swipe that throws a card away, in the reference implementation's numbers.
  *
  * `SWIPE_DISTANCE` **or** `SWIPE_VELOCITY` — either alone is enough. Distance without
  * velocity refuses a flick that clearly meant it; velocity without distance refuses a slow,

--- a/packages/native/src/components/toast/toast.md
+++ b/packages/native/src/components/toast/toast.md
@@ -109,7 +109,7 @@ and its depth is entirely in its transform, so a pile of eight costs the height 
 | 1         | `10` toward the edge | `0.97` |
 | 2         | `20`                 | `0.94` |
 
-Both numbers are HeroUI's, read off their `toast.animation.ts`: `translateY: [0, 10]` and
+Both numbers are the reference implementation's, read off their `toast.animation.ts`: `translateY: [0, 10]` and
 `scale: [1, 0.97]`, interpolated over the index. The shoulder a card leaves is
 `10 − 0.03 × height`, around 7 points on a two-line toast — enough to say there is another
 one, not enough to be read as a second card.
@@ -127,7 +127,7 @@ must not land on something nobody can see.
 The front card is thrown away by dragging it **away from its edge** — up on a top stack,
 down on a bottom one. The pile empties one card at a time, each swipe promoting the next.
 
-It goes past **50 points or 500 points a second**, HeroUI's thresholds, and either alone is
+It goes past **50 points or 500 points a second**, the reference implementation's thresholds, and either alone is
 enough: distance without velocity refuses a flick that clearly meant it, velocity without
 distance refuses a slow deliberate push. A toast is glanced at, so both readings count.
 
@@ -191,7 +191,7 @@ save succeeded has turned a good outcome into a bad one.
 
 ## It replaces `Snackbar`
 
-The legacy component is `Snackbar`. It is the same object under two names, and HeroUI calls
+The legacy component is `Snackbar`. It is the same object under two names, and the reference implementation calls
 it `toast`; the roadmap's P5.18 closes with this.
 
 | Legacy                        | v1                                     |

--- a/packages/native/src/components/toast/toast.recipe.ts
+++ b/packages/native/src/components/toast/toast.recipe.ts
@@ -31,7 +31,7 @@ export const toastRecipe = createRecipe({
     root: {
       backgroundColor: theme.colors.overlay,
       padding: theme.spacing(4),
-      // HeroUI's `--radius-3xl` on a base of 8 is 24 points; ours is 12, so the same 24
+      // The reference implementation's `--radius-3xl` on a base of 8 is 24 points; ours is 12, so the same 24
       // is `2xl`.
       borderRadius: theme.radius['2xl'],
       borderCurve: 'continuous',

--- a/packages/native/src/components/toast/toast.utils.ts
+++ b/packages/native/src/components/toast/toast.utils.ts
@@ -3,7 +3,7 @@ import type { ToastPlacement } from './toast.type'
 /**
  * How far one step back sits toward the edge, and how much it shrinks doing it.
  *
- * Both are HeroUI's, read off their `toast.animation.ts` rather than matched by eye:
+ * Both are the reference implementation's, read off their `toast.animation.ts` rather than matched by eye:
  * `translateY: [0, 10]` and `scale: [1, 0.97]`, interpolated over the index. The shoulder
  * a card leaves is `PEEK - SHRINK × height`, so around 7 points on a two-line toast —
  * enough to say "there is another one" and not enough to be read as a second card.
@@ -24,7 +24,7 @@ export type ToastStackStyle = {
  * edge, and depth is expressed entirely in the transform. That is what makes a pile of
  * eight cost the height of one.
  *
- * Nothing clamps the depth: HeroUI's interpolation clamps only the front side, so the
+ * Nothing clamps the depth: The reference implementation's interpolation clamps only the front side, so the
  * fourth card is genuinely further back than the third rather than sitting on it. What
  * ends the ladder is `maxVisible`, past which the card is transparent — and being still
  * mounted is the point, because dismissing the front one promotes it into view instead of

--- a/packages/native/src/components/typography/typography.type.ts
+++ b/packages/native/src/components/typography/typography.type.ts
@@ -3,7 +3,7 @@ import type { StyleProp, TextProps, TextStyle } from 'react-native'
 import type { TextStyleProps } from '../../system/style-props'
 
 /**
- * The ten roles, aligned with HeroUI Native's `text` — six headings, three body steps and
+ * The ten roles, aligned with the reference implementation's `text` — six headings, three body steps and
  * inline code. Each one fixes **size, line height, weight and family together**, which is
  * what removes the separate `size` and `weight` props the legacy component carried, and
  * with them the illegal combinations they allowed: a heading in `weight="light"`, a

--- a/packages/native/src/hooks/use-rotation.ts
+++ b/packages/native/src/hooks/use-rotation.ts
@@ -10,7 +10,7 @@ import {
 } from 'react-native-reanimated'
 
 /**
- * One turn. Slow enough to read as waiting, fast enough not to read as stuck — HeroUI
+ * One turn. Slow enough to read as waiting, fast enough not to read as stuck — the reference implementation
  * arrives at the same figure from the other side, a 1000ms turn played at 1.1×.
  *
  * It is a constant rather than a parameter because the library turns at one speed: two

--- a/packages/native/src/system/anchored/indicator-spring.ts
+++ b/packages/native/src/system/anchored/indicator-spring.ts
@@ -1,11 +1,11 @@
 /**
  * The chevron's turn, shared by the `Select` and the `Accordion`.
  *
- * HeroUI's numbers. Heavily damped against a very high stiffness: it arrives in about a
+ * The reference implementation's numbers. Heavily damped against a very high stiffness: it arrives in about a
  * fifth of a second and does not overshoot, which is what a turn of 180 degrees needs —
  * an oscillating chevron reads as a bug rather than as motion.
  */
 export const INDICATOR_SPRING = { damping: 140, stiffness: 1000, mass: 4 } as const
 
-/** Degrees. Down when closed, up when open, turning anticlockwise as HeroUI's does. */
+/** Degrees. Down when closed, up when open, turning anticlockwise as the reference implementation's does. */
 export const INDICATOR_ROTATION = [0, -180] as const

--- a/packages/native/src/theme/derive-colors.ts
+++ b/packages/native/src/theme/derive-colors.ts
@@ -5,7 +5,7 @@ import type { XAUIDerivedColors, XAUISourceColors } from './theme.type'
  * The derived layer: ~30 tokens computed from the source layer, never written by hand.
  * Override `accent` and `accentPressed`, `accentSoft`, `accentSoftForeground` follow.
  *
- * These are HeroUI's `color-mix(in oklab, …)` formulas transposed to JS, because React
+ * These are the reference implementation's `color-mix(in oklab, …)` formulas transposed to JS, because React
  * Native has no `color-mix()`. Their `-hover` names became `-pressed`: what they feed is
  * the press overlay, and the web name was a leftover.
  *

--- a/packages/native/src/theme/scales.ts
+++ b/packages/native/src/theme/scales.ts
@@ -23,7 +23,7 @@ export function buildRadius(base: number): XAUIRadius {
     '3xl': base * 3,
     '4xl': base * 4,
     /**
-     * HeroUI's value, reached from the other side of the scale: their `--radius-field` is
+     * The reference implementation's value, reached from the other side of the scale: their `--radius-field` is
      * an alias of their `--radius-xl`, and their base is 8 where ours is 12 — so their
      * field corner is 12 points and, at our default base, so is this.
      *
@@ -77,7 +77,7 @@ export const fontFamilies: XAUITheme['fontFamilies'] = {
   heading: 'System',
   // `'monospace'` is an Android family name, not a generic one: iOS does not resolve it and
   // silently falls back to the system face, so code set with it is not monospaced there.
-  // Menlo is the face iOS ships, and it is what HeroUI Native selects for the same reason.
+  // Menlo is the face iOS ships, and it is what the reference implementation selects for the same reason.
   mono: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
 }
 

--- a/packages/native/src/utils/placement.ts
+++ b/packages/native/src/utils/placement.ts
@@ -105,7 +105,7 @@ export function resolvePlacement(input: PlacementInput): PlacementResult {
   // that, a panel beside a trigger with no room for it goes off the screen entirely —
   // which is what `start` and `end` did until the day someone opened one.
   //
-  // The panel may then overlap its own trigger. That is the right trade and the one HeroUI
+  // The panel may then overlap its own trigger. That is the right trade and the one the reference implementation
   // makes too: a panel covering the button that opened it is legible, and a panel past the
   // edge of the screen is not.
   const top = clamp(


### PR DESCRIPTION
## What

Removes every reference to **HeroUI** and **Flutter** from the repository outside the
frozen `packages/native-legacy` tree.

- **HeroUI** — every design note that named the library it was measured against now reads
  "the reference implementation". Touches `packages/native` doc comments (`.type.ts`,
  `.recipe.ts`, `.tsx`, hooks, theme, system), the component `.md` pages,
  `packages/native/CHANGELOG.md`, the `.agents/` + `.claude/` skills, `.project-specs/`
  (plan, API review, roadmap, `derive.mjs`), the pending `.changeset/*.md` entries, and
  the `apps/demo` screen notes.
- **Flutter** — the "Flutter-inspired" framing is dropped from `README.md` and
  `CONTRIBUTING.md` ("composition-first" instead).
- `apps/docs` generated output (`public/docs/*.md`, `lib/data/native-api.generated.json`,
  `llms.txt`, …) regenerated with `pnpm docs:generate`.
- `.changeset/field-radius-heroui.md` → `.changeset/field-radius-align.md`, with the
  matching entry in `.changeset/pre.json` renamed so the consumed-changesets list stays
  coherent. Nothing else in `pre.json` is touched.

## Why

Retire the third-party attribution ahead of v1.

## How

Scripted prose substitution plus manual passes for the French specs, sentence-initial
capitalisation, and one broken markdown link in `text-area.md`. No API, token, value,
animation constant or behaviour is changed — comments and docs only.

`packages/native-legacy` is left untouched (frozen tree; still carries the `flutter`
keyword and Flutter-style API notes by design).

## Checks

- `pnpm lint` — clean (one pre-existing `demo` warning in `segment.tsx`, unrelated)
- `pnpm --filter @xaui/native type-check` — clean
- `pnpm --filter @xaui/native test` — 603/603 pass
- `pnpm prettier --check` on the touched files — clean
- `docs#type-check` fails on a pre-existing stale `.next` artifact
  (`expansion-panel/page.js`), reproducible on `main` before this change