### PR TITLE
docs: define Hybrid beta parity roadmap

### DIFF
--- a/.agents/skills/xaui-flow/SKILL.md
+++ b/.agents/skills/xaui-flow/SKILL.md
@@ -24,7 +24,7 @@ remaining items can be ordered freely.
 | **P3** | The fifteen-component core, in the plan's order                                                                                              | alphas                                                             |
 | **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                               |
 | **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                              |
-| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                                  |
+| **P6** | API-identical `@xaui/hybrid`, rendered with Emotion Styled + Framer Motion                                                                   | `@xaui/hybrid@0.9.x-beta.x`                                        |
 | **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                            |
 
 Two consequences worth stating out loud when a request cuts across them:
@@ -45,7 +45,7 @@ components, everything else waits for `1.x` (plan §10).
 | A component: new, new slot, legacy → v1 conversion                                       | `xaui-component`        |
 | Tokens, OKLab, `deriveColors`, `createTheme`, provider, `tokens:check`                   | `xaui-theme`            |
 | `system/` — recipe, style cache, slots, `asChild`, `PressableFeedback`, `Portal`, `Icon` | `xaui-system`           |
-| `packages/hybrid`, `em` units, web renderer                                              | `xaui-hybrid`           |
+| `packages/hybrid`, pixel-equivalent scaling, web renderer                                | `xaui-hybrid`           |
 | `apps/docs`, `apps/demo`, prop tables, `llms.txt`                                        | `xaui-docs`             |
 | `native-legacy`, `core-shim`, codemods, `@deprecated`                                    | `xaui-legacy-migration` |
 | Checking work against the v1 rules                                                       | `xaui-review`           |
@@ -136,6 +136,10 @@ why — resolving it would hide the disagreement rather than settle it.
 light and dark — that is how a component is verified, not a test file · the doc page follows
 the eight-section structure · the legacy equivalent carries `@deprecated` pointing at the
 replacement · a changeset is committed.
+
+For P6, the `xaui-hybrid` definition of done replaces the demo/doc requirements: the Native
+documentation remains the single source for the shared API, no `apps/docs` file changes, and
+the port passes the Hybrid browser check plus export/type parity checks against Native.
 
 ## When to stop and ask
 

--- a/.agents/skills/xaui-hybrid/SKILL.md
+++ b/.agents/skills/xaui-hybrid/SKILL.md
@@ -1,63 +1,117 @@
 ---
 name: xaui-hybrid
-description: Port a component or theme from @xaui/native to @xaui/hybrid (web renderer for mobile webviews) with the em sizing convention. Use when working in packages/hybrid, porting a native component to the web renderer, or fixing an em/px or RN-shorthand issue in hybrid styles.
+description: Port the @xaui/native v1 API to @xaui/hybrid with Emotion Styled, Framer Motion, strict public-API parity, DOM-safe props, and pixel-equivalent responsive sizing. Use for any work in packages/hybrid or any Native-to-Hybrid port.
 ---
 
 # XAUI — Porting to `@xaui/hybrid`
 
-`@xaui/hybrid` is the same public API rendered on the web. **It is frozen from P0 to P4** —
-no new component, no API change — so that no decision has to be paid for twice before it
-stabilises. Work here resumes after `@xaui/native@1.0.0` (plan §9/P6). If a task asks for a
-hybrid component while the native v1 core is unfinished, say so before starting.
+`@xaui/hybrid` is the web renderer of `@xaui/native`, not a related API. It remains frozen
+until P4 ships, then follows the P6 order in `.project-specs/XAUI-V1-PLAN.md`. P6 remains on
+`0.9.x-beta.x` and the `beta` dist-tag even after parity; do not publish a stable or `1.0.0`
+Hybrid version without a separate explicit task.
 
-Once it resumes: same folder tree, same file names, same testing rule as native. Only `.style.ts`
-and the renderer differ — `createRecipe` is taken as-is, it is pure resolution and the
-renderer only comes in at the very end.
+## The parity contract
 
-## The `em` rule — the whole reason this package has a convention
+For every Native entry, Hybrid has the same subpath, component names, dot-notation slots,
+exported context hooks, XAUI-owned props, unions, defaults and controlled/uncontrolled
+behaviour. Keep `variant`, `color`, style props, `style`, `asChild`, accessibility and the
+style precedence identical.
 
-Every size in `@xaui/hybrid` uses **`em`**, never `px`, so the hybrid version scales
-identically to the native one:
+Only host-bound types differ where the platform makes identity impossible: a ref targets a
+DOM element and an event is a DOM event. Adapt those at the renderer boundary without adding
+Hybrid-only props. Add or update the export/type parity checks with every port; a difference
+is a defect unless Native changed first.
+
+Do not add Hybrid component pages or previews to `apps/docs`. Native documentation is the
+single documentation source for the shared API.
+
+## Renderer choices
+
+- Use `@emotion/styled` for every styled node. No Tailwind, inline stylesheet system or CSS
+  file in `packages/hybrid`.
+- Use Framer Motion for every animation. Preserve the public animation props and semantics,
+  make `animation={false}` static, and respect reduced-motion preferences.
+- Filter XAUI props and style props before they reach the DOM. Unknown-property warnings are
+  renderer bugs, not harmless noise.
+- Preserve `asChild`, ref merging, event composition, focus and keyboard activation.
+- Map accessibility props to the equivalent semantic element, role and ARIA attributes while
+  keeping the Native-facing prop names.
+
+## Geometry and device scaling
+
+Public numeric style values keep their React Native meaning. At scale 1, **one Native point
+equals one CSS logical pixel**: a Native size of `4` must have a computed Hybrid size of
+`4px`, not `4em` or a density-multiplied value.
+
+Use a root-relative conversion at the Emotion renderer boundary:
 
 ```ts
-const toEm = (px: number) => `${px / 16}em`
+const toWebUnit = (value: number) => `${value / 16}rem`
 ```
 
-Applies to spacing (padding, margin, gap), dimensions (width, height), border
-(`borderWidth`, `borderRadius`), typography (`fontSize`) — **every fixed pixel value**
-coming from the theme or from the native `StyleSheet`.
+With the browser's default `16px` root, `toWebUnit(4)` is `0.25rem` and computes to `4px`.
+Using `rem` instead of a local `em` prevents a parent's text size from silently enlarging a
+nested component. Do not force the document root back to `16px`: browser zoom, a user's root
+font-size preference and device DPR are the natural scaling layer. Never multiply dimensions
+by DPR, viewport width or another device factor inside a component.
 
-## Porting a native component
+Convert every fixed length at this boundary: spacing, dimensions, gaps, borders, radii,
+typography and every hardcoded length brought over from Native. Do not convert unitless values
+such as opacity, flex ratios, font weight or z-index. Preserve strings the public API already
+accepts.
 
-1. Copy the folder shape verbatim: `.recipe.ts`, `.context.ts`, `.type.ts`, `.hook.ts`,
-   `.style.ts`, root, one file per slot, `index.ts`.
-2. Use `toEm()` on the **number** a theme lookup produces — `toEm(theme.spacing(2))`,
-   `toEm(theme.borderWidth.default)`, `toEm(theme.fontSizes.md)`, `toEm(theme.radius.md)`.
-   `spacing` is a function, not a table, so `toEm(theme.spacing)` yields `NaNem`.
-3. Wrap every hardcoded pixel value from the native `StyleSheet` too — `gap: 12` becomes
-   `gap: toEm(12)`.
-4. **Use CSS-valid properties only.** Never RN shorthands: no `paddingVertical`,
-   `paddingHorizontal`, `marginVertical`, `marginHorizontal` — split them into
-   `paddingTop`/`paddingBottom`, `paddingLeft`/`paddingRight`, etc. The token generator
-   does this split automatically for generated tokens; hand-written styles are on you.
-5. No component test file — same rule as native. Only pure helpers are tested, in the
-   mirror `__tests__/` path.
-6. Same subpath export shape: `@xaui/hybrid/<component>`.
+Translate direction-aware Native names to CSS logical properties, for example
+`paddingStart` → `paddingInlineStart` and `start` → `insetInlineStart`. Do not replace them
+with physical left/right properties. Expand RN-only internal shorthands before styling.
 
-Styling uses Tailwind or framer-motion for animation — **no CSS files** (CLAUDE.md).
+Use `toWebUnit()` on a resolved number such as `toWebUnit(theme.spacing(2))`; `spacing` is a
+function, so passing the function itself produces an invalid value.
 
 ## Tokens
 
-`packages/hybrid/src/theme/tokens.gen.ts` is **generated** from the single source in
-`tooling/tokens/source.ts` with the `em` conversion applied. Never edit it by hand, and
-regenerate it in the same commit as any native token change — `pnpm tokens:check` fails the
-build when native and hybrid drift apart.
+`packages/hybrid/src/theme/tokens.gen.ts` is generated from
+`tooling/tokens/source.ts`; never edit it by hand. Regenerate it with the Native tokens in
+the same commit. `pnpm tokens:check` must keep keys and generated values in parity.
+
+## Porting shape
+
+Mirror Native's source boundaries and component folder names: recipe, context, types, hooks,
+root, one file per slot, styles and index. Animation files keep the same responsibility but
+use Framer Motion. Pure recipe resolution keeps the Native semantics; Emotion enters only at
+the styled-node boundary.
+
+Every component subpath must exist in both `package.json` and `tsup.config.ts`. Root exports
+must match Native as well.
+
+Tests follow the repository rule: only pure functions receive unit tests. Components, slots,
+hooks and animation constants are verified in a browser, not with component test files.
+
+## P6 order
+
+1. Contract and renderer: theme, provider, hooks, system primitives, Emotion, Framer Motion,
+   DOM filtering and parity checks.
+2. Reference slice: `Typography`/`TextSpan`, `Icon`, `view`, `Spinner`, `Button`.
+3. Static primitives: `Surface`, `Divider`, `Skeleton`, both progress components, `Card`,
+   `Avatar`, `Badge`.
+4. Actions/status: `CloseButton`, `Chip`, `Alert`, `Fab`, `MorphButton`, `EmptyState`,
+   `Widget`, `FlipCard`.
+5. Fields/selection: `TextField` through `TagGroup`, in P6.4 of the plan.
+6. Overlays/choices: `Accordion` through `Snackbar`, in P6.5 of the plan.
+7. Date/calendar, then data/navigation, then charts, in P6.6–P6.8.
+8. Parity milestone: all 75 subpaths, exports and public types match before the next beta
+   release. Parity does not graduate Hybrid from beta.
 
 ## Review checklist
 
-- [ ] No `px` literal anywhere in a style, no bare number where a length is expected.
-- [ ] No RN shorthand property.
-- [ ] No CSS file added.
-- [ ] Same component API as native — props, slots, `variant` values, `asChild`.
-- [ ] Any pure helper added has a test; the component itself has none.
-- [ ] `pnpm lint && pnpm type-check && pnpm test` pass.
+- [ ] Same subpath, exports, slots, hook, XAUI props, unions and defaults as Native.
+- [ ] Emotion Styled only; no CSS file or Tailwind in the package.
+- [ ] Framer Motion only; static opt-out and reduced motion both work.
+- [ ] No style or XAUI-only prop leaks to the DOM.
+- [ ] At a `16px` root, every Native numeric length computes to the same CSS pixel value
+      (`4` → `0.25rem` → `4px`); no local font-size or DPR multiplier changes it.
+- [ ] Fixed lengths use the root-relative conversion; unitless values remain unitless.
+- [ ] Logical CSS properties preserve RTL behaviour; no physical left/right style.
+- [ ] `style` remains the final override and does not change descendant slots.
+- [ ] Only pure helpers have unit tests; browser verification covers rendering and motion.
+- [ ] `apps/docs` is untouched.
+- [ ] lint, type-check, tests, build, tarball check and export/type parity all pass.

--- a/.agents/skills/xaui-theme/SKILL.md
+++ b/.agents/skills/xaui-theme/SKILL.md
@@ -114,13 +114,13 @@ Acceptance: a parent that re-renders 100 times recomputes the theme zero times.
 
 ```
 tooling/tokens/source.ts → packages/native/src/theme/tokens.gen.ts   (numbers, hex)
-                         → packages/hybrid/src/theme/tokens.gen.ts   (em, via toEm)
+                         → packages/hybrid/src/theme/tokens.gen.ts   (same colours)
 ```
 
-`generate.ts` writes **both layers already resolved** for the default light and dark
+`generate.ts` writes **both colour layers already resolved** for the default light and dark
 themes — no colour maths at app startup. `deriveColors` only runs at runtime when the user
-overrides the source layer. It also applies hybrid's `em` convention and splits RN
-shorthands (`paddingVertical` → `paddingTop`/`paddingBottom`) on the web side.
+overrides the source layer. Dimensional theme values remain RN numbers in both packages;
+Hybrid converts them to root-relative CSS units only at its Emotion renderer boundary.
 
 Three guards, all blocking:
 
@@ -139,4 +139,4 @@ Files ending in `.gen.ts` are **never edited by hand** — change `source.ts` an
 - [ ] `pnpm tokens:check` produces no diff.
 - [ ] Contrast job still green for every `X`/`XForeground` pair.
 - [ ] Frozen-value tests updated intentionally, never "to make the suite pass".
-- [ ] Hybrid's `tokens.gen.ts` regenerated in the same commit (`em` units).
+- [ ] Hybrid's `tokens.gen.ts` regenerated in the same commit with the same colour values.

--- a/.claude/skills/xaui-flow/SKILL.md
+++ b/.claude/skills/xaui-flow/SKILL.md
@@ -24,7 +24,7 @@ remaining items can be ordered freely.
 | **P3** | The fifteen-component core, in the plan's order                                                                                              | alphas                                                             |
 | **P4** | Docs, generated prop tables, migration guide, `llms.txt`                                                                                     | `@xaui/native@1.0.0`                                               |
 | **P5** | The remaining 32, then the parity milestone                                                                                                  | `1.x`                                                              |
-| **P6** | `@xaui/hybrid` resumes                                                                                                                       | —                                                                  |
+| **P6** | API-identical `@xaui/hybrid`, rendered with Emotion Styled + Framer Motion                                                                   | `@xaui/hybrid@0.9.x-beta.x`                                        |
 | **P7** | Delete `native-legacy`                                                                                                                       | `2.0.0`                                                            |
 
 Two consequences worth stating out loud when a request cuts across them:
@@ -45,7 +45,7 @@ components, everything else waits for `1.x` (plan §10).
 | A component: new, new slot, legacy → v1 conversion                                       | `xaui-component`        |
 | Tokens, OKLab, `deriveColors`, `createTheme`, provider, `tokens:check`                   | `xaui-theme`            |
 | `system/` — recipe, style cache, slots, `asChild`, `PressableFeedback`, `Portal`, `Icon` | `xaui-system`           |
-| `packages/hybrid`, `em` units, web renderer                                              | `xaui-hybrid`           |
+| `packages/hybrid`, pixel-equivalent scaling, web renderer                                | `xaui-hybrid`           |
 | `apps/docs`, `apps/demo`, prop tables, `llms.txt`                                        | `xaui-docs`             |
 | `native-legacy`, `core-shim`, codemods, `@deprecated`                                    | `xaui-legacy-migration` |
 | Checking work against the v1 rules                                                       | `xaui-review`           |
@@ -136,6 +136,10 @@ why — resolving it would hide the disagreement rather than settle it.
 light and dark — that is how a component is verified, not a test file · the doc page follows
 the eight-section structure · the legacy equivalent carries `@deprecated` pointing at the
 replacement · a changeset is committed.
+
+For P6, the `xaui-hybrid` definition of done replaces the demo/doc requirements: the Native
+documentation remains the single source for the shared API, no `apps/docs` file changes, and
+the port passes the Hybrid browser check plus export/type parity checks against Native.
 
 ## When to stop and ask
 

--- a/.claude/skills/xaui-hybrid/SKILL.md
+++ b/.claude/skills/xaui-hybrid/SKILL.md
@@ -1,63 +1,117 @@
 ---
 name: xaui-hybrid
-description: Port a component or theme from @xaui/native to @xaui/hybrid (web renderer for mobile webviews) with the em sizing convention. Use when working in packages/hybrid, porting a native component to the web renderer, or fixing an em/px or RN-shorthand issue in hybrid styles.
+description: Port the @xaui/native v1 API to @xaui/hybrid with Emotion Styled, Framer Motion, strict public-API parity, DOM-safe props, and pixel-equivalent responsive sizing. Use for any work in packages/hybrid or any Native-to-Hybrid port.
 ---
 
 # XAUI — Porting to `@xaui/hybrid`
 
-`@xaui/hybrid` is the same public API rendered on the web. **It is frozen from P0 to P4** —
-no new component, no API change — so that no decision has to be paid for twice before it
-stabilises. Work here resumes after `@xaui/native@1.0.0` (plan §9/P6). If a task asks for a
-hybrid component while the native v1 core is unfinished, say so before starting.
+`@xaui/hybrid` is the web renderer of `@xaui/native`, not a related API. It remains frozen
+until P4 ships, then follows the P6 order in `.project-specs/XAUI-V1-PLAN.md`. P6 remains on
+`0.9.x-beta.x` and the `beta` dist-tag even after parity; do not publish a stable or `1.0.0`
+Hybrid version without a separate explicit task.
 
-Once it resumes: same folder tree, same file names, same testing rule as native. Only `.style.ts`
-and the renderer differ — `createRecipe` is taken as-is, it is pure resolution and the
-renderer only comes in at the very end.
+## The parity contract
 
-## The `em` rule — the whole reason this package has a convention
+For every Native entry, Hybrid has the same subpath, component names, dot-notation slots,
+exported context hooks, XAUI-owned props, unions, defaults and controlled/uncontrolled
+behaviour. Keep `variant`, `color`, style props, `style`, `asChild`, accessibility and the
+style precedence identical.
 
-Every size in `@xaui/hybrid` uses **`em`**, never `px`, so the hybrid version scales
-identically to the native one:
+Only host-bound types differ where the platform makes identity impossible: a ref targets a
+DOM element and an event is a DOM event. Adapt those at the renderer boundary without adding
+Hybrid-only props. Add or update the export/type parity checks with every port; a difference
+is a defect unless Native changed first.
+
+Do not add Hybrid component pages or previews to `apps/docs`. Native documentation is the
+single documentation source for the shared API.
+
+## Renderer choices
+
+- Use `@emotion/styled` for every styled node. No Tailwind, inline stylesheet system or CSS
+  file in `packages/hybrid`.
+- Use Framer Motion for every animation. Preserve the public animation props and semantics,
+  make `animation={false}` static, and respect reduced-motion preferences.
+- Filter XAUI props and style props before they reach the DOM. Unknown-property warnings are
+  renderer bugs, not harmless noise.
+- Preserve `asChild`, ref merging, event composition, focus and keyboard activation.
+- Map accessibility props to the equivalent semantic element, role and ARIA attributes while
+  keeping the Native-facing prop names.
+
+## Geometry and device scaling
+
+Public numeric style values keep their React Native meaning. At scale 1, **one Native point
+equals one CSS logical pixel**: a Native size of `4` must have a computed Hybrid size of
+`4px`, not `4em` or a density-multiplied value.
+
+Use a root-relative conversion at the Emotion renderer boundary:
 
 ```ts
-const toEm = (px: number) => `${px / 16}em`
+const toWebUnit = (value: number) => `${value / 16}rem`
 ```
 
-Applies to spacing (padding, margin, gap), dimensions (width, height), border
-(`borderWidth`, `borderRadius`), typography (`fontSize`) — **every fixed pixel value**
-coming from the theme or from the native `StyleSheet`.
+With the browser's default `16px` root, `toWebUnit(4)` is `0.25rem` and computes to `4px`.
+Using `rem` instead of a local `em` prevents a parent's text size from silently enlarging a
+nested component. Do not force the document root back to `16px`: browser zoom, a user's root
+font-size preference and device DPR are the natural scaling layer. Never multiply dimensions
+by DPR, viewport width or another device factor inside a component.
 
-## Porting a native component
+Convert every fixed length at this boundary: spacing, dimensions, gaps, borders, radii,
+typography and every hardcoded length brought over from Native. Do not convert unitless values
+such as opacity, flex ratios, font weight or z-index. Preserve strings the public API already
+accepts.
 
-1. Copy the folder shape verbatim: `.recipe.ts`, `.context.ts`, `.type.ts`, `.hook.ts`,
-   `.style.ts`, root, one file per slot, `index.ts`.
-2. Use `toEm()` on the **number** a theme lookup produces — `toEm(theme.spacing(2))`,
-   `toEm(theme.borderWidth.default)`, `toEm(theme.fontSizes.md)`, `toEm(theme.radius.md)`.
-   `spacing` is a function, not a table, so `toEm(theme.spacing)` yields `NaNem`.
-3. Wrap every hardcoded pixel value from the native `StyleSheet` too — `gap: 12` becomes
-   `gap: toEm(12)`.
-4. **Use CSS-valid properties only.** Never RN shorthands: no `paddingVertical`,
-   `paddingHorizontal`, `marginVertical`, `marginHorizontal` — split them into
-   `paddingTop`/`paddingBottom`, `paddingLeft`/`paddingRight`, etc. The token generator
-   does this split automatically for generated tokens; hand-written styles are on you.
-5. No component test file — same rule as native. Only pure helpers are tested, in the
-   mirror `__tests__/` path.
-6. Same subpath export shape: `@xaui/hybrid/<component>`.
+Translate direction-aware Native names to CSS logical properties, for example
+`paddingStart` → `paddingInlineStart` and `start` → `insetInlineStart`. Do not replace them
+with physical left/right properties. Expand RN-only internal shorthands before styling.
 
-Styling uses Tailwind or framer-motion for animation — **no CSS files** (CLAUDE.md).
+Use `toWebUnit()` on a resolved number such as `toWebUnit(theme.spacing(2))`; `spacing` is a
+function, so passing the function itself produces an invalid value.
 
 ## Tokens
 
-`packages/hybrid/src/theme/tokens.gen.ts` is **generated** from the single source in
-`tooling/tokens/source.ts` with the `em` conversion applied. Never edit it by hand, and
-regenerate it in the same commit as any native token change — `pnpm tokens:check` fails the
-build when native and hybrid drift apart.
+`packages/hybrid/src/theme/tokens.gen.ts` is generated from
+`tooling/tokens/source.ts`; never edit it by hand. Regenerate it with the Native tokens in
+the same commit. `pnpm tokens:check` must keep keys and generated values in parity.
+
+## Porting shape
+
+Mirror Native's source boundaries and component folder names: recipe, context, types, hooks,
+root, one file per slot, styles and index. Animation files keep the same responsibility but
+use Framer Motion. Pure recipe resolution keeps the Native semantics; Emotion enters only at
+the styled-node boundary.
+
+Every component subpath must exist in both `package.json` and `tsup.config.ts`. Root exports
+must match Native as well.
+
+Tests follow the repository rule: only pure functions receive unit tests. Components, slots,
+hooks and animation constants are verified in a browser, not with component test files.
+
+## P6 order
+
+1. Contract and renderer: theme, provider, hooks, system primitives, Emotion, Framer Motion,
+   DOM filtering and parity checks.
+2. Reference slice: `Typography`/`TextSpan`, `Icon`, `view`, `Spinner`, `Button`.
+3. Static primitives: `Surface`, `Divider`, `Skeleton`, both progress components, `Card`,
+   `Avatar`, `Badge`.
+4. Actions/status: `CloseButton`, `Chip`, `Alert`, `Fab`, `MorphButton`, `EmptyState`,
+   `Widget`, `FlipCard`.
+5. Fields/selection: `TextField` through `TagGroup`, in P6.4 of the plan.
+6. Overlays/choices: `Accordion` through `Snackbar`, in P6.5 of the plan.
+7. Date/calendar, then data/navigation, then charts, in P6.6–P6.8.
+8. Parity milestone: all 75 subpaths, exports and public types match before the next beta
+   release. Parity does not graduate Hybrid from beta.
 
 ## Review checklist
 
-- [ ] No `px` literal anywhere in a style, no bare number where a length is expected.
-- [ ] No RN shorthand property.
-- [ ] No CSS file added.
-- [ ] Same component API as native — props, slots, `variant` values, `asChild`.
-- [ ] Any pure helper added has a test; the component itself has none.
-- [ ] `pnpm lint && pnpm type-check && pnpm test` pass.
+- [ ] Same subpath, exports, slots, hook, XAUI props, unions and defaults as Native.
+- [ ] Emotion Styled only; no CSS file or Tailwind in the package.
+- [ ] Framer Motion only; static opt-out and reduced motion both work.
+- [ ] No style or XAUI-only prop leaks to the DOM.
+- [ ] At a `16px` root, every Native numeric length computes to the same CSS pixel value
+      (`4` → `0.25rem` → `4px`); no local font-size or DPR multiplier changes it.
+- [ ] Fixed lengths use the root-relative conversion; unitless values remain unitless.
+- [ ] Logical CSS properties preserve RTL behaviour; no physical left/right style.
+- [ ] `style` remains the final override and does not change descendant slots.
+- [ ] Only pure helpers have unit tests; browser verification covers rendering and motion.
+- [ ] `apps/docs` is untouched.
+- [ ] lint, type-check, tests, build, tarball check and export/type parity all pass.

--- a/.claude/skills/xaui-theme/SKILL.md
+++ b/.claude/skills/xaui-theme/SKILL.md
@@ -114,13 +114,13 @@ Acceptance: a parent that re-renders 100 times recomputes the theme zero times.
 
 ```
 tooling/tokens/source.ts → packages/native/src/theme/tokens.gen.ts   (numbers, hex)
-                         → packages/hybrid/src/theme/tokens.gen.ts   (em, via toEm)
+                         → packages/hybrid/src/theme/tokens.gen.ts   (same colours)
 ```
 
-`generate.ts` writes **both layers already resolved** for the default light and dark
+`generate.ts` writes **both colour layers already resolved** for the default light and dark
 themes — no colour maths at app startup. `deriveColors` only runs at runtime when the user
-overrides the source layer. It also applies hybrid's `em` convention and splits RN
-shorthands (`paddingVertical` → `paddingTop`/`paddingBottom`) on the web side.
+overrides the source layer. Dimensional theme values remain RN numbers in both packages;
+Hybrid converts them to root-relative CSS units only at its Emotion renderer boundary.
 
 Three guards, all blocking:
 
@@ -139,4 +139,4 @@ Files ending in `.gen.ts` are **never edited by hand** — change `source.ts` an
 - [ ] `pnpm tokens:check` produces no diff.
 - [ ] Contrast job still green for every `X`/`XForeground` pair.
 - [ ] Frozen-value tests updated intentionally, never "to make the suite pass".
-- [ ] Hybrid's `tokens.gen.ts` regenerated in the same commit (`em` units).
+- [ ] Hybrid's `tokens.gen.ts` regenerated in the same commit with the same colour values.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -165,7 +165,17 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P5.45 | `Widget` — net new, no legacy equivalent | done |
 | P5.47 | `Scaffold` — the app's chrome over `useAppearance`: the ground, the status bar and the navigator's options, with no navigator dependency | done |
 | P5.46 | Parity milestone — `npm deprecate @xaui/native-legacy` | todo |
-| P6 | `@xaui/hybrid` on the v1 API — frozen until P4 ships | todo |
+| P6 | `@xaui/hybrid` on the identical v1 API — Emotion Styled + Framer Motion, no docs fork | todo |
+| P6.0 | Hybrid contract and renderer — Emotion, Framer Motion, `1 Native point = 1 CSS logical pixel` at scale 1, export/type parity | todo |
+| P6.1 | Hybrid reference slice — `Typography`, `Icon`, `view`, `Spinner`, `Button` | todo |
+| P6.2 | Hybrid static primitives — `Surface` through `Badge` | todo |
+| P6.3 | Hybrid actions and status — `CloseButton` through `FlipCard` | todo |
+| P6.4 | Hybrid fields and selection — `TextField` through `TagGroup` | todo |
+| P6.5 | Hybrid overlays and composed choices — `Accordion` through `Snackbar` | todo |
+| P6.6 | Hybrid date and calendar — `Calendar` through `DateTimePicker` | todo |
+| P6.7 | Hybrid data and navigation — `List` through `Scaffold` | todo |
+| P6.8 | Hybrid charts — `Chart`, line, area, bar, pie, radar and radial | todo |
+| P6.9 | Hybrid parity milestone — 75 matching subpaths/exports/types, publish `0.9.x-beta.x` only | todo |
 | P7 | Delete `native-legacy` — not before the P5 parity milestone | todo |
 
 ## Repository debt

--- a/.project-specs/XAUI-V1-PLAN.md
+++ b/.project-specs/XAUI-V1-PLAN.md
@@ -1025,12 +1025,14 @@ Une couleur ponctuelle sur un composant n'est **pas** une surcharge de thème : 
 
 ```
 tooling/tokens/source.ts     →  packages/native/src/theme/tokens.gen.ts   (nombres, hex)
-                             →  packages/hybrid/src/theme/tokens.gen.ts   (em, via toEm)
+                             →  packages/hybrid/src/theme/tokens.gen.ts   (mêmes couleurs)
 ```
 
 `generate.ts` écrit **les deux couches déjà résolues** pour les thèmes par défaut clair et sombre — aucun calcul de couleur au démarrage de l'app. `deriveColors` n'est exécuté à l'exécution que si l'utilisateur surcharge la couche source.
 
-`generate.ts` applique aussi la convention `em` de hybrid (documentée dans CLAUDE.md) et éclate les shorthands RN (`paddingVertical` → `paddingTop`/`paddingBottom`) côté web.
+Les tokens générés sont des couleurs et restent identiques dans les deux packages. Les nombres
+du thème restent eux aussi des nombres RN ; leur conversion en unité CSS appartient au
+renderer Hybrid, pas au générateur de tokens.
 
 **Trois garde-fous CI :**
 
@@ -1513,11 +1515,53 @@ Même boucle par composant. Commencer par les dix qui ont déjà un contexte de 
 
 ---
 
-### P6 — Hybrid (après la 1.0)
+### P6 — Hybrid beta (après la 1.0 Native)
 
 `@xaui/hybrid` est **gelé de P0 à P4** : aucun nouveau composant, aucun changement d'API. Sinon chaque décision se paie deux fois avant d'être stabilisée.
 
-Il reprend ensuite avec la même arborescence, les mêmes noms de fichiers et les mêmes tests. Seuls `.style.ts` et le renderer diffèrent — `createRecipe` est repris tel quel, c'est de la résolution pure et le renderer n'intervient qu'au bout.
+Il reprend ensuite comme **renderer web de la même API**, pas comme une deuxième librairie :
+
+- mêmes sous-chemins, composants, slots, hooks de contexte, props XAUI, unions, valeurs par
+  défaut et comportements contrôlés/non contrôlés ;
+- mêmes règles `variant`, `color`, style props, `style`, `asChild`, accessibilité et ordre de
+  priorité ;
+- seules les cibles de `ref`, les objets d'événement hôte et l'implémentation du renderer
+  s'adaptent au DOM — aucune prop Hybrid n'est ajoutée pour les compenser ;
+- `@emotion/styled` rend tous les styles et filtre les style props avant le DOM ;
+- Framer Motion rend toutes les animations et respecte les mêmes props publiques,
+  `animation={false}` et la préférence de réduction des mouvements ;
+- les nombres restent des valeurs RN dans l'API publique. À l'échelle 1, un point Native vaut
+  un pixel logique CSS : `4` devient `0.25rem`, soit `4px` calculés avec une racine à `16px`.
+  La conversion est relative à la racine, jamais au texte parent, et aucun multiplicateur DPR
+  ou viewport n'est appliqué par les composants. Zoom, réglages d'accessibilité et DPR gardent
+  ainsi le scaling naturel du device ;
+- les directions deviennent des propriétés CSS logiques ;
+- aucune page ni preview n'est dupliquée dans `apps/docs` : la documentation Native décrit
+  l'API partagée.
+
+`createRecipe` et les fonctions pures sont repris avec la même sémantique. Les composants ne
+reçoivent pas de tests unitaires ; seules les fonctions pures sont testées. Chaque lot passe
+lint, type-check, tests, build, contrôle du tarball, vérification navigateur et contrôles de
+parité des exports/types.
+
+P6 publie uniquement `@xaui/hybrid@0.9.x-beta.x` sur le dist-tag `beta`. Même au jalon de
+parité, Hybrid ne passe ni en stable ni en `1.0.0` ; cette graduation demande une décision et
+une tâche séparées.
+
+L'ordre P6 est celui des dépendances :
+
+| Ref  | Lot                        | Entrées                                                                                                                                                                                                                                                      |
+| ---- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P6.0 | Contrat et renderer        | thème, provider, hooks, recipe/cache, slots, `asChild`, style props, Portal, `PressableFeedback`, Icon, ancrage et sélection ; configuration Emotion et Framer Motion ; conversion `4` → `0.25rem` → `4px` à l'échelle 1 ; contrôles de parité               |
+| P6.1 | Tranche de référence       | `Typography`/`TextSpan`, `Icon`, `view`, `Spinner`, `Button`                                                                                                                                                                                                 |
+| P6.2 | Primitives statiques       | `Surface`, `Divider`, `Skeleton`, `ProgressBar`, `ProgressCircle`, `Card`, `Avatar`, `Badge`                                                                                                                                                                 |
+| P6.3 | Actions et statuts         | `CloseButton`, `Chip`, `Alert`, `Fab`, `MorphButton`, `EmptyState`, `Widget`, `FlipCard`                                                                                                                                                                     |
+| P6.4 | Champs et sélection        | `TextField`, `TextArea`, `FieldGroup`, `DummyField`, `SearchField`, `MaskField`, `InputOTP`, `NumberPad`, `NumberField`, `NumberStepper`, `Checkbox`, `Radio`, `Switch`, `Segment`, `ToggleButton`, `Stepper`, `Slider`, `SlideButton`, `Rating`, `TagGroup` |
+| P6.5 | Overlays et choix composés | `Accordion`, `Dialog`, `Popover`, `BottomSheet`, `Menu`, `ListBox`, `Select`, `Autocomplete`, `Combobox`, `WheelPicker`, `PhoneNumberField`, `TimePicker`, `ColorPicker`, `Toast`, `Snackbar`                                                                |
+| P6.6 | Date et calendrier         | `Calendar`, `RangeCalendar`, `AgendaCalendar`, `DatePicker`, `DateRangePicker`, `DateTimePicker`                                                                                                                                                             |
+| P6.7 | Données et navigation      | `List`, `Table`, `Timeline`, `Tabs`, `Carousel`, `Pager`, `Scaffold`                                                                                                                                                                                         |
+| P6.8 | Graphiques                 | `Chart`, `LineChart`, `AreaChart`, `BarChart`, `PieChart`, `RadarChart`, `RadialChart`                                                                                                                                                                       |
+| P6.9 | Jalon de parité            | les 75 sous-chemins existent des deux côtés, les exports/types correspondent, le tarball est complet et Hybrid est publié en `0.9.x-beta.x` sans graduation stable                                                                                           |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 Instructions for every agent working in this monorepo. `CLAUDE.md` only points here.
 
-XAUI is a React Native UI library: composition-first components, animations on the UI thread
-with Reanimated, and a semantic token system. TypeScript, Turborepo + pnpm, Vitest, tsup,
-Changesets, Next.js docs, Expo demo.
+XAUI is a two-renderer UI library: composition-first components for React Native and hybrid
+webviews, with one public API and one semantic token system. Native animations run on the UI
+thread with Reanimated; hybrid animations use Framer Motion. TypeScript, Turborepo + pnpm,
+Vitest, tsup, Changesets, Next.js docs, Expo demo.
 
 ## Before writing code
 
@@ -24,7 +25,7 @@ Source of truth in `.agents/skills/<name>/SKILL.md`, copied — never symlinked 
 | `xaui-component`        | Writing a component — the fourteen rules, folder shape, per-component loop |
 | `xaui-system`           | Recipe engine, style cache, slots, `PressableFeedback`, `Portal`, `Icon`   |
 | `xaui-theme`            | Tokens, OKLab derivation, `createTheme`, provider, generation              |
-| `xaui-hybrid`           | The web renderer and the `em` sizing convention                            |
+| `xaui-hybrid`           | The web renderer and pixel-equivalent responsive scaling                   |
 | `xaui-docs`             | Docs pages, demo screens, generated tables                                 |
 | `xaui-legacy-migration` | The frozen tree, `core-shim`, codemods                                     |
 | `xaui-review`           | Run on the diff before every PR — v1 rules and clean code                  |
@@ -43,7 +44,11 @@ Source of truth in `.agents/skills/<name>/SKILL.md`, copied — never symlinked 
   root, slots receive stable `StyleSheet` references.
 - **A two-layer theme** — a hand-written source layer, ~32 tokens derived from it in OKLab.
   `.gen.ts` files are never hand-edited.
-- **100% Reanimated**, touch feedback through one shared `PressableFeedback`.
+- **Renderer-native motion** — 100% Reanimated in `@xaui/native`, 100% Framer Motion in
+  `@xaui/hybrid`, with the same public animation props and behaviour.
+- **Pixel-equivalent geometry** — at scale 1, one Native point equals one CSS logical pixel
+  in Hybrid. Browser zoom, root accessibility scaling and device DPR provide natural device
+  scaling; Hybrid never applies an extra density multiplier.
 - **RTL-safe styles** — `paddingStart` / `paddingEnd`, `start` / `end`. Never `left` / `right`.
 - **A fifteen-component core** for 1.0. Everything else waits for `1.x`.
 
@@ -53,15 +58,20 @@ The rules behind each line live in `xaui-component`, `xaui-system` and `xaui-the
 
 - Turborepo + pnpm workspaces: `apps/*`, `packages/*`.
 - `@xaui/native` (React Native) and `@xaui/hybrid` (mobile webview) are the published
-  libraries; `*-legacy` are the frozen trees. Apps: `docs` (Next.js), `demo` (Expo).
+  libraries. Hybrid mirrors every XAUI-owned prop, slot, hook, default and subpath from
+  native; only host refs/events and the renderer implementation differ. `*-legacy` are the
+  frozen trees. Apps: `docs` (Next.js), `demo` (Expo).
 - `packages/<pkg>/src` has six top-level folders — `theme/`, `provider/`, `system/`,
   `hooks/`, `utils/`, `types/` — plus `components/` and a mirrored `__tests__/`.
   **`system/` is public and follows semver; `utils/` is private.** A file used by one
   component stays with it; promotion happens at the second use. See `xaui-component`.
 - **Each top-level `src/` folder carries a `README.md`** saying what belongs in it, what does
   not, and how it is used. Add it with the folder, update it when the boundary moves.
-- Each component is an independent subpath export (`@xaui/native/button`), declared in
-  `package.json` **and** `tsup.config.ts`.
+- Each component is an independent subpath export (`@xaui/native/button` and
+  `@xaui/hybrid/button`), declared in `package.json` **and** `tsup.config.ts`.
+- Hybrid styling is written with `@emotion/styled`; hybrid animation is written with
+  Framer Motion. P6 does not add or update component documentation: the native pages describe
+  the shared API.
 
 ## Environment and commands
 
@@ -117,7 +127,7 @@ Prettier: no semicolons, single quotes, print width 85, 2 spaces, ES5 trailing c
 - A comment restating the code. Comment the non-obvious decision instead.
 - `any`; a function with more than 3 parameters; deep nesting.
 - An unrelated refactor inside a focused change.
-- A CSS file — Tailwind for styling, framer-motion for web animation.
+- A CSS file. Apps use Tailwind; `@xaui/hybrid` uses Emotion Styled and Framer Motion.
 - A hand-edited `.gen.ts`.
 - An empty file created to satisfy a convention.
 
@@ -126,6 +136,10 @@ Prettier: no semicolons, single quotes, print width 85, 2 spaces, ES5 trailing c
 - `workspace:*` for internal dependencies; package names singular; tsup builds dual CJS/ESM.
 - `react-native-reanimated` and `react-native-worklets` are required peers — all animation
   goes through them, never RN's built-in `Animated`.
+- `@xaui/hybrid` uses `@emotion/react` + `@emotion/styled` for styling and Framer Motion for
+  every animation; it never introduces a Hybrid-only appearance or animation prop.
+- P6 publishes `@xaui/hybrid` only as `0.9.x-beta.x` on the `beta` dist-tag. API parity does
+  not authorize a stable or `1.0.0` Hybrid release; that requires a separate explicit task.
 - `gesture-handler`, `svg` and `safe-area-context` are optional peers, imported only by the
   components that use them.
 


### PR DESCRIPTION
## What

- Define Hybrid as the API-identical web renderer of Native across all 75 component subpaths.
- Standardize Hybrid styling on Emotion Styled and animation on Framer Motion.
- Specify pixel-equivalent responsive sizing: 1 Native point equals 1 CSS logical pixel at scale 1, using root-relative rem conversion without extra DPR or viewport multiplication.
- Record the P6 implementation waves and keep Hybrid on 0.9.x-beta.x only.
- Keep Native component documentation as the single source of truth; apps/docs is untouched.

## Why

Hybrid currently contains only generated theme tokens and its previous instructions left renderer choices and scaling behavior ambiguous. A strict parity contract prevents props, slots, exports, dimensions, and release policy from drifting away from Native.

## How

- Update the v1 plan and roadmap with P6.0 through P6.9.
- Update AGENTS.md with the renderer, scaling, documentation, and beta-release invariants.
- Update and synchronize the xaui-flow, xaui-hybrid, and xaui-theme skills in both instruction trees.
- Correct the outdated claim that the color-token generator converts dimensional values.

## Verification

- pnpm lint
- pnpm type-check
- Native: 604 tests passed
- Native Legacy: 842 tests passed
- Hybrid: no test files, exits successfully with passWithNoTests
- Skill copies and YAML frontmatter validated
- Prettier and git diff checks passed

No changeset is included because no published package changed.