### PR TITLE
feat(hybrid): Icon on the Native three-form API

### DIFF
--- a/.changeset/hybrid-icon.md
+++ b/.changeset/hybrid-icon.md
@@ -1,0 +1,10 @@
+---
+'@xaui/hybrid': patch
+---
+
+Add the beta Hybrid `Icon` on Native's three-form API — an icon component through `as`, a
+raw `<svg>` as children, or an image URL through `source` — with the same context cascade,
+theme defaults and named failure.
+
+Open the `@xaui/hybrid/system` subpath, add `ImageStyle`, `ImageStyleProps` and the
+`StyleProps` generic, and ship `ChevronDownIcon`.

--- a/.project-specs/ROADMAP.md
+++ b/.project-specs/ROADMAP.md
@@ -169,7 +169,7 @@ phase and block nothing, but each one is a place where the repo lies about itsel
 | P6.0 | Hybrid contract and renderer — Emotion, Framer Motion, `1 Native point = 1 CSS logical pixel` at scale 1, export/type parity | todo |
 | P6.1 | Hybrid reference slice — `Typography`, `Icon`, `view`, `Spinner`, `Button` | todo |
 | P6.1a | Hybrid `Typography` + `TextSpan` — identical API, DOM-safe text host, pixel-equivalent roles | done |
-| P6.1b | Hybrid `Icon` | todo |
+| P6.1b | Hybrid `Icon` — three forms, masked image tint, `system` subpath | done |
 | P6.1c | Hybrid `view` | todo |
 | P6.1d | Hybrid `Spinner` | todo |
 | P6.1e | Hybrid `Button` | todo |

--- a/packages/hybrid/package.json
+++ b/packages/hybrid/package.json
@@ -26,6 +26,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./system": {
+      "import": {
+        "types": "./dist/system/index.d.ts",
+        "default": "./dist/system/index.js"
+      },
+      "require": {
+        "types": "./dist/system/index.d.cts",
+        "default": "./dist/system/index.cjs"
+      }
+    },
     "./theme": {
       "import": {
         "types": "./dist/theme/index.d.ts",

--- a/packages/hybrid/src/__tests__/system/icon/icon.utils.test.ts
+++ b/packages/hybrid/src/__tests__/system/icon/icon.utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { maskStyle, uriOf } from '../../../system/icon/icon.utils'
+
+describe('Icon image tinting', () => {
+  it('reads both source forms', () => {
+    expect(uriOf('/trash.png')).toBe('/trash.png')
+    expect(uriOf({ uri: '/trash.png' })).toBe('/trash.png')
+  })
+
+  it('paints the tint through the image and keeps one point one pixel', () => {
+    expect(
+      maskStyle({ source: '/trash.png', size: 24, tint: '#7c3aed' })
+    ).toMatchObject({
+      width: '1.5rem',
+      height: '1.5rem',
+      backgroundColor: '#7c3aed',
+      maskImage: 'url("/trash.png")',
+      maskSize: 'cover',
+      maskRepeat: 'no-repeat',
+    })
+  })
+
+  it('maps every Native resize mode onto a mask size', () => {
+    const sizeFor = (resizeMode: string | undefined) =>
+      maskStyle({ source: '/i.png', size: 16, tint: '#000', resizeMode }).maskSize
+    expect(sizeFor('contain')).toBe('contain')
+    expect(sizeFor('stretch')).toBe('100% 100%')
+    expect(sizeFor('center')).toBe('auto')
+    expect(sizeFor('unknown')).toBe('cover')
+    expect(
+      maskStyle({ source: '/i.png', size: 16, tint: '#000', resizeMode: 'repeat' })
+        .maskRepeat
+    ).toBe('repeat')
+  })
+})

--- a/packages/hybrid/src/components/typography/text-span.tsx
+++ b/packages/hybrid/src/components/typography/text-span.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from 'react'
-import { TextRoot, toWebStyle, useStyleProps, useTextHostProps } from '../../system'
-import type { TextHostProps, TextStyle } from '../../system'
+import { toWebStyle, useStyleProps } from '../../system'
+import { TextRoot, useTextHostProps } from '../../system/text-host'
+import type { TextStyle } from '../../system'
+import type { TextHostProps } from '../../system/text-host'
 import type { TextSpanProps } from './typography.type'
 
 export const TextSpan = forwardRef<HTMLElement, TextSpanProps>(function TextSpan(

--- a/packages/hybrid/src/components/typography/typography.tsx
+++ b/packages/hybrid/src/components/typography/typography.tsx
@@ -1,8 +1,10 @@
 import { forwardRef } from 'react'
-import { TextRoot, toWebStyle, useStyleProps, useTextHostProps } from '../../system'
+import { toWebStyle, useStyleProps } from '../../system'
+import { TextRoot, useTextHostProps } from '../../system/text-host'
 import { useXAUITheme } from '../../theme/theme-hooks'
 import { typographyRecipe } from './typography.recipe'
-import type { TextHostProps, TextStyle } from '../../system'
+import type { TextStyle } from '../../system'
+import type { TextHostProps } from '../../system/text-host'
 import type { TypographyProps } from './typography.type'
 
 export const Typography = forwardRef<HTMLElement, TypographyProps>(

--- a/packages/hybrid/src/components/typography/typography.type.ts
+++ b/packages/hybrid/src/components/typography/typography.type.ts
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react'
-import type {
-  StyleProp,
-  TextHostProps,
-  TextStyle,
-  TextStyleProps,
-} from '../../system'
+import type { StyleProp, TextStyle, TextStyleProps } from '../../system'
+import type { TextHostProps } from '../../system/text-host'
 
 export type TypographyVariant =
   | 'h1'

--- a/packages/hybrid/src/index.ts
+++ b/packages/hybrid/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components'
+export * from './system'
 export * from './theme'

--- a/packages/hybrid/src/system/README.md
+++ b/packages/hybrid/src/system/README.md
@@ -5,4 +5,8 @@ Renderer primitives shared by Hybrid components live here: recipes and their cac
 conversion boundary. A primitive joins the public `system` subpath only when its Native
 contract is fully ported.
 
+`text-host` is the exception that proves the rule: it exists only because the DOM needs an
+adapter Native does not, so it stays off the public `system` barrel — exporting it would
+put a Hybrid-only name on a subpath whose contents must match Native's.
+
 Component-specific recipes and styles stay with their component.

--- a/packages/hybrid/src/system/icon/chevron-down-icon.tsx
+++ b/packages/hybrid/src/system/icon/chevron-down-icon.tsx
@@ -1,0 +1,28 @@
+import type { IconComponentProps } from './icon.type'
+
+/**
+ * The chevron the library ships, rather than requiring one from the caller: a control
+ * whose whole affordance is "there is more under here" cannot be written without it, and
+ * asking for an icon package to draw one arrow is a peer dependency for a chevron.
+ *
+ * It sits in `system/` because two components draw it — `Select` turns it half a turn when
+ * its list opens, `Accordion` when its panel does.
+ */
+export function ChevronDownIcon({
+  size = 20,
+  color = 'currentColor',
+}: IconComponentProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <path
+        d="m6 9 6 6 6-6"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+ChevronDownIcon.displayName = 'XAUI.ChevronDownIcon'

--- a/packages/hybrid/src/system/icon/icon-context.ts
+++ b/packages/hybrid/src/system/icon/icon-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+import type { IconContextValue } from './icon.type'
+
+/**
+ * Not a slot context that throws outside its parent: an `Icon` has to work on its own as
+ * much as inside a `Button`. An empty context is the honest default — nothing inherited,
+ * so the theme decides.
+ */
+export const IconContext = createContext<IconContextValue>({})
+
+IconContext.displayName = 'XAUI.Icon.Context'
+
+export function useIconContext(): IconContextValue {
+  return useContext(IconContext)
+}

--- a/packages/hybrid/src/system/icon/icon-image.tsx
+++ b/packages/hybrid/src/system/icon/icon-image.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled'
+import type { CSSObject } from '@emotion/react'
+import { flatStyle, splitStyleProps, toWebStyle } from '../style-props'
+import type { ImageStyle } from '../style-props'
+import { maskStyle } from './icon.utils'
+import type { IconSourceProps } from './icon.type'
+
+const Box = styled('span', {
+  shouldForwardProp: property => property !== '$xauiStyle',
+})<{ $xauiStyle: CSSObject }>(({ $xauiStyle }) => $xauiStyle)
+
+type IconImageProps = IconSourceProps & {
+  resolved: { size: number; color: string }
+}
+
+/**
+ * Its own component because it is the only form with style props to split, and because a
+ * hook cannot be called inside a branch. Which is the shape of the rule rather than a
+ * workaround: R14 belongs to the form that renders a node.
+ */
+export function IconImage({
+  source,
+  style,
+  resolved,
+  size: _size,
+  color: _color,
+  ...props
+}: IconImageProps) {
+  const [styleProps] = splitStyleProps(props)
+  const declared = [styleProps as ImageStyle, style]
+  // Read before conversion: `toWebStyle` has already renamed `resizeMode` to `objectFit`
+  // by the time it returns, and neither key survives on a masked box.
+  const raw = flatStyle(declared)
+  const tint = (raw.tintColor as string | undefined) ?? resolved.color
+  const fit = raw.resizeMode as string | undefined
+
+  const declaredStyle = toWebStyle(declared)
+  delete declaredStyle.tintColor
+  delete declaredStyle.objectFit
+
+  return (
+    <Box
+      $xauiStyle={{
+        ...maskStyle({ source, size: resolved.size, tint, resizeMode: fit }),
+        // The caller's own width, height or margin lands after the resolved geometry, the
+        // order Native's style array already gave them.
+        ...declaredStyle,
+      }}
+    />
+  )
+}
+
+IconImage.displayName = 'XAUI.Icon.Image'

--- a/packages/hybrid/src/system/icon/icon.md
+++ b/packages/hybrid/src/system/icon/icon.md
@@ -1,0 +1,168 @@
+# Icon
+
+An icon, given the size and colour of whatever it sits in. The web renderer of Native's
+`Icon`, on the identical API.
+
+## Import
+
+```tsx
+import {
+  ChevronDownIcon,
+  Icon,
+  IconContext,
+  useIconContext,
+} from '@xaui/hybrid/system'
+```
+
+`Icon` reads the theme for its fallbacks, so it needs an `XAUIProvider` above it.
+
+## Anatomy
+
+The gap nobody else closes: an icon is a third-party component, so a slot context does not
+reach it and every call site ends up computing the colour by hand.
+
+```tsx
+<Button variant="danger">
+  <Button.Icon as={TrashIcon} />
+  <Button.Label>Supprimer</Button.Label>
+</Button>
+```
+
+Three accepted forms, and the type says which one you are in:
+
+- **`as`** — an icon component. `size` and `color` are injected into it.
+- **`children`** — a raw `<svg>` element, cloned with the resolved size and colour.
+- **`source`** — an image URL, painted in the resolved colour.
+
+## Usage
+
+### Inside a slot — nothing to pass
+
+```tsx
+<Icon as={TrashIcon} />
+```
+
+A component root publishes what its icons should be through `IconContext`, so the call site
+names the glyph and nothing else. Every icon package whose components take `size` and
+`color` fits `as` — Lucide, Heroicons, your own.
+
+### A raw SVG, its baked-in size overridden
+
+```tsx
+<Icon>
+  <svg viewBox="0 0 24 24">
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth={2}
+      fill="none"
+    />
+  </svg>
+</Icon>
+```
+
+The resolved values win over the element's own `width`, `height` and `color`. An SVG pasted
+out of a design tool carries a size baked in, and inheriting the slot's instead is the
+entire point of putting it in an `Icon`.
+
+`color` is set as the SVG presentation attribute, so a `stroke="currentColor"` or a
+`fill="currentColor"` anywhere inside the element follows it. That is the one thing to get
+right in the SVG you paste: a hardcoded `stroke="#000"` will not inherit, here or on
+Native.
+
+### An image
+
+```tsx
+<Icon source="/glyphs/trash.png" />
+<Icon source={{ uri: '/glyphs/trash.png' }} resizeMode="contain" />
+```
+
+Where Native takes an `ImageSourcePropType`, the web takes a URL — there is no bundler
+`require()` returning an asset number here. The two shapes a Native call site already
+writes, a string and a `{ uri }`, both work.
+
+**The image is painted, not displayed.** React Native's `tintColor` recolours an image and
+CSS has no such property, so the renderer uses the image as a mask and paints the resolved
+colour through it: the glyph comes out in exactly that colour rather than near it, which a
+`filter` could not promise. The node is therefore a box, not an `<img>` — an `<img>` would
+show its own pixels through the paint. Give it a monochrome glyph with transparency, as you
+would on Native.
+
+`tintColor` overrides the resolved colour, and `resizeMode` picks how the glyph fits —
+`cover` by default, as on Native.
+
+### Outside any slot
+
+```tsx
+<Icon as={TrashIcon} size={32} color="#7c3aed" />
+```
+
+Nothing above it is required. With no context, the theme decides.
+
+### The cascade
+
+An explicit prop, else what the surrounding slot published, else the theme:
+
+```tsx
+<IconContext.Provider value={{ size: 12, color: '#dc2626' }}>
+  <Icon as={TrashIcon} /> {/* 12, #dc2626 — from the context */}
+  <Icon as={TrashIcon} size={32} /> {/* 32, #dc2626 — size overridden      */}
+</IconContext.Provider>
+```
+
+Defaults are `theme.fontSizes.md` and `theme.colors.foreground`. `useIconContext()` reads
+what is published, for a component that needs to resolve the same values itself.
+
+## Props
+
+| Prop       | Type                                | Default                   | Notes                      |
+| ---------- | ----------------------------------- | ------------------------- | -------------------------- |
+| `as`       | `ComponentType<IconComponentProps>` | —                         | An icon component          |
+| `children` | `ReactNode`                         | —                         | A raw `<svg>` element      |
+| `source`   | `string \| { uri: string }`         | —                         | An image URL               |
+| `size`     | `number`                            | `theme.fontSizes.md`      | Overrides the slot's       |
+| `color`    | `string`                            | `theme.colors.foreground` | A raw value, never a token |
+| `style`    | `StyleProp<ImageStyle>`             | —                         | **`source` only**          |
+
+The three forms are mutually exclusive, and the union enforces it at compile time.
+
+## Why R14 stops at one form
+
+Style props — and `style` — exist on the `source` form alone, because it is the only one
+where we render the node. On the other two the node belongs to somebody else: a third
+party's component, or the caller's own element. When every form declared the style props,
+`<Icon as={Trash2} marginEnd={8} />` compiled and did nothing at all — the prop was dropped
+silently, and only a comment said so. Now it is a compile error that points at `size` and
+`color`, which are the levers those forms actually have.
+
+Wrapping the other two in a box to make the props work would add a level of depth to every
+icon in the library. Style them where you wrote them, or put the margin on the slot.
+
+## Failure
+
+`<Icon />` with no form throws by name rather than rendering nothing:
+
+> XAUI: Icon needs one of `as` (an icon component), a raw `<svg>` element as its child, or
+> `source` (an image URL). It renders nothing on its own.
+
+## `ChevronDownIcon`
+
+The one glyph the library ships, rather than requiring an icon package for a chevron:
+
+```tsx
+<ChevronDownIcon size={20} color="currentColor" />
+```
+
+It takes `IconComponentProps`, so it also goes through `Icon` — `<Icon as={ChevronDownIcon} />`
+inherits the slot's size and colour like any other.
+
+## Differences from Native
+
+- `source` is a URL, not an `ImageSourcePropType`.
+- The `children` form takes a DOM `<svg>` where Native takes a `react-native-svg` element.
+- The `source` form renders a masked box rather than an `Image` with `tintColor`.
+
+Everything else — the three forms, the cascade, the context, the defaults, the failure —
+is identical.

--- a/packages/hybrid/src/system/icon/icon.tsx
+++ b/packages/hybrid/src/system/icon/icon.tsx
@@ -1,0 +1,59 @@
+import { cloneElement, isValidElement } from 'react'
+import type { ReactElement } from 'react'
+import { useXAUITheme } from '../../theme/theme-hooks'
+import { IconImage } from './icon-image'
+import { useIconContext } from './icon-context'
+import type { IconProps } from './icon.type'
+
+/**
+ * The gap nobody else closes: an icon is a third-party component, so a slot context does
+ * not reach it and every call site ends up computing the colour by hand.
+ *
+ * ```tsx
+ * <Button variant="danger">
+ *   <Button.Icon as={TrashIcon} />
+ *   <Button.Label>Supprimer</Button.Label>
+ * </Button>
+ * ```
+ *
+ * Three accepted forms — a component through `as`, a raw `<svg>` as children, or an image
+ * through `source` — and the resolution is the same for all three: an explicit prop, else
+ * what the surrounding slot published, else the theme.
+ *
+ * The props are taken whole rather than destructured, because they are a union: which keys
+ * exist depends on the form, and narrowing is what lets `style` be reachable in the one
+ * branch that renders a node and unwritable in the two that do not.
+ */
+export function Icon(props: IconProps) {
+  const inherited = useIconContext()
+  const theme = useXAUITheme()
+
+  const size = props.size ?? inherited.size ?? theme.fontSizes.md
+  const color = props.color ?? inherited.color ?? theme.colors.foreground
+
+  if (props.as) {
+    const Component = props.as
+    return <Component size={size} color={color} />
+  }
+
+  if (isValidElement(props.children)) {
+    // The resolved values win over the element's own `width`, `height` and `color`. An SVG
+    // pasted from a design tool carries a baked-in size, and inheriting the slot's instead
+    // is the entire point of putting it in an `Icon`. `color` is an SVG presentation
+    // attribute, so a `stroke="currentColor"` inside the element follows it.
+    return cloneElement(props.children as ReactElement<Record<string, unknown>>, {
+      width: size,
+      height: size,
+      color,
+    })
+  }
+
+  if (props.source) return <IconImage {...props} resolved={{ size, color }} />
+
+  throw new Error(
+    'XAUI: Icon needs one of `as` (an icon component), a raw <svg> element as its child, ' +
+      'or `source` (an image URL). It renders nothing on its own.'
+  )
+}
+
+Icon.displayName = 'XAUI.Icon'

--- a/packages/hybrid/src/system/icon/icon.type.ts
+++ b/packages/hybrid/src/system/icon/icon.type.ts
@@ -1,0 +1,77 @@
+import type { ComponentType, ReactNode } from 'react'
+import type { ImageStyle, ImageStyleProps, StyleProp } from '../style-props'
+
+/**
+ * The props Lucide, Heroicons and the rest all accept — the shape `as` is handed. It is a
+ * convention rather than an interface anyone published, which is exactly why `Icon`
+ * exists: without it every call site computes the two values by hand.
+ */
+export type IconComponentProps = {
+  size?: number
+  color?: string
+}
+
+/** What every form takes, and the only lever the two non-rendering ones have. */
+type IconBase = {
+  /** Overrides what the surrounding slot asked for. */
+  size?: number
+  /** A raw value (R7), never a token. Overrides the slot's. */
+  color?: string
+}
+
+/**
+ * An icon component — `size` and `color` are injected into it.
+ *
+ * No style props and no `style`: we do not render this node, the third party does, and
+ * there is no published interface that says it would accept either.
+ */
+type IconAsProps = IconBase & {
+  as: ComponentType<IconComponentProps>
+  children?: never
+  source?: never
+}
+
+/**
+ * A raw `<svg>` element, cloned with the resolved size and colour.
+ *
+ * No style props and no `style` either: the node is the caller's own element, and they can
+ * style it where they wrote it.
+ */
+type IconChildrenProps = IconBase & {
+  as?: never
+  children: ReactNode
+  source?: never
+}
+
+/**
+ * Where Native takes `ImageSourcePropType`, the web takes a URL: there is no bundler
+ * `require()` returning an asset number here. The one host-bound type of the three forms.
+ */
+export type ImageSource = string | { uri: string }
+
+/**
+ * An image, tinted with the resolved colour — **the one form that carries R14**, because
+ * it is the one where we render the node.
+ */
+export type IconSourceProps = IconBase &
+  ImageStyleProps & {
+    as?: never
+    children?: never
+    source: ImageSource
+    style?: StyleProp<ImageStyle>
+  }
+
+/**
+ * Three forms, and the type says which one you are in.
+ *
+ * The union is what makes R14's boundary checkable rather than merely documented: a style
+ * prop on a form that does not render the node is a compile error pointing at `size` and
+ * `color`, which are the levers those forms actually have.
+ */
+export type IconProps = IconAsProps | IconChildrenProps | IconSourceProps
+
+/** What a component root publishes so the icons inside it need no props at all. */
+export type IconContextValue = {
+  size?: number
+  color?: string
+}

--- a/packages/hybrid/src/system/icon/icon.utils.ts
+++ b/packages/hybrid/src/system/icon/icon.utils.ts
@@ -1,0 +1,46 @@
+import type { CSSObject } from '@emotion/react'
+import { toWebUnit } from '../style-props'
+import type { ImageSource } from './icon.type'
+
+const MASK_SIZE: Record<string, string> = {
+  contain: 'contain',
+  cover: 'cover',
+  stretch: '100% 100%',
+  center: 'auto',
+  repeat: 'auto',
+}
+
+export function uriOf(source: ImageSource): string {
+  return typeof source === 'string' ? source : source.uri
+}
+
+type Mask = {
+  source: ImageSource
+  size: number
+  tint: string
+  resizeMode?: string
+}
+
+/**
+ * React Native's `tintColor` recolours an image; CSS has no such property, and a `filter`
+ * only approximates it. A mask is the exact equivalent: the image becomes the stencil and
+ * the colour is painted through it, so any glyph comes out in the resolved colour rather
+ * than near it.
+ *
+ * It is also why this form renders a box and not an `<img>` — an `<img>` would show its
+ * own pixels through the paint.
+ */
+export function maskStyle({ source, size, tint, resizeMode }: Mask): CSSObject {
+  const length = toWebUnit(size)
+
+  return {
+    display: 'inline-block',
+    width: length,
+    height: length,
+    backgroundColor: tint,
+    maskImage: `url("${uriOf(source)}")`,
+    maskSize: MASK_SIZE[resizeMode ?? 'cover'] ?? 'cover',
+    maskRepeat: resizeMode === 'repeat' ? 'repeat' : 'no-repeat',
+    maskPosition: 'center',
+  }
+}

--- a/packages/hybrid/src/system/icon/index.ts
+++ b/packages/hybrid/src/system/icon/index.ts
@@ -1,0 +1,9 @@
+export { ChevronDownIcon } from './chevron-down-icon'
+export { Icon } from './icon'
+export { IconContext, useIconContext } from './icon-context'
+export type {
+  IconComponentProps,
+  IconContextValue,
+  IconProps,
+  ImageSource,
+} from './icon.type'

--- a/packages/hybrid/src/system/index.ts
+++ b/packages/hybrid/src/system/index.ts
@@ -1,4 +1,4 @@
+export * from './icon'
 export * from './recipe'
 export * from './slot'
 export * from './style-props'
-export * from './text-host'

--- a/packages/hybrid/src/system/style-props/index.ts
+++ b/packages/hybrid/src/system/style-props/index.ts
@@ -1,9 +1,12 @@
-export { splitStyleProps, toWebStyle, toWebUnit } from './style-props'
+export { flatStyle, splitStyleProps, toWebStyle, toWebUnit } from './style-props'
 export type { RestPropsOf, StylePropKey, StylePropsOf } from './style-props'
 export type {
   DirectionalStyleKey,
+  ImageStyle,
+  ImageStyleProps,
   NativeFontWeight,
   StyleProp,
+  StyleProps,
   TextStyle,
   TextStyleProps,
 } from './style-props.type'

--- a/packages/hybrid/src/system/style-props/style-props.ts
+++ b/packages/hybrid/src/system/style-props/style-props.ts
@@ -289,6 +289,16 @@ export function toWebStyle(style: StyleProp<TextStyle>): CSSObject {
   return web as CSSObject
 }
 
+/**
+ * The Native-shaped keys, merged but not yet converted. A renderer that has to read a key
+ * back — `tintColor`, `resizeMode` — needs it before `toWebStyle` renames it.
+ */
+export function flatStyle(style: StyleProp<TextStyle>): Record<string, unknown> {
+  const flat: Record<string, unknown> = {}
+  flattenStyle(style, flat)
+  return flat
+}
+
 function flattenStyle(
   style: StyleProp<TextStyle>,
   target: Record<string, unknown>

--- a/packages/hybrid/src/system/style-props/style-props.type.ts
+++ b/packages/hybrid/src/system/style-props/style-props.type.ts
@@ -36,7 +36,7 @@ export type NativeFontWeight =
 
 type CSSStyleKey = Extract<StylePropKey, keyof CSSProperties>
 
-type NativeTextStyleOverrides = {
+type NativeBoxStyleOverrides = {
   borderBottomEndRadius?: NativeLength
   borderBottomStartRadius?: NativeLength
   borderTopEndRadius?: NativeLength
@@ -69,6 +69,9 @@ type NativeTextStyleOverrides = {
   transformMatrix?: ReadonlyArray<number>
   translateX?: NativeLength
   translateY?: NativeLength
+}
+
+type NativeTextOnlyOverrides = {
   fontVariant?: CSSProperties['fontVariant'] | ReadonlyArray<string>
   fontWeight?: NativeFontWeight
   includeFontPadding?: boolean
@@ -79,14 +82,44 @@ type NativeTextStyleOverrides = {
   writingDirection?: 'auto' | 'ltr' | 'rtl'
 }
 
-type ImageOnlyStyleKey = 'objectFit' | 'overlayColor' | 'resizeMode' | 'tintColor'
+type NativeImageOnlyOverrides = {
+  objectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down'
+  overlayColor?: NativeColor
+  resizeMode?: 'cover' | 'contain' | 'stretch' | 'repeat' | 'center'
+  tintColor?: NativeColor
+}
+
+type ImageOnlyStyleKey = keyof NativeImageOnlyOverrides
+
+/** Keys a text node has and an image node does not — `fontWeight` on an image is a lie. */
+type TextOnlyStyleKey =
+  | keyof NativeTextOnlyOverrides
+  | 'color'
+  | 'fontFamily'
+  | 'fontSize'
+  | 'fontStyle'
+  | 'letterSpacing'
+  | 'lineHeight'
+  | 'textAlign'
+  | 'textDecorationColor'
+  | 'textDecorationLine'
+  | 'textDecorationStyle'
+  | 'textTransform'
+  | 'userSelect'
+  | 'verticalAlign'
+
+type BoxStyle = Omit<
+  Pick<CSSProperties, CSSStyleKey>,
+  keyof NativeBoxStyleOverrides | ImageOnlyStyleKey
+> &
+  NativeBoxStyleOverrides
 
 /** React Native-shaped text styles, without taking a dependency on React Native. */
-export type TextStyle = Omit<
-  Pick<CSSProperties, CSSStyleKey>,
-  keyof NativeTextStyleOverrides | ImageOnlyStyleKey
-> &
-  NativeTextStyleOverrides
+export type TextStyle = Omit<BoxStyle, keyof NativeTextOnlyOverrides> &
+  NativeTextOnlyOverrides
+
+/** React Native-shaped image styles — `resizeMode`, `tintColor`, and no typography. */
+export type ImageStyle = Omit<BoxStyle, TextOnlyStyleKey> & NativeImageOnlyOverrides
 
 export type StyleProp<Style> =
   | Style
@@ -95,5 +128,13 @@ export type StyleProp<Style> =
   | undefined
   | ReadonlyArray<StyleProp<Style>>
 
-/** R13 and R14: every Native text style key except physical directions. */
-export type TextStyleProps = Omit<TextStyle, DirectionalStyleKey | 'pointerEvents'>
+/**
+ * R13 and R14: every style key of a node, exposed as props, minus the physical directions
+ * R13 bans and `pointerEvents`, which stays the component's own prop.
+ */
+export type StyleProps<Style> = Omit<Style, DirectionalStyleKey | 'pointerEvents'>
+
+/** A text node — `color`, `fontSize`, `letterSpacing`… */
+export type TextStyleProps = StyleProps<TextStyle>
+/** An image node — `resizeMode`, `tintColor`… */
+export type ImageStyleProps = StyleProps<ImageStyle>

--- a/packages/hybrid/tsup.config.ts
+++ b/packages/hybrid/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 const entries = {
   index: 'src/index.ts',
   'components/typography/index': 'src/components/typography/index.ts',
+  'system/index': 'src/system/index.ts',
   'theme/index': 'src/theme/index.ts',
 }
 

--- a/tooling/hybrid-parity/icon.type-test.ts
+++ b/tooling/hybrid-parity/icon.type-test.ts
@@ -1,0 +1,31 @@
+import type {
+  IconComponentProps as NativeIconComponentProps,
+  IconContextValue as NativeIconContextValue,
+  IconProps as NativeIconProps,
+} from '../../packages/native/src/system/icon'
+import type {
+  IconComponentProps as HybridIconComponentProps,
+  IconContextValue as HybridIconContextValue,
+  IconProps as HybridIconProps,
+} from '../../packages/hybrid/src/system/icon'
+
+type AssertNever<Difference extends never> = Difference
+
+type _MissingIconProps = AssertNever<
+  Exclude<keyof NativeIconProps, keyof HybridIconProps>
+>
+type _ExtraIconProps = AssertNever<
+  Exclude<keyof HybridIconProps, keyof NativeIconProps>
+>
+type _MissingComponentProps = AssertNever<
+  Exclude<keyof NativeIconComponentProps, keyof HybridIconComponentProps>
+>
+type _ExtraComponentProps = AssertNever<
+  Exclude<keyof HybridIconComponentProps, keyof NativeIconComponentProps>
+>
+type _MissingContextKeys = AssertNever<
+  Exclude<keyof NativeIconContextValue, keyof HybridIconContextValue>
+>
+type _ExtraContextKeys = AssertNever<
+  Exclude<keyof HybridIconContextValue, keyof NativeIconContextValue>
+>


### PR DESCRIPTION
## What

P6.1b — the Hybrid `Icon`, plus the `@xaui/hybrid/system` subpath it is exported from.

- `Icon` with Native's three forms: `as` (an icon component), a raw `<svg>` as children,
  `source` (an image URL). Same context cascade, same theme fallbacks, same named error.
- `IconContext` / `useIconContext`, and `ChevronDownIcon`.
- `ImageStyle`, `ImageStyleProps` and the `StyleProps<Style>` generic, so `TextStyleProps`
  and `ImageStyleProps` now derive from one definition as they do on Native.
- The `./system` subpath in `package.json`, `tsup.config.ts` and the root export.
- A compile-time Icon parity check against Native.

## Why

`Icon` is the second item of the P6.1 reference slice, and it is the one that forces the
`system` subpath open — it lives in `system/` on Native, not in `components/`.

Two decisions worth stating:

**`text-host` stays off the public barrel.** It is the DOM adapter Native has no
counterpart for, and `./system` must export what Native's does. A Hybrid-only name on a
shared subpath is exactly the parity defect the type check exists to catch, so
`system/index.ts` exports `icon`, `recipe`, `slot` and `style-props`, and Typography now
imports the adapter by its own path.

**The image form renders a masked box, not an `<img>`.** React Native's `tintColor`
recolours an image and CSS has no such property; a `filter` only approximates one. Using
the image as a mask and painting the resolved colour through it is the exact equivalent —
and an `<img>` would show its own pixels through the paint.

## How

Verified in rendered DOM, not assumed:

- `as` — theme defaults resolve to `16` / `#18181b`, an explicit prop overrides, and an
  `IconContext` between them is inherited.
- children — the SVG's own `width={99}` is overridden by the resolved size, and `color` is
  set as the SVG presentation attribute so `stroke="currentColor"` follows it.
- `source` — `marginStart={8}` computes to `margin-inline-start: 0.5rem`, `size={32}` to
  `2rem`, `tintColor` overrides the resolved colour and `resizeMode="contain"` reaches
  `mask-size`. Emotion emits the `-webkit-` prefixes.
- No form at all throws the named error.

`pnpm lint`, `pnpm type-check` (Icon parity check included) and the 24 hybrid tests pass;
the package builds. Only the pure helper has unit tests, per the repo rule.

`maskStyle` takes an options object rather than the four positional parameters it started
with — CLAUDE.md caps at three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)